### PR TITLE
docker fixtures: unique container names, ownership-scoped cleanup, unconditional removal

### DIFF
--- a/tests/integration_frameworks/conftest.py
+++ b/tests/integration_frameworks/conftest.py
@@ -5,8 +5,8 @@ import pytest
 from utils.docker_fixtures import (
     FrameworkTestClientApi,
     TestAgentAPI,
+    new_test_id,
 )
-from utils.docker_fixtures._core import new_test_id
 from utils import context, scenarios, logger
 
 

--- a/tests/integration_frameworks/conftest.py
+++ b/tests/integration_frameworks/conftest.py
@@ -1,5 +1,4 @@
 from collections.abc import Generator
-import uuid
 
 import pytest
 
@@ -7,6 +6,7 @@ from utils.docker_fixtures import (
     FrameworkTestClientApi,
     TestAgentAPI,
 )
+from utils.docker_fixtures._core import new_test_id
 from utils import context, scenarios, logger
 
 
@@ -24,7 +24,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 @pytest.fixture
 def test_id(request: pytest.FixtureRequest) -> str:
-    result = str(uuid.uuid4())[0:6]
+    result = new_test_id()
     logger.info(f"Test {request.node.nodeid} ID: {result}")
     return result
 

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -9,8 +9,7 @@ import pytest
 import yaml
 
 from utils import scenarios, logger
-from utils.docker_fixtures import TestAgentAPI, ParametricTestClientApi as APMLibrary
-from utils.docker_fixtures._core import new_test_id
+from utils.docker_fixtures import TestAgentAPI, ParametricTestClientApi as APMLibrary, new_test_id
 from utils.docker_fixtures._test_agent import DEFAULT_OTLP_HTTP_PORT, DEFAULT_OTLP_GRPC_PORT
 from utils.docker_fixtures._test_agent_pool import WorkerAgentPool
 

--- a/tests/parametric/conftest.py
+++ b/tests/parametric/conftest.py
@@ -4,13 +4,13 @@ import json
 from pathlib import Path
 import shutil
 import subprocess
-import uuid
 
 import pytest
 import yaml
 
 from utils import scenarios, logger
 from utils.docker_fixtures import TestAgentAPI, ParametricTestClientApi as APMLibrary
+from utils.docker_fixtures._core import new_test_id
 from utils.docker_fixtures._test_agent import DEFAULT_OTLP_HTTP_PORT, DEFAULT_OTLP_GRPC_PORT
 from utils.docker_fixtures._test_agent_pool import WorkerAgentPool
 
@@ -21,7 +21,7 @@ default_subprocess_run_timeout = 300
 
 @pytest.fixture
 def test_id(request: pytest.FixtureRequest) -> str:
-    result = str(uuid.uuid4())[0:6]
+    result = new_test_id()
     logger.info(f"Test {request.node.nodeid} ID: {result}")
     return result
 

--- a/tests/test_the_test/test_docker_run_cleanup.py
+++ b/tests/test_the_test/test_docker_run_cleanup.py
@@ -1,0 +1,171 @@
+import io
+
+from _pytest.outcomes import Failed
+from docker.errors import APIError, NotFound
+import pytest
+
+from utils import scenarios
+from utils.docker_fixtures._core import INVOCATION_LABEL, docker_run, new_test_id
+
+
+class _FakeContainer:
+    def __init__(
+        self,
+        *,
+        name: str = "test-client-deadbeef",
+        labels: dict[str, str] | None = None,
+        stop_exc: Exception | None = None,
+        logs_exc: Exception | None = None,
+        remove_exc: Exception | None = None,
+    ) -> None:
+        self.name = name
+        self.labels = labels or {}
+        self._stop_exc = stop_exc
+        self._logs_exc = logs_exc
+        self._remove_exc = remove_exc
+        self.removed = 0
+
+    def stop(self, timeout: int) -> None:  # noqa: ARG002
+        if self._stop_exc is not None:
+            raise self._stop_exc
+
+    def logs(self) -> bytes:
+        if self._logs_exc is not None:
+            raise self._logs_exc
+        return b"hello from client\n"
+
+    def remove(self, *, force: bool) -> None:
+        assert force is True
+        self.removed += 1
+        if self._remove_exc is not None:
+            raise self._remove_exc
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        *,
+        container: _FakeContainer | None = None,
+        run_exc: Exception | None = None,
+        existing: list[_FakeContainer] | None = None,
+        creates_before_failing: bool = False,
+    ) -> None:
+        self.containers = self
+        self.existing = list(existing or [])
+        self._container = container
+        self._run_exc = run_exc
+        self._creates_before_failing = creates_before_failing
+
+    def run(
+        self,
+        image: str,  # noqa: ARG002
+        *,
+        name: str,
+        labels: dict[str, str],
+        **_rest: object,
+    ) -> _FakeContainer | None:
+        if self._run_exc is not None:
+            if self._creates_before_failing:
+                self.existing.append(_FakeContainer(name=name, labels=dict(labels)))
+            raise self._run_exc
+        return self._container
+
+    def list(self, *, filters: dict[str, str], **_rest: object) -> list[_FakeContainer]:
+        label = filters.get("label")
+        assert label is not None, "cleanup must select by ownership label, never by container name"
+        key, _, value = label.partition("=")
+        return [c for c in self.existing if c.labels.get(key) == value]
+
+
+def _docker_run(client: _FakeClient, log_file: io.StringIO):
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("utils.docker_fixtures._core.get_docker_client", lambda: client)
+    return docker_run(
+        image="image",
+        name="test-client-deadbeef",
+        env={},
+        volumes={},
+        network="net",
+        ports={},
+        log_file=log_file,
+    )
+
+
+def _run(client: _FakeClient) -> io.StringIO:
+    log_file = io.StringIO()
+    with _docker_run(client, log_file):
+        pass
+    return log_file
+
+
+@scenarios.test_the_test
+def test_test_id_is_wide_enough_not_to_collide():
+    assert len(new_test_id()) == 16
+    assert len({new_test_id() for _ in range(10_000)}) == 10_000
+
+
+@scenarios.test_the_test
+def test_container_logs_are_captured_and_container_removed():
+    container = _FakeContainer()
+
+    log_file = _run(_FakeClient(container=container))
+
+    assert log_file.getvalue() == "hello from client\n"
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"logs_exc": APIError("409 dead or marked for removal")}, id="logs_fails"),
+        pytest.param({"stop_exc": APIError("stop failed")}, id="stop_fails"),
+    ],
+)
+def test_teardown_failure_still_removes_container_and_still_fails_loudly(kwargs: dict):
+    container = _FakeContainer(**kwargs)
+
+    with pytest.raises(APIError):
+        _run(_FakeClient(container=container))
+
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+def test_already_removed_container_does_not_fail_teardown():
+    container = _FakeContainer(remove_exc=NotFound("already gone"))
+
+    _run(_FakeClient(container=container))
+
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+def test_body_exception_propagates_and_container_is_removed():
+    container = _FakeContainer()
+
+    with pytest.raises(ValueError, match="boom"), _docker_run(_FakeClient(container=container), io.StringIO()):
+        raise ValueError("boom")
+
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+def test_failed_create_does_not_remove_another_workers_container():
+    foreign = _FakeContainer(labels={INVOCATION_LABEL: "another-invocation"})
+    client = _FakeClient(run_exc=APIError("409 name is already in use"), existing=[foreign])
+
+    with pytest.raises(Failed):
+        _run(client)
+
+    assert foreign.removed == 0
+
+
+@scenarios.test_the_test
+def test_failed_create_removes_only_the_container_it_created():
+    client = _FakeClient(run_exc=APIError("start failed"), creates_before_failing=True)
+
+    with pytest.raises(Failed):
+        _run(client)
+
+    assert [c.removed for c in client.existing] == [1]

--- a/tests/test_the_test/test_docker_run_cleanup.py
+++ b/tests/test_the_test/test_docker_run_cleanup.py
@@ -1,3 +1,5 @@
+import contextlib
+from collections.abc import Iterator
 import io
 
 from _pytest.outcomes import Failed
@@ -5,6 +7,7 @@ from docker.errors import APIError, NotFound
 import pytest
 
 from utils import scenarios
+from utils.docker_fixtures import _core as docker_core
 from utils.docker_fixtures._core import INVOCATION_LABEL, docker_run, new_test_id
 
 
@@ -25,7 +28,8 @@ class _FakeContainer:
         self._remove_exc = remove_exc
         self.removed = 0
 
-    def stop(self, timeout: int) -> None:  # noqa: ARG002
+    def stop(self, timeout: int) -> None:
+        del timeout
         if self._stop_exc is not None:
             raise self._stop_exc
 
@@ -48,47 +52,55 @@ class _FakeClient:
         container: _FakeContainer | None = None,
         run_exc: Exception | None = None,
         existing: list[_FakeContainer] | None = None,
-        creates_before_failing: bool = False,
+        create_remove_excs: list[Exception | None] | None = None,
+        list_exc: Exception | None = None,
     ) -> None:
         self.containers = self
         self.existing = list(existing or [])
         self._container = container
         self._run_exc = run_exc
-        self._creates_before_failing = creates_before_failing
+        self._create_remove_excs = create_remove_excs or []
+        self._list_exc = list_exc
 
     def run(
         self,
-        image: str,  # noqa: ARG002
+        _image: str,
         *,
         name: str,
         labels: dict[str, str],
         **_rest: object,
     ) -> _FakeContainer | None:
         if self._run_exc is not None:
-            if self._creates_before_failing:
-                self.existing.append(_FakeContainer(name=name, labels=dict(labels)))
+            self.existing.extend(
+                _FakeContainer(name=name, labels=dict(labels), remove_exc=remove_exc)
+                for remove_exc in self._create_remove_excs
+            )
             raise self._run_exc
         return self._container
 
     def list(self, *, filters: dict[str, str], **_rest: object) -> list[_FakeContainer]:
+        if self._list_exc is not None:
+            raise self._list_exc
         label = filters.get("label")
         assert label is not None, "cleanup must select by ownership label, never by container name"
         key, _, value = label.partition("=")
         return [c for c in self.existing if c.labels.get(key) == value]
 
 
-def _docker_run(client: _FakeClient, log_file: io.StringIO):
-    monkeypatch = pytest.MonkeyPatch()
-    monkeypatch.setattr("utils.docker_fixtures._core.get_docker_client", lambda: client)
-    return docker_run(
-        image="image",
-        name="test-client-deadbeef",
-        env={},
-        volumes={},
-        network="net",
-        ports={},
-        log_file=log_file,
-    )
+@contextlib.contextmanager
+def _docker_run(client: _FakeClient, log_file: io.StringIO) -> Iterator[None]:
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("utils.docker_fixtures._core.get_docker_client", lambda: client)
+        with docker_run(
+            image="image",
+            name="test-client-deadbeef",
+            env={},
+            volumes={},
+            network="net",
+            ports={},
+            log_file=log_file,
+        ):
+            yield
 
 
 def _run(client: _FakeClient) -> io.StringIO:
@@ -99,9 +111,17 @@ def _run(client: _FakeClient) -> io.StringIO:
 
 
 @scenarios.test_the_test
-def test_test_id_is_wide_enough_not_to_collide():
-    assert len(new_test_id()) == 16
-    assert len({new_test_id() for _ in range(10_000)}) == 10_000
+def test_test_id_uses_64_random_bits(monkeypatch: pytest.MonkeyPatch):
+    calls: list[int] = []
+
+    def token_hex(byte_count: int) -> str:
+        calls.append(byte_count)
+        return "00abcdef12345678"
+
+    monkeypatch.setattr(docker_core.secrets, "token_hex", token_hex)
+
+    assert new_test_id() == "00abcdef12345678"
+    assert calls == [8]
 
 
 @scenarios.test_the_test
@@ -116,18 +136,41 @@ def test_container_logs_are_captured_and_container_removed():
 
 @scenarios.test_the_test
 @pytest.mark.parametrize(
-    "kwargs",
+    ("stop_exc", "logs_exc"),
     [
-        pytest.param({"logs_exc": APIError("409 dead or marked for removal")}, id="logs_fails"),
-        pytest.param({"stop_exc": APIError("stop failed")}, id="stop_fails"),
+        pytest.param(None, APIError("409 dead or marked for removal"), id="logs_fails"),
+        pytest.param(APIError("stop failed"), None, id="stop_fails"),
     ],
 )
-def test_teardown_failure_still_removes_container_and_still_fails_loudly(kwargs: dict):
-    container = _FakeContainer(**kwargs)
+def test_teardown_failure_still_removes_container_and_still_fails_loudly(
+    stop_exc: Exception | None, logs_exc: Exception | None
+):
+    container = _FakeContainer(stop_exc=stop_exc, logs_exc=logs_exc)
 
     with pytest.raises(APIError):
         _run(_FakeClient(container=container))
 
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+@pytest.mark.parametrize(
+    ("stop_exc", "logs_exc"),
+    [
+        pytest.param(None, APIError("logs failed"), id="logs_fails"),
+        pytest.param(APIError("stop failed"), None, id="stop_fails"),
+    ],
+)
+def test_teardown_failure_is_preserved_when_removal_also_fails(stop_exc: Exception | None, logs_exc: Exception | None):
+    teardown_error = stop_exc or logs_exc
+    assert teardown_error is not None
+    remove_error = APIError("remove failed")
+    container = _FakeContainer(stop_exc=stop_exc, logs_exc=logs_exc, remove_exc=remove_error)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(_FakeClient(container=container))
+
+    assert exc_info.value is teardown_error
     assert container.removed == 1
 
 
@@ -141,6 +184,18 @@ def test_already_removed_container_does_not_fail_teardown():
 
 
 @scenarios.test_the_test
+def test_removal_failure_propagates_when_no_other_error_exists():
+    remove_error = APIError("remove failed")
+    container = _FakeContainer(remove_exc=remove_error)
+
+    with pytest.raises(APIError) as exc_info:
+        _run(_FakeClient(container=container))
+
+    assert exc_info.value is remove_error
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
 def test_body_exception_propagates_and_container_is_removed():
     container = _FakeContainer()
 
@@ -148,6 +203,25 @@ def test_body_exception_propagates_and_container_is_removed():
         raise ValueError("boom")
 
     assert container.removed == 1
+
+
+@scenarios.test_the_test
+def test_body_exception_is_preserved_when_removal_also_fails():
+    container = _FakeContainer(remove_exc=APIError("remove failed"))
+
+    with pytest.raises(ValueError, match="boom"), _docker_run(_FakeClient(container=container), io.StringIO()):
+        raise ValueError("boom")
+
+    assert container.removed == 1
+
+
+@scenarios.test_the_test
+def test_docker_client_patch_is_restored_after_helper_invocation():
+    original = docker_core.get_docker_client
+
+    _run(_FakeClient(container=_FakeContainer()))
+
+    assert docker_core.get_docker_client is original
 
 
 @scenarios.test_the_test
@@ -163,9 +237,30 @@ def test_failed_create_does_not_remove_another_workers_container():
 
 @scenarios.test_the_test
 def test_failed_create_removes_only_the_container_it_created():
-    client = _FakeClient(run_exc=APIError("start failed"), creates_before_failing=True)
+    client = _FakeClient(run_exc=APIError("start failed"), create_remove_excs=[None])
 
     with pytest.raises(Failed):
         _run(client)
 
     assert [c.removed for c in client.existing] == [1]
+
+
+@scenarios.test_the_test
+def test_failed_create_preserves_run_error_when_listing_for_cleanup_fails():
+    client = _FakeClient(run_exc=APIError("start failed"), list_exc=APIError("list failed"))
+
+    with pytest.raises(Failed, match=r"start failed.*list failed"):
+        _run(client)
+
+
+@scenarios.test_the_test
+def test_failed_create_attempts_all_removals_and_reports_cleanup_errors():
+    client = _FakeClient(
+        run_exc=APIError("start failed"),
+        create_remove_excs=[NotFound("already gone"), APIError("remove failed"), None],
+    )
+
+    with pytest.raises(Failed, match=r"start failed.*remove failed"):
+        _run(client)
+
+    assert [c.removed for c in client.existing] == [1, 1, 1]

--- a/utils/docker_fixtures/__init__.py
+++ b/utils/docker_fixtures/__init__.py
@@ -1,4 +1,4 @@
-from ._core import get_host_port, docker_run, compute_volumes
+from ._core import get_host_port, docker_run, compute_volumes, new_test_id
 from ._test_agent import TestAgentAPI, TestAgentFactory
 from ._test_clients import (
     ParametricTestClientFactory,
@@ -17,4 +17,5 @@ __all__ = [
     "compute_volumes",
     "docker_run",
     "get_host_port",
+    "new_test_id",
 ]

--- a/utils/docker_fixtures/_core.py
+++ b/utils/docker_fixtures/_core.py
@@ -1,6 +1,8 @@
 import contextlib
 from collections.abc import Generator, Mapping
 from pathlib import Path
+import secrets
+import sys
 from typing import TextIO
 from urllib.parse import urlparse
 import uuid
@@ -18,12 +20,11 @@ HOST_GATEWAY_EXTRA_HOSTS = {HOST_DOCKER_INTERNAL: "host-gateway"}
 
 INVOCATION_LABEL = "system-tests.invocation-id"
 
-# 64 bits, and short enough to keep the longest generated name inside the 63-char DNS label limit
-_TEST_ID_HEX_CHARS = 16
+_TEST_ID_BYTES = 8
 
 
 def new_test_id() -> str:
-    return uuid.uuid4().hex[:_TEST_ID_HEX_CHARS]
+    return secrets.token_hex(_TEST_ID_BYTES)
 
 
 def get_host_port(worker_id: str, base_port: int) -> int:
@@ -103,13 +104,26 @@ def docker_run(
         )
         logger.debug(f"Container {name} successfully started")
     except Exception as e:
-        # only containers this call created: a name match may be another xdist worker's live one
-        for created in get_docker_client().containers.list(
-            filters={"label": f"{INVOCATION_LABEL}={invocation_id}"}, all=True
-        ):
-            created.remove(force=True)
+        cleanup_errors = []
+        try:
+            created_containers = get_docker_client().containers.list(
+                filters={"label": f"{INVOCATION_LABEL}={invocation_id}"}, all=True
+            )
+        except Exception as cleanup_error:
+            cleanup_errors.append(cleanup_error)
+        else:
+            for created in created_containers:
+                try:
+                    created.remove(force=True)
+                except NotFound:
+                    pass
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
 
-        pytest.fail(f"Failed to run container {name}: {e}")
+        cleanup_details = ""
+        if cleanup_errors:
+            cleanup_details = "; cleanup also failed: " + "; ".join(str(error) for error in cleanup_errors)
+        pytest.fail(f"Failed to run container {name}: {e}{cleanup_details}")
 
     try:
         yield container
@@ -120,5 +134,12 @@ def docker_run(
             log_file.write(container.logs().decode("utf-8"))
             log_file.flush()
         finally:
-            with contextlib.suppress(NotFound):
+            active_error = sys.exception()
+            try:
                 container.remove(force=True)
+            except NotFound:
+                pass
+            except Exception as remove_error:
+                if active_error is None:
+                    raise
+                active_error.add_note(f"Container removal also failed: {remove_error}")

--- a/utils/docker_fixtures/_core.py
+++ b/utils/docker_fixtures/_core.py
@@ -3,7 +3,9 @@ from collections.abc import Generator, Mapping
 from pathlib import Path
 from typing import TextIO
 from urllib.parse import urlparse
+import uuid
 
+from docker.errors import NotFound
 from docker.models.containers import Container
 import pytest
 
@@ -13,6 +15,15 @@ from utils._context.docker import get_docker_client
 
 HOST_DOCKER_INTERNAL = "host.docker.internal"
 HOST_GATEWAY_EXTRA_HOSTS = {HOST_DOCKER_INTERNAL: "host-gateway"}
+
+INVOCATION_LABEL = "system-tests.invocation-id"
+
+# 64 bits, and short enough to keep the longest generated name inside the 63-char DNS label limit
+_TEST_ID_HEX_CHARS = 16
+
+
+def new_test_id() -> str:
+    return uuid.uuid4().hex[:_TEST_ID_HEX_CHARS]
 
 
 def get_host_port(worker_id: str, base_port: int) -> int:
@@ -75,6 +86,8 @@ def docker_run(
     """
     logger.info(f"Run container {name} from image {image} with ports {ports}")
 
+    invocation_id = uuid.uuid4().hex
+
     try:
         container: Container = get_docker_client().containers.run(
             image,
@@ -85,13 +98,16 @@ def docker_run(
             ports=ports,
             command=command,
             extra_hosts=extra_hosts,
+            labels={INVOCATION_LABEL: invocation_id},
             detach=True,
         )
         logger.debug(f"Container {name} successfully started")
     except Exception as e:
-        # at this point, even if it failed to start, the container may exists!
-        for container in get_docker_client().containers.list(filters={"name": name}, all=True):
-            container.remove(force=True)
+        # only containers this call created: a name match may be another xdist worker's live one
+        for created in get_docker_client().containers.list(
+            filters={"label": f"{INVOCATION_LABEL}={invocation_id}"}, all=True
+        ):
+            created.remove(force=True)
 
         pytest.fail(f"Failed to run container {name}: {e}")
 
@@ -99,8 +115,10 @@ def docker_run(
         yield container
     finally:
         logger.info(f"Stopping {name}")
-        container.stop(timeout=stop_timeout)
-        logs = container.logs()
-        log_file.write(logs.decode("utf-8"))
-        log_file.flush()
-        container.remove(force=True)
+        try:
+            container.stop(timeout=stop_timeout)
+            log_file.write(container.logs().decode("utf-8"))
+            log_file.flush()
+        finally:
+            with contextlib.suppress(NotFound):
+                container.remove(force=True)


### PR DESCRIPTION
## Motivation

> [View the color-coded bug and fix report](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/073ee4cf-084e-4ea5-b719-1ce399d8201b) (AppGate required)

In CI Visibility over the last 30 days, this bug caused **5 of 145 final-status parametric
failures (3.45%)** on default branches (`main` and `master`).

Two parametric tests failed in a dd-trace-php run: one in setup with
`409 Conflict. The container name "/php-test-client-<id>" is already in use`, the other in
teardown on that same container. Neither is a sampling bug; any two tests in the scenario can
hit it. Three defects combine, and the third is what actually killed the container:

1. `test_id` was `str(uuid.uuid4())[0:6]`. That 24-bit value is the only variable part of every
   container and network name built from it, and those names are shared by all xdist workers
   against one docker daemon. At ~800 container-creating tests per session that is a ~1.8%
   collision chance per session. Two node ids drew the same value 2.1s apart, on gw5 and gw3.

2. `tests/integration_frameworks/conftest.py` carried a byte-identical copy of the same fixture,
   so the scenario had the same exposure.

3. On a failed create, `docker_run` force-removed every container matching the name without
   checking that it had created them. When the name was already taken, that destroyed the owning
   worker's *live* container. The losing test's cleanup removed the winner's container while the
   winner was inside `stop(timeout=5)`, so the winner's `logs()` then returned
   `409 ... dead or marked for removal`.

Separately, `docker_run`'s teardown gated `container.remove(force=True)` on `container.logs()`,
so any log-capture error skipped removal and leaked the container. Its name stayed taken for the
rest of the session, and the log file needed to explain the death was discarded.

## Changes

- `new_test_id()` is now exported by `utils.docker_fixtures` and used by both the parametric and
  integration-frameworks fixtures, so the two cannot drift apart again. It uses eight random
  bytes. The 16 hex characters keep the longest generated name
  (`{library}-test-library-{framework}-{framework_version}-{test_id}`) inside the 63-character DNS
  label limit.
- Containers are created with a per-invocation label, and failed-create cleanup selects on that
  label instead of the name, so another worker's container is never removed. Cleanup attempts all
  matching containers and reports any cleanup failures without losing the original create error.
- `container.remove(force=True)` moved into its own `finally`. A body, stop, or log-capture error
  remains the primary exception if removal also fails; the removal error is attached as a note.
  A removal-only error still propagates, while `NotFound` is suppressed when the container is
  already gone.
- The test helper now restores its patched Docker client after every invocation.
- `tests/test_the_test/test_docker_run_cleanup.py` has 15 cases covering ID entropy, ownership,
  create-failure cleanup, teardown precedence, removal paths, log capture, and helper isolation.

Verified: `ruff format --check`, `ruff check`, and `mypy` pass; full `TEST_THE_TEST` has 379 passed
and 1 xfailed.

### Note for reviewers

This changes `docker_run`'s create-failure and teardown-failure contracts, which every tracer's
parametric run depends on. Cleanup now preserves the original operation error and reports any
secondary cleanup error. A removal-only failure still fails the test.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * `utils/docker_fixtures/_core.py` and `utils/docker_fixtures/__init__.py` are modified - R&P approval still needed, not yet obtained.
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
    * No base image changes.
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    * No scenario changes.
