### PR TITLE
fix(sampling): support v1 in manual sampling test

### DIFF
--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -29,7 +29,9 @@ def _assert_upstream_trace_continued(request: HttpResponse) -> None:
     assert spans, "No span reported for that request"
 
     trace_ids = {span["trace_id"] for span in spans}
-    assert trace_ids == {UPSTREAM_TRACE_ID}, f"Spans do not belong to the upstream trace: {trace_ids}"
+    assert all(span.trace_id_equals(UPSTREAM_TRACE_ID) for span in spans), (
+        f"Spans do not belong to the upstream trace: {trace_ids}"
+    )
 
     parent_ids = {span.get("parent_id") for span in spans}
     assert UPSTREAM_PARENT_ID in parent_ids, f"No span is a child of the upstream span: {parent_ids}"

--- a/tests/test_sampling_manual.py
+++ b/tests/test_sampling_manual.py
@@ -64,16 +64,16 @@ def _assert_decision_propagated_downstream(request: HttpResponse, expected: Samp
 
 
 def _get_sampling_priority(request: HttpResponse) -> int:
-    """Sampling priority is reported on the local root span of the trace chunk, which is the
-    weblog span here, as the trace is continued from an upstream service.
+    """Sampling priority is reported on the local root span in legacy payloads and on the trace
+    chunk in v1 payloads.
     """
     priorities = {
-        span["metrics"]["_sampling_priority_v1"]
+        sampling_priority
         for _, _, span in interfaces.library.get_spans(request=request)
-        if "_sampling_priority_v1" in span.get("metrics", {})
+        if (sampling_priority := span.get_sampling_priority()) is not None
     }
 
-    assert priorities, "No span reported a _sampling_priority_v1 metric for that request"
+    assert priorities, "No span reported a sampling priority for that request"
     assert len(priorities) == 1, f"Spans of the same trace disagree on the sampling priority: {priorities}"
 
     return priorities.pop()


### PR DESCRIPTION
## Motivation

The manual sampling test accessed legacy trace payload fields directly, causing equivalent `v1` trace IDs and chunk-level sampling priorities to fail validation.

## Changes

- Use `trace_id_equals()` to compare trace IDs across legacy and `v1` payload formats.
- Use `get_sampling_priority()` to read sampling priorities from legacy span metrics or `v1` trace chunks.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
