### PR TITLE
Fix trace ID comparisons for v0.x and v1 compatibility.

### DIFF
--- a/tests/integrations/crossed_integrations/test_kafka.py
+++ b/tests/integrations/crossed_integrations/test_kafka.py
@@ -5,16 +5,6 @@ from utils.buddies import java_buddy, _Weblog as Weblog
 from utils.dd_types import DataDogLibrarySpan
 
 
-def assert_trace_id_equality(a: str | int, b: str | int):
-    if isinstance(a, str):
-        a = int(a, 16) & 0xFFFFFFFFFFFFFFFF
-
-    if isinstance(b, str):
-        b = int(b, 16) & 0xFFFFFFFFFFFFFFFF
-
-    assert a == b
-
-
 class _BaseKafka:
     """Test kafka compatibility with inputted datadog tracer"""
 
@@ -94,7 +84,7 @@ class _BaseKafka:
         # asserting on direct parent/child relationships
         assert producer_span is not None
         assert consumer_span is not None
-        assert_trace_id_equality(producer_span["trace_id"], consumer_span["trace_id"])
+        assert producer_span.trace_id_equals(consumer_span["trace_id"])
 
     def setup_consume(self):
         """Send request A to library buddy : this request will produce a kafka message
@@ -134,7 +124,7 @@ class _BaseKafka:
         # asserting on direct parent/child relationships
         assert producer_span is not None
         assert consumer_span is not None
-        assert_trace_id_equality(producer_span["trace_id"], consumer_span["trace_id"])
+        assert producer_span.trace_id_equals(consumer_span["trace_id"])
 
     def validate_kafka_spans(
         self,

--- a/tests/integrations/crossed_integrations/test_kinesis.py
+++ b/tests/integrations/crossed_integrations/test_kinesis.py
@@ -121,7 +121,7 @@ class _BaseKinesis:
         # asserting on direct parent/child relationships
         assert producer_span is not None
         assert consumer_span is not None
-        assert producer_span["trace_id"] == consumer_span["trace_id"]
+        assert producer_span.trace_id_equals(consumer_span["trace_id"])
 
     def setup_consume(self):
         """Send request A to library buddy : this request will produce a Kinesis message
@@ -177,7 +177,7 @@ class _BaseKinesis:
         # asserting on direct parent/child relationships
         assert producer_span is not None
         assert consumer_span is not None
-        assert producer_span["trace_id"] == consumer_span["trace_id"]
+        assert producer_span.trace_id_equals(consumer_span["trace_id"])
 
     def validate_kinesis_spans(
         self,

--- a/tests/integrations/crossed_integrations/test_sqs.py
+++ b/tests/integrations/crossed_integrations/test_sqs.py
@@ -134,7 +134,7 @@ class _BaseSQS:
         # Both producer and consumer spans should be part of the same trace
         # Different tracers can handle the exact propagation differently, so for now, this test avoids
         # asserting on direct parent/child relationships
-        assert producer_span["trace_id"] == consumer_span["trace_id"]
+        assert producer_span.trace_id_equals(consumer_span["trace_id"])
 
     def setup_consume(self):
         """Send request A to library buddy : this request will produce a sqs message

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -90,7 +90,7 @@ class Test_Span_Links_From_Conflicting_Contexts:
             span
             for _, _, span in interfaces.library.get_spans(self.req, full_trace=True)
             if len(span.get_span_links()) != 0
-            and span["trace_id"] == 1
+            and span.trace_id_equals(1)
             and span["parent_id"] == 987654321  # Only fetch the trace that is related to the header extractions
         ]
 
@@ -117,7 +117,7 @@ class Test_Span_Links_From_Conflicting_Contexts:
             span
             for _, _, span in interfaces.library.get_spans(self.req, full_trace=True)
             if len(span.get_span_links()) != 0
-            and span["trace_id"] == 5
+            and span.trace_id_equals(5)
             and span["parent_id"] == 987654324  # Only fetch the trace that is related to the header extractions
         ]
 
@@ -147,7 +147,7 @@ class Test_Span_Links_Flags_From_Conflicting_Contexts:
             span
             for _, _, span in interfaces.library.get_spans(self.req, full_trace=True)
             if len(span.get_span_links()) != 0
-            and span["trace_id"] == 2
+            and span.trace_id_equals(2)
             and span["parent_id"] == 987654321  # Only fetch the trace that is related to the header extractions
         ]
 
@@ -183,7 +183,7 @@ class Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts:
             span
             for _, _, span in interfaces.library.get_spans(self.req, full_trace=True)
             if len(span.get_span_links()) != 0
-            and span["trace_id"] == 2
+            and span.trace_id_equals(2)
             and span["parent_id"] == 987654321  # Only fetch the trace that is related to the header extractions
         ]
 


### PR DESCRIPTION
## Motivation

The `v1` trace payload represents trace IDs as 128-bit hexadecimal strings, while `v0.x` payloads expose 64-bit integers. Direct comparisons between these representations caused cross-library tracing tests to fail even when both values referred to the same trace.

## Changes

- Use `trace_id_equals()` for Kafka, Kinesis, and SQS cross-library trace comparisons.
- Use `trace_id_equals()` when selecting distributed-tracing spans by trace ID.
- Remove the Kafka-specific trace ID normalization helper in favor of the shared API.
- Keep comparisons compatible with both v0.x and v1 payload formats.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
