### PR TITLE
Remove bogus v1 payload version gates from nodejs/ruby manifests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -3131,44 +3131,4 @@ manifest:
         fastify: '>=6.8.0'
         nextjs: '>=6.8.0'
   tests/test_telemetry.py::Test_TelemetryV2: *ref_4_21_0
-  tests/test_v1_payloads.py:  # TODO: a lower version might be supported
-    - weblog_declaration:
-        '*': missing_feature
-        express4-typescript: '>=6.8.0'
-        uds-express4: '>=6.8.0'
-        express4: '>=6.8.0'
-        express5: '>=6.8.0'
-        fastify: '>=6.8.0'
-        nextjs: '>=6.8.0'
-  tests/test_v1_payloads.py::Test_V1PayloadByDefault:
-    - weblog_declaration:
-        fastify: missing_feature
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature
-  tests/test_v1_payloads.py::Test_V1Payloads:
-    - weblog_declaration:
-        fastify: missing_feature
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature
-  tests/test_v1_payloads.py::Test_V1SpanEvents:
-    - weblog_declaration:
-        fastify: missing_feature
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature
-  tests/test_v1_payloads.py::Test_V1SpanLinks:
-    - weblog_declaration:
-        fastify: missing_feature
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature
+  tests/test_v1_payloads.py: missing_feature (dd-trace-js only implements the 0.4 and 0.5 trace encoders)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -3271,19 +3271,4 @@ manifest:
   tests/test_telemetry.py::Test_TelemetryV2::test_telemetry_v2_required_headers:
     - declaration: missing_feature (dd-client-library-version missing)
       component_version: <1.22.0
-  tests/test_v1_payloads.py:  # TODO: a lower version might be supported
-    - weblog_declaration:
-        '*': missing_feature
-        rack: '>=2.33.0'
-  tests/test_v1_payloads.py::Test_V1PayloadByDefault:
-    - weblog_declaration:
-        rack: missing_feature
-  tests/test_v1_payloads.py::Test_V1Payloads:
-    - weblog_declaration:
-        rack: missing_feature
-  tests/test_v1_payloads.py::Test_V1SpanLinks:
-    - weblog_declaration:
-        rack: missing_feature
-  tests/test_v1_payloads.py::Test_V1TopLevelSpans:
-    - weblog_declaration:
-        rack: missing_feature
+  tests/test_v1_payloads.py: missing_feature (dd-trace-rb only exposes the /v0.3 and /v0.4 trace endpoints)


### PR DESCRIPTION
> **⚠️ Merge order: this PR must land BEFORE #7450.**
> #7450 adds an `assert root_spans, "Expected at least one root span"` guard to `Test_V1TopLevelSpans`, which is still activated for the 6 nodejs weblogs on `main`. This PR deactivates it. If #7450 merges first, nodejs `Test_V1TopLevelSpans` goes red until this PR follows.

## Motivation

The file-level manifest entries for `tests/test_v1_payloads.py` in `manifests/nodejs.yml` and `manifests/ruby.yml` declared version gates for a capability that does not exist in either tracer. Verified against tracer sources:

- **dd-trace-js**: `packages/dd-trace/src/encode/` contains only `0.4.js` and `0.5.js` on every ref, including `master` and tag `v6.8.0` — which is also the current latest release. No v1 encoder has ever been committed, so `>=6.8.0` asserted support that never shipped.
- **dd-trace-rb**: `lib/datadog/tracing/transport/http.rb` declares only `/v0.4/traces` and `/v0.3/traces` on both `v2.33.0` and `master`. There is no `protocol_version` setting and no `DD_TRACE_AGENT_PROTOCOL_VERSION` env var anywhere in the gem, so `>=2.33.0` asserted support that never shipped.

Both blocks were generated by the easy-win auto-activation script, which replaced a plain `tests/test_v1_payloads.py: missing_feature` with a file-level version gate plus per-class `missing_feature` overrides — including the bot's leftover `# TODO: a lower version might be supported` comment:

- nodejs: 8c308b5c1 "Auto-activate nodejs easy wins for apm-lang-platform (#6619)"
- ruby: 12b02cb7e3 "Auto-activate ruby easy wins for apm-lang-platform (#6993)"

## Changes

Collapsed both to a single `missing_feature` entry carrying the reason, removing the version gates, the per-class duplicates, and the stale `# TODO`. Net: 2 insertions, 57 deletions, no files outside these two manifests.

## ⚠️ This is not a no-op — it disables 7 previously-activated entries

The gates were **not** inert. Because declarations accumulate rather than override, the per-class overrides masked the gate only for the classes they named — and each manifest omitted exactly one class, leaving the gate live for it. The file has **five** classes; nodejs declared four and ruby declared a *different* four:

| Manifest | Class left un-shadowed | Before |
|---|---|---|
| nodejs | `Test_V1TopLevelSpans` | no declaration → activated (× 6 weblogs) |
| ruby | `Test_V1SpanEvents` | no declaration → activated (`rack`) |

So those tests were activated and expected to pass against tracers with no v1 support at all.

Verified with `Manifest.get_declarations()` across all five classes and every affected weblog, before and after: the only semantic change is those 7 entries going from no-declaration to `missing_feature`. **No test that was previously disabled becomes enabled.** Since `missing_feature` is a non-strict xfail, the newly disabled entries XPASS silently rather than break CI.

`Manifest.validate()` passes. `yamlfmt` lint is clean on both files (scoped to the two edited files — my local yamlfmt is v0.20.0 vs the v0.16.0 pinned by `format.sh`/CI, and a full sweep produces spurious diffs in `manifests/python.yml`).

## Reviewer notes

**Why the bot got this wrong.** `Test_V1TopLevelSpans::test_root_span_is_top_level` iterates `interfaces.library.get_root_spans(self.r)` with no non-empty guard. `get_root_spans` (`utils/interfaces/_library/core.py:145`) is a generator that yields nothing when no root spans match, so when the tracer sends v0.4 the loop body never executes and the test **passes vacuously** — which is how the auto-activation script classified it as an easy win. Compare `get_root_span` singular (`core.py:159`), which does `assert spans, "No root spans found"`. `Test_V1PayloadByDefault::test_main` looks to have the same flaw. Fixing that test is out of scope here and tracked separately; the manifest cleanup addresses the symptom, not the upstream cause.

**These entries are bot-managed**, so the auto-activation script may regenerate them unless its pass-detection is fixed — flagging for #apm-shared-testing.

**Java and golang left untouched.** Both share the same bot-generated file-level-gate shape and both have live un-shadowed classes (java: `Test_V1Payloads`/`Test_V1SpanLinks`/`Test_V1TopLevelSpans` on 4 weblogs; golang: 4 classes on both weblogs). Unlike nodejs/ruby these tracers do appear to have real v1 support (`golang Test_V1Payloads: v2.7.0`), so activation may be legitimate. Worth noting structurally though: a file-level version gate auto-activates any *new* class added to the file for those weblogs.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) — only `manifests/` is modified
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

