### PR TITLE
[Java] Fix akka-http multipart Strict/Streamed race causing AppSec blocking flake

### DIFF
--- a/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
+++ b/utils/build/docker/java/akka-http/src/main/scala/com/datadoghq/akka_http/AppSecRoutes.scala
@@ -32,6 +32,7 @@ import datadog.appsec.api.user.User.setUser
 import scala.jdk.CollectionConverters._
 import akka.stream.scaladsl._
 import akka.util.ByteString
+import scala.concurrent.duration._
 
 object AppSecRoutes {
 
@@ -162,10 +163,12 @@ object AppSecRoutes {
         } ~
           post {
             entity(as[Multipart.FormData]) { formData =>
-              val contentFuture = formData.parts
-                .mapAsync(1)(_.entity.dataBytes.runFold(ByteString.empty)(_ ++ _))
-                .runFold(ByteString.empty)(_ ++ _)
-                .map(_.utf8String)
+              val contentFuture = formData.toStrict(20.seconds).flatMap { strict =>
+                strict.parts
+                  .mapAsync(1)(_.entity.dataBytes.runFold(ByteString.empty)(_ ++ _))
+                  .runFold(ByteString.empty)(_ ++ _)
+                  .map(_.utf8String)
+              }
               onSuccess(contentFuture) { content =>
                 complete(content)
               }


### PR DESCRIPTION
## Motivation

The `APPSEC_BLOCKING` scenario intermittently fails against the akka-http weblog: a malicious
multipart request that should be blocked (403) sometimes returns 200 with no AppSec event
instead.

Root cause: Akka HTTP's `entity(as[Multipart.FormData])` directive does not guarantee a
`Strict` entity — it resolves internally to `Strict` or `Streamed` depending on whether the
request header and body arrive in the same TCP socket read, which is timing-dependent, not
payload-dependent. dd-trace-java's AppSec instrumentation only captures the WAF addresses
(`server.request.body`, `.filenames`, `.files_content`) when the entity resolves to
`Multipart.FormData.Strict`. When it resolves to `Streamed`, the instrumentation returns early
without publishing any address, so the request completes with 200 and no blocking event.

Jira: [APPSEC-69529](https://datadoghq.atlassian.net/browse/APPSEC-69529)

## Changes

- `AppSecRoutes.scala`: force `formData.toStrict(20.seconds)` explicitly in the multipart
  branch of the `/waf` POST route, before consuming its parts, so the entity is always
  `Strict` and the tracer can reliably capture the WAF addresses.
- Timeout set to 20s to match Akka's own `request-timeout` default, so `toStrict` doesn't
  time out before the server's own timeout would.
- No other branch of the `/waf` route is touched (`formFieldMultiMap`, JSON, XML,
  octet-stream, String fallback all unaffected — they already force `Strict` internally or
  aren't subject to this race).
- Only akka-http is affected; the `play` weblog resolves its body fully before the controller
  runs, so it has no Strict/Streamed ambiguity at this level.
- No manifest changes — this restores determinism for an already-declared capability, it
  doesn't add a new one.

## Flakiness tested
https://github.com/DataDog/system-tests/actions/runs/30893940343 probes that the fix works

[APPSEC-69529]: https://datadoghq.atlassian.net/browse/APPSEC-69529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ