### PR TITLE
[docs] Fix false claim that specific manifest rules override directory rules

### DIFF
--- a/docs/edit/manifest.md
+++ b/docs/edit/manifest.md
@@ -288,16 +288,89 @@ manifest:
 
 ### Directory-Level Rules
 
-Apply rules to entire directories. More specific rules override directory rules:
+An entry is matched against a node ID by path prefix, so an entry on a directory applies to
+every test underneath it:
 
 ```yaml
 manifest:
   # All tests in the sink subdirectory
   tests/appsec/iast/sink: "missing_feature"
+```
 
-  # More specific rules override directory rules
+### How Entries Combine
+
+**Declarations from every matching level accumulate.** Directory, file, class and method
+entries are all collected, and none of them overrides another. A more specific entry can
+only *add* a restriction — it can never remove or relax one coming from a broader entry.
+
+The reason is that no entry ever states "this test is enabled". A version entry such as
+`v2.0.0` is shorthand for "disabled with `missing_feature` below 2.0.0", and a test is
+[enabled](../glossary.md) only when *no* matching entry produces a declaration. A version
+entry whose constraint is satisfied therefore contributes nothing — it has no declaration to
+override a broader one with:
+
+```yaml
+manifest:
+  # Every test in this subdirectory is disabled, at every version
+  tests/appsec/iast/sink: "missing_feature"
+
+  # This does NOT re-enable the file. Both entries match the tests it contains, so they
+  # stay disabled at 2.0.0 and above, inheriting missing_feature from the entry above.
   tests/appsec/iast/sink/test_specific.py: "v2.0.0"
 ```
+
+To enable a test that a broader entry disables, narrow the broader entry itself, with
+`component_version`, `excluded_weblog`/`weblog`, or `weblog_declaration`.
+
+Narrowing by version — the directory entry stops applying at 2.0.0, so the file entry
+governs from there on:
+
+```yaml
+manifest:
+  tests/appsec/iast/sink:
+    - declaration: missing_feature
+      component_version: "<2.0.0"
+
+  # This file needs a later version than the rest of the directory
+  tests/appsec/iast/sink/test_specific.py: "v2.5.0"
+```
+
+Narrowing by weblog — `rack` is carved out of the directory entry, so only for `rack` does
+the file entry decide:
+
+```yaml
+manifest:
+  tests/appsec/iast/sink:
+    - declaration: missing_feature
+      excluded_weblog: [rack]
+
+  # Applies to rack; every other weblog stays disabled by the entry above
+  tests/appsec/iast/sink/test_specific.py: "v2.0.0"
+```
+
+If no such narrowing expresses what you need, restructure the broader entry — for instance
+replace the directory entry with one entry per sibling file or class.
+
+#### Weblog lists don't need to be mirrored
+
+When a broader entry already gates unlisted weblogs through `weblog_declaration` and `'*'`,
+a bare version entry below it is safe:
+
+```yaml
+manifest:
+  tests/appsec/test_feature.py:
+    - weblog_declaration:
+        '*': missing_feature   # every unlisted weblog stays disabled
+        django-poc: v1.0.0
+        flask-poc: v1.0.0
+
+  # Only raises the required version for django-poc and flask-poc, the weblogs the entry
+  # above lets through. fastapi, express4... remain disabled by '*'.
+  tests/appsec/test_feature.py::Test_A: "v2.0.0"
+```
+
+Because the `'*'` declaration still accumulates for the weblogs it covers, there is no need
+to repeat the weblog list on the class entry.
 
 ### Agent Manifest
 


### PR DESCRIPTION
## Motivation

`docs/edit/manifest.md` contained a factually incorrect statement about manifest rule
resolution, in the section people read precisely when they are trying to activate a test:

> ### Directory-Level Rules
>
> Apply rules to entire directories. More specific rules override directory rules

Manifest declarations **accumulate** — they never override. `Manifest.get_declarations`
(`utils/manifest/_internal/core.py`) appends the declarations of *every* rule whose
path-segment prefix matches the nodeid (`match_rule` in `rule.py` is a pure prefix match),
and `conftest.py` calls `add_pytest_marker` once per collected declaration. Nothing anywhere
picks a "most specific" winner.

Worse, the example given to illustrate the claim demonstrates the opposite. Verified with
that exact snippet: at python `3.0.0`, the nodeid
`tests/appsec/iast/sink/test_specific.py::Test_X::test_y` still resolves to
`missing_feature`, inherited from the directory rule, even though it satisfies the more
specific `v2.0.0` entry. Following the doc as written leaves you with a test you believe is
enabled and that is silently still disabled.

## Changes

Docs only — no framework or test behaviour is touched.

Split the old section into `### Directory-Level Rules` (prefix matching only) and a new
`### How Entries Combine`, which:

- States that declarations from every matching level (directory, file, class, method)
  accumulate, and that a narrower entry can only *add* restrictions.
- Explains **why**, which turns the rule from an arbitrary gotcha into something
  derivable: no entry ever declares a test enabled. `process_inline` (`parser.py`) turns
  `v2.0.0` into a condition with `excluded_component_version: >=2.0.0` carrying a
  `missing_feature` declaration, so a *satisfied* version entry emits nothing at all. Only
  disabling declarations exist — hence there is nothing for a narrower entry to override a
  broader one with.
- Keeps the original YAML as the worked example, re-annotated with what actually happens.
- Adds the two ways to genuinely enable a test that a broader entry disables — narrowing
  that entry by version (`component_version`) or by weblog (`excluded_weblog`/`weblog`) —
  plus a note to restructure the broader entry when neither fits.
- Documents the corollary that weblog lists need **not** be mirrored onto narrower entries:
  when a broader `weblog_declaration` already gates unlisted weblogs through `'*'`, a bare
  version entry below it is safe.

## Notes for the reviewer

**Every YAML block in the new section was executed** against a throwaway manifest directory
via `Manifest(components, weblog, path=...)` before being written down — 13 cases in total,
including the negative ones (unlisted weblogs such as `fastapi`/`express4` staying gated by
`'*'`, and versions below the narrower entry still being gated by it). All matched the
documented behaviour.

I also grepped `docs/` for other statements about override/precedence in manifest
resolution; the claim was confined to this one section, and `docs/edit/enable-test.md` does
not repeat it.

`./format.sh` passes. Two failures show up on a first local run and are **pre-existing and
environmental**, not from this change (both already known on this machine):

- `yamlfmt` reformatted `manifests/python.yml` (85 lines of `*django:` → `*django :`).
  Cause: `format.sh` pins yamlfmt 0.16.0 but only installs it when `which yamlfmt` finds
  nothing, so a newer global v0.20.0 shadows it. Reverted; confirmed the pinned 0.16.0
  leaves `manifests/` untouched and lint-clean, so nothing of it is in this PR.
- `utils/scripts/shellcheck.sh` dies with `line 74: @: unbound variable` under macOS bash
  3.2 (empty `"${@}"` with `set -u`). Passes under bash 5, as in CI.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) — **applies here: this changes `docs/`, so R&P approval is required.**
* [ ] A docker base image is modified? — no
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed? — no
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
