### PR TITLE
test(agentic-onboarding): enable ruby tests for v2.40.0-dev

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1156,7 +1156,7 @@ manifest:
         sinatra32: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         sinatra41: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
         uds-sinatra: missing_feature (no instrumentation of authentication frameworks that work with sinatra or rack)
-  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: missing_feature (APPSEC-68904)
+  tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v2.40.0-dev
   tests/appsec/test_asm_standalone.py::Test_APISecurityStandalone: v2.18.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled: v2.13.0


### PR DESCRIPTION
APPSEC-69231

## Motivation

`Test_AppsecAgenticOnboarding` (RFC-1113) was declared `missing_feature (APPSEC-68904)` for Ruby. The tracer now reports `DD_APPSEC_AGENTIC_ONBOARDING` through telemetry configuration, so the tests can be activated.

## Changes

- `manifests/ruby.yml`: `Test_AppsecAgenticOnboarding` → `v2.40.0-dev` (was `missing_feature (APPSEC-68904)`)

Follows the same pattern as #7351 (python), #7369 (dotnet, nodejs, php).