### PR TITLE
Cover the ETP/v1 ↔ Client-Side Stats intersection in both directions

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -281,6 +281,9 @@ jobs:
     - name: Run APM_TRACING_EFFICIENT_PAYLOAD scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"APM_TRACING_EFFICIENT_PAYLOAD"')
       run: ./run.sh APM_TRACING_EFFICIENT_PAYLOAD
+    - name: Run APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED scenario
+      if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED"')
+      run: ./run.sh APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED
     - name: Run LIBRARY_CONF_CUSTOM_HEADER_TAGS scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"LIBRARY_CONF_CUSTOM_HEADER_TAGS"')
       run: ./run.sh LIBRARY_CONF_CUSTOM_HEADER_TAGS

--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -209,6 +209,9 @@ jobs:
     - name: Run TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE scenario
       if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE"')
       run: ./run.sh TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE
+    - name: Run TRACE_STATS_COMPUTATION_V1 scenario
+      if: always() && steps.build.outcome == 'success' && contains(inputs.scenarios, '"TRACE_STATS_COMPUTATION_V1"')
+      run: ./run.sh TRACE_STATS_COMPUTATION_V1
     - name: Run IAST_STANDALONE scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"IAST_STANDALONE"')
       run: ./run.sh IAST_STANDALONE

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -2090,4 +2090,5 @@ manifest:
         net-http: '>=2.5.0'
         net-http-orchestrion: '>=2.5.0'
   tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (v1 is the default since v2.10.0-rc.1, but it is gated on client-side stats, which the DEFAULT scenario disables, so the tracer downgrades to v0.4)
+  tests/test_v1_payloads.py::Test_V1PayloadWithStatsDisabled: 'missing_feature (v1 gated on CSS, fixed by dd-trace-go#5122)'
   tests/test_v1_payloads.py::Test_V1Payloads: v2.7.0

--- a/tests/k8s_lib_injection/test_k8s_lib_injection_profiling.py
+++ b/tests/k8s_lib_injection/test_k8s_lib_injection_profiling.py
@@ -1,7 +1,7 @@
 import time
 import requests
 
-from utils import scenarios, features
+from utils import scenarios, features, context, bug
 from tests.k8s_lib_injection.utils import get_cluster_info, K8sClusterInfo
 
 
@@ -41,6 +41,10 @@ class TestK8sLibInjectioProfilingDisabledByDefault(_TestK8sLibInjectionProfiling
 class TestK8sLibInjectioProfilingClusterEnabled(_TestK8sLibInjectionProfiling):
     """Test K8s lib injection with profiling enabled."""
 
+    @bug(
+        context.library == "java",
+        reason="PROF-15664",
+    )
     def test_profiling_admission_controller(self):
         profiling_request_found = self._check_profiling_request_sent(get_cluster_info())
         assert profiling_request_found, "No profiling request found"
@@ -51,6 +55,10 @@ class TestK8sLibInjectioProfilingClusterEnabled(_TestK8sLibInjectionProfiling):
 class TestK8sLibInjectioProfilingClusterOverride(_TestK8sLibInjectionProfiling):
     """Test K8s lib injection with profiling enabled, overriting cluster agent config."""
 
+    @bug(
+        context.library == "java",
+        reason="PROF-15664",
+    )
     def test_profiling_override_cluster_env(self):
         profiling_request_found = self._check_profiling_request_sent(get_cluster_info())
         assert profiling_request_found, "No profiling request found"

--- a/tests/schemas/test_schemas.py
+++ b/tests/schemas/test_schemas.py
@@ -164,14 +164,16 @@ class Test_DdtraceSchemas:
                 endpoint="/v0.6/stats",
                 data_path="$",  # service is missing
                 condition=context.library == "nodejs"
-                and context.scenario is scenarios.trace_stats_computation_client_drop_p0s_false,
+                and context.scenario
+                in (scenarios.trace_stats_computation_client_drop_p0s_false, scenarios.trace_stats_computation_v1),
                 ticket="APMLP-1498",
             ),
             SchemaBug(
                 endpoint="/v0.6/stats",
                 data_path="$.Stats[].Stats[]",  # IsTraceRoot is missing
                 condition=context.library == "nodejs"
-                and context.scenario is scenarios.trace_stats_computation_client_drop_p0s_false,
+                and context.scenario
+                in (scenarios.trace_stats_computation_client_drop_p0s_false, scenarios.trace_stats_computation_v1),
                 ticket="APMLP-1498",
             ),
         ]

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -21,6 +21,7 @@ Config:
 
 @features.client_side_stats_supported
 @scenarios.trace_stats_computation
+@scenarios.trace_stats_computation_v1
 class Test_Client_Stats:
     """Test client-side stats are compatible with Agent implementation"""
 
@@ -447,6 +448,7 @@ class Test_Agent_Info_Endpoint:
 
 @features.client_side_stats_supported
 @scenarios.trace_stats_computation
+@scenarios.trace_stats_computation_v1
 class Test_Peer_Tags:
     """Test peer tags aggregation for Client-Side Stats"""
 
@@ -513,6 +515,7 @@ class Test_Peer_Tags:
 
 @features.client_side_stats_supported
 @scenarios.trace_stats_computation
+@scenarios.trace_stats_computation_v1
 class Test_Transport_Headers:
     """Test transport headers validation for Client-Side Stats"""
 
@@ -600,14 +603,13 @@ class Test_Client_Drop_P0s:
         stats_requests = list(interfaces.library.get_data("/v0.6/stats"))
         assert len(stats_requests) == 0, "No stats should be sent when client_drop_p0s is false"
 
-        # Check trace headers to ensure Datadog-Client-Computed-Stats is not set to true
-        trace_requests = list(interfaces.library.get_data("/v0.4/traces"))
-        if len(trace_requests) == 0:
-            trace_requests = list(interfaces.library.get_data("/v0.5/traces"))
-        if len(trace_requests) == 0:
-            trace_requests = list(interfaces.library.get_data("/v0.7/traces"))
-        if len(trace_requests) == 0:
-            trace_requests = list(interfaces.library.get_data("/v1.0/traces"))
+        # Check trace headers to ensure Datadog-Client-Computed-Stats is not set to true.
+        # Collect every trace endpoint rather than stopping at the first non-empty one: a tracer can
+        # emit on more than one (e.g. one defaulting to /v1.0/traces that also falls back to a legacy
+        # endpoint), and the header must be absent/false on all of them, not just the first we find.
+        trace_requests = list(
+            interfaces.library.get_data(["/v0.4/traces", "/v0.5/traces", "/v0.7/traces", "/v1.0/traces"])
+        )
 
         assert len(trace_requests) > 0, "Should have at least one trace request"
 

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -611,6 +611,9 @@
   "tests/test_telemetry.py::Test_TelemetrySCAEnvVar::test_telemetry_sca_propagated": [
     "DEFAULT"
   ],
+  "tests/test_v1_payloads.py::Test_V1PayloadWithStatsDisabled::test_v1_used_with_stats_disabled": [
+    "APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED"
+  ],
   "tests/test_v1_payloads.py::Test_V1Payloads::test_field_changes": [
     "APM_TRACING_EFFICIENT_PAYLOAD"
   ],

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -5603,13 +5603,16 @@
     "DEFAULT"
   ],
   "tests/stats/test_stats.py::Test_Client_Stats::test_client_stats": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Client_Stats::test_obfuscation": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Client_Stats::test_is_trace_root": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Client_Stats::test_disable": [
     "DEFAULT"
@@ -5618,13 +5621,16 @@
     "TRACE_STATS_COMPUTATION"
   ],
   "tests/stats/test_stats.py::Test_Peer_Tags::test_peer_tags": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Transport_Headers::test_transport_headers": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Transport_Headers::test_container_id_header": [
-    "TRACE_STATS_COMPUTATION"
+    "TRACE_STATS_COMPUTATION",
+    "TRACE_STATS_COMPUTATION_V1"
   ],
   "tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats": [
     "TRACE_STATS_COMPUTATION"

--- a/tests/test_v1_payloads.py
+++ b/tests/test_v1_payloads.py
@@ -45,6 +45,36 @@ class Test_V1Payloads:
         assert agent_trace.trace_id == trace.raw_trace["trace_id"]
 
 
+@scenarios.apm_tracing_efficient_payload_stats_disabled
+@features.efficient_trace_payload
+class Test_V1PayloadWithStatsDisabled:
+    """The v1 trace format must not depend on Client-Side Stats being enabled.
+
+    CSS is negotiated out of band: a Datadog-Client-Computed-Stats header and a separate /v0.6/stats
+    endpoint, both handled identically by the Agent on either trace protocol. Disabling it therefore
+    has no bearing on the trace wire format. dd-trace-go used to gate v1 on CSS capability and
+    silently downgrade to /v0.4/traces the moment stats computation was turned off
+    (https://github.com/DataDog/dd-trace-go/pull/5122); this pins the two as independent.
+    """
+
+    def setup_v1_used_with_stats_disabled(self):
+        self.r = weblog.get("/status?code=200")
+
+    def test_v1_used_with_stats_disabled(self):
+        # Guard the premise: if CSS were somehow active, this scenario would not be testing anything.
+        stats_requests = list(interfaces.library.get_data("/v0.6/stats"))
+        assert len(stats_requests) == 0, "Client-side stats must be disabled in this scenario"
+
+        traces = list(interfaces.library.get_traces())
+        assert len(traces) > 0, "Expected at least one trace"
+        for data, trace in traces:
+            assert data["path"] == "/v1.0/traces", (
+                f"Trace was sent to {data['path']} rather than /v1.0/traces while stats computation "
+                f"was disabled: the trace protocol must not be gated on Client-Side Stats"
+            )
+            assert trace.format == LibraryTraceFormat.v10
+
+
 @scenarios.apm_tracing_efficient_payload
 @features.efficient_trace_payload
 class Test_V1SpanLinks:

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -225,6 +225,31 @@ class _Scenarios:
         scenario_groups=[scenario_groups.appsec],
     )
 
+    trace_stats_computation_v1 = DdTraceEndToEndScenario(
+        name="TRACE_STATS_COMPUTATION_V1",
+        # Same as trace_stats_computation, but the tracer emits traces on the v1 (efficient payload)
+        # endpoint instead of a legacy one. CSS and the v1 trace protocol are independent features, so
+        # the stats assertions must hold identically here: the only delta versus TRACE_STATS_COMPUTATION
+        # is the trace protocol. Without this scenario the combination is only ever reached by accident,
+        # via whichever protocol a tracer happens to default to.
+        weblog_env={
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "true",  # default env var for CSS
+            "DD_TRACE_COMPUTE_STATS": "true",
+            "DD_TRACE_FEATURES": "discovery",
+            "DD_TRACE_TRACER_METRICS_ENABLED": "true",  # java
+            "_DD_TRACE_STATS_COMPUTATION_EXPERIMENTAL_CLIENT_OBFUSCATION_ENABLED": "true",
+            "DD_TRACE_AGENT_PROTOCOL_VERSION": "1.0",
+        },
+        agent_env={
+            "DD_APM_ENABLE_V1_TRACE_ENDPOINT": "true",
+        },
+        doc=(
+            "End to end testing with DD_TRACE_COMPUTE_STATS=1 and the v1 trace protocol. "
+            "Tests that client-side stats computation is unaffected by the trace payload format."
+        ),
+        scenario_groups=[scenario_groups.appsec],
+    )
+
     sampling = DdTraceEndToEndScenario(
         "SAMPLING",
         tracer_sampling_rate=0.5,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -872,6 +872,26 @@ class _Scenarios:
         doc="End-to-end testing scenario focused on efficient payload handling and v1 trace format validation",
     )
 
+    apm_tracing_efficient_payload_stats_disabled = DdTraceEndToEndScenario(
+        "APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED",
+        # Same as apm_tracing_efficient_payload but with Client-Side Stats explicitly disabled. CSS is
+        # negotiated out of band (the Datadog-Client-Computed-Stats header and the separate /v0.6/stats
+        # endpoint), so turning it off must not change the trace wire format. This is the only scenario
+        # that pins the v1 protocol while CSS is off, which is what makes it able to catch a tracer
+        # gating v1 on CSS and silently falling back to /v0.4/traces.
+        weblog_env={
+            "DD_TRACE_SAMPLE_RATE": "1.0",
+            "DD_TRACE_AGENT_PROTOCOL_VERSION": "1.0",
+            # Same idiom DefaultScenario uses to express "CSS off"
+            "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
+        },
+        agent_env={
+            "DD_APM_ENABLE_V1_TRACE_ENDPOINT": "true",
+        },
+        backend_interface_timeout=5,
+        doc="End-to-end testing that the v1 trace format does not depend on Client-Side Stats being enabled",
+    )
+
     otel_tracing_e2e = OpenTelemetryScenario("OTEL_TRACING_E2E", require_api_key=True, doc="")
     otel_metric_e2e = OpenTelemetryScenario("OTEL_METRIC_E2E", require_api_key=True, mocked_backend=False, doc="")
     otel_log_e2e = OpenTelemetryScenario("OTEL_LOG_E2E", require_api_key=True, doc="")


### PR DESCRIPTION
## Motivation

CSS (Client-Side Stats) and the ETP/v1 trace protocol were only ever exercised **separately**. No scenario configured both, so the combination was reached solely by accident — via whichever protocol a tracer happened to default to.

The two features genuinely interact. CSS drops P0s client-side, changing **which** traces are emitted; ETP/v1 changes **how** they are encoded. Both act on the same trace-emission path — which is also why several parametric tests have to set `DD_TRACE_STATS_COMPUTATION_ENABLED=false` to observe P0s at all (see the comment at `tests/parametric/test_span_sampling.py:862`).

And the interaction was not hypothetical. Released dd-trace-go **gates v1 on CSS capability** and silently downgrades to `/v0.4/traces` the moment stats computation is disabled; DataDog/dd-trace-go#5122 removes that gate. system-tests never reported it, because the one place it would have surfaced — `Test_V1PayloadByDefault`, which runs in the DEFAULT scenario where `DD_TRACE_STATS_COMPUTATION_ENABLED=false` — is declared `missing_feature`, i.e. a **non-strict xfail** that cannot fail. Worse, its stated reason (`not implemented by default yet`) is inaccurate: Go *had* implemented v1-by-default; the test failed because the scenario disables CSS. The declaration hid the bug and misattributed its cause.

This PR makes the intersection explicit in both directions.

## Changes

### 1. `TRACE_STATS_COMPUTATION_V1` — CSS on, v1 protocol

Identical to `TRACE_STATS_COMPUTATION` apart from two lines: weblog `DD_TRACE_AGENT_PROTOCOL_VERSION=1.0` and agent `DD_APM_ENABLE_V1_TRACE_ENDPOINT=true`. Keeping everything else byte-for-byte identical is deliberate: a failure here points at a CSS/ETP interaction, not at a sampling or obfuscation difference.

The format-sensitive stats classes now run in it too:

| Class | Why |
|---|---|
| `Test_Client_Stats` | hit / top-level-hit counting and `IsTraceRoot` depend on top-level span detection, which v1 relocates into `attributes` |
| `Test_Peer_Tags` | peer tag extraction depends on span structure |
| `Test_Transport_Headers` | stats request headers |

Deliberately excluded: `Test_Time_Bucketing` (timing-sensitive — would double an existing flake surface) and `Test_Agent_Info_Endpoint` (asserts `/info` capabilities, format-independent).

### 2. `APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED` — CSS off, v1 protocol

Scenario 1 alone is **not** a regression test for the coupling: CSS-on + v1 worked even while v1 was gated on CSS, so it cannot discriminate. The discriminating case is the mirror — v1 pinned while CSS is **off** — and no existing scenario did that. Only two scenarios pin the protocol, and neither disabled CSS.

`APM_TRACING_EFFICIENT_PAYLOAD` plus `DD_TRACE_STATS_COMPUTATION_ENABLED=false`, with `Test_V1PayloadWithStatsDisabled` asserting every trace still goes to `/v1.0/traces` in v1 format. It first asserts that no `/v0.6/stats` payloads exist, so it fails loudly rather than passing vacuously if CSS were somehow active.

This also settles something the suite currently cannot answer: whether the old code honoured an explicit protocol pin or overrode it — the difference between a default-selection bug and a config-precedence bug.

### 3. Fixed endpoint probing in `Test_Client_Drop_P0s`

The sequential `if len(...) == 0` chain stopped at the first non-empty endpoint, so a tracer emitting on both `v0.4` and `v1.0` only ever had `v0.4` header-checked. `get_data` accepts a list of path filters and matches any of them, so all trace payloads are now collected and every one is verified.

### Manifests

`Test_V1PayloadWithStatsDisabled` is declared `missing_feature` for:

- **golang** — until #5122 ships. This is the bug being fixed, so the test is expected to fail on every current release.
- **nodejs** and **ruby** — matching every other class in this file; neither has working v1 today.

**Java is deliberately left inheriting the file-level `>=1.62.0`.** It supports v1 when the protocol is pinned and has no CSS coupling, so it is the language that proves the new test is meaningful rather than vacuous.

### Plumbing

Both scenarios registered in `.github/workflows/run-end-to-end.yml`; affected entries updated in `tests/test_the_test/scenarios.json`.

## Longer term: this becomes the permanent guard

Once DataDog/dd-trace-go#5122 ships, `Test_V1PayloadByDefault` in the DEFAULT scenario becomes a real regression guard for the decoupling, at no extra cost — DEFAULT already disables CSS and already asserts v1, which is precisely the property #5122 establishes.

That gives a concrete acceptance criterion, in this order:

1. **#5122 merges and is released.** It is not in `v2.10.0-rc.1` — verified with `git merge-base --is-ancestor` — so it lands in `v2.11.0` unless backported.
2. **Flip `Test_V1PayloadWithStatsDisabled` for golang** from `missing_feature` to that release version.
3. **Flip `Test_V1PayloadByDefault` for golang** from `missing_feature (not implemented by default yet)` to the same version, replacing the inaccurate reason.

⚠️ Do **not** set either to `v2.10.0-rc.1`. That tag predates the decoupling, so CSS-off still downgrades to v0.4 and both tests must fail on `net-http` / `net-http-orchestrion`. Until #5122 is released, `missing_feature` is the correct declaration — just not for the reason currently written down.

Worth noting for whoever does step 3: because `missing_feature` is a non-strict xfail, these tests will **XPASS silently** the moment Go starts passing them. Nothing will tell you it is time to flip them. That is the same gap that let the original coupling go unreported, and it is being tracked separately.

## Notes for the reviewer

**This needs R&P review on two counts** — scenarios are added, and files outside `tests/`/`manifests/` are touched (`utils/_context/`, `.github/workflows/`).

**One open decision.** Python, .NET and PHP have CSS coverage but no ETP/v1 support, so `DD_TRACE_AGENT_PROTOCOL_VERSION=1.0` will likely be ignored and they will emit legacy payloads — making `TRACE_STATS_COMPUTATION_V1` a duplicate run of `TRACE_STATS_COMPUTATION` for them. It passes, it just costs CI time. Left ungated on purpose: when those tracers gain ETP/v1 the coverage activates by itself with no manifest edit, and it surfaces the day a tracer starts honouring the flag. Happy to add `missing_feature` gating for those three if you would rather pay less CI.

**Verification done** — the full `./format.sh --check` equivalent is green locally:

- `mypy` 2.1.0 (as pinned): `Success: no issues found in 528 source files`
- `ruff format --check`: 612 files already formatted
- `ruff check`: all checks passed
- no trailing whitespace
- all three edited manifests parse through the repo's own parser (`utils/manifest/_internal/parser.load`), including the quoted `#` in the golang reason string
- `Test_V1PayloadWithStatsDisabled` resolves to exactly one scenario marker, `APM_TRACING_EFFICIENT_PAYLOAD_STATS_DISABLED`
- `test_disable` correctly still maps to `DEFAULT` — its method-level `@scenarios.default` overrides the class markers, per `conftest.py:344`

**Not verified**: neither scenario has been executed against a real tracer, so they are unproven end-to-end. CI is the first real proof, and the manifest declarations above are my best reading of each tracer's current state — expect to adjust them.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [x] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
