### PR TITLE
Fix vacuous passes in v1 payload tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -3172,3 +3172,14 @@ manifest:
         uds-express4: missing_feature
         express4-typescript: missing_feature
         nextjs: missing_feature
+  # dd-trace-js has no v1 trace encoder (packages/dd-trace/src/encode/ only ships
+  # 0.4 and 0.5), so no v1 root span is ever collected. This was activated by the
+  # easy win script off a vacuous pass, before the test asserted a root span exists.
+  tests/test_v1_payloads.py::Test_V1TopLevelSpans:
+    - weblog_declaration:
+        fastify: missing_feature
+        express4: missing_feature
+        express5: missing_feature
+        uds-express4: missing_feature
+        express4-typescript: missing_feature
+        nextjs: missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -3172,14 +3172,3 @@ manifest:
         uds-express4: missing_feature
         express4-typescript: missing_feature
         nextjs: missing_feature
-  # dd-trace-js has no v1 trace encoder (packages/dd-trace/src/encode/ only ships
-  # 0.4 and 0.5), so no v1 root span is ever collected. This was activated by the
-  # easy win script off a vacuous pass, before the test asserted a root span exists.
-  tests/test_v1_payloads.py::Test_V1TopLevelSpans:
-    - weblog_declaration:
-        fastify: missing_feature
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature

--- a/tests/test_v1_payloads.py
+++ b/tests/test_v1_payloads.py
@@ -8,7 +8,10 @@ class Test_V1PayloadByDefault:
     """Tracers use by default v1 trace format"""
 
     def test_main(self):
-        for data, trace in interfaces.library.get_traces():
+        traces = list(interfaces.library.get_traces())
+        assert traces, "Expected at least one trace"
+
+        for data, trace in traces:
             assert data["path"] == "/v1.0/traces"
             assert trace.format == LibraryTraceFormat.v10
 
@@ -122,7 +125,10 @@ class Test_V1TopLevelSpans:
 
     def test_root_span_is_top_level(self):
         """The root span of a trace must be marked as top-level"""
-        for _, root_span in interfaces.library.get_root_spans(self.r):
+        root_spans = list(interfaces.library.get_root_spans(self.r))
+        assert root_spans, "Expected at least one root span"
+
+        for _, root_span in root_spans:
             attrs = root_span.raw_span.get("attributes", {})
             assert attrs.get("_dd.top_level") == 1 or attrs.get("_dd.top_level") == 1.0, (
                 f"Root span must have _dd.top_level=1 in attributes, got: {attrs.get('_dd.top_level')}"


### PR DESCRIPTION
> **⚠️ Merge order: this PR must land AFTER #7447.**
> `Test_V1TopLevelSpans` is currently activated for the 6 nodejs weblogs on `main` off a vacuous pass (see below). This PR adds an assertion that makes that vacuous pass fail honestly. #7447 deactivates `Test_V1TopLevelSpans` for nodejs. If this PR merges before #7447, nodejs `Test_V1TopLevelSpans` goes red until #7447 follows.

## Motivation

Two tests in `tests/test_v1_payloads.py` could pass without asserting anything.

`Test_V1TopLevelSpans::test_root_span_is_top_level` iterates `interfaces.library.get_root_spans(self.r)` with no non-empty guard. `get_root_spans` (`utils/interfaces/_library/core.py:145`) is a generator that yields nothing when no root spans match, so when the tracer sends v0.4 instead of v1 the loop body never executes and the test **passes** — despite its own docstring asserting that a root span must exist and be marked top-level. Compare `get_root_span` singular (`core.py:159`), which does `assert spans, "No root spans found"`.

`Test_V1PayloadByDefault::test_main` has the same shape over `get_traces()`.

This is not theoretical. It caused a real misclassification: the easy-win auto-activation script observed `Test_V1TopLevelSpans` "passing" for the 6 nodejs weblogs and activated it in `manifests/nodejs.yml`, even though dd-trace-js has no v1 trace encoder at any version — `packages/dd-trace/src/encode/` ships only `0.4.js` and `0.5.js` on every ref including `master` and tag `v6.8.0`. The tracer sends v0.4, zero v1 root spans are collected, and the test reports success.

## Changes

Collect each generator into a list and assert it is non-empty before looping, so an empty result is a failure rather than a silent pass.

Test-only — no manifest changes.

## Merge order: this must land after #7447

`Test_V1TopLevelSpans` is **currently activated for the 6 nodejs weblogs on main**, off the back of the vacuous pass described above. Once the guard lands, that test genuinely fails for nodejs.

#7447 removes the bogus file-level version gate for `tests/test_v1_payloads.py` and collapses the block to a single `missing_feature` entry, which deactivates `Test_V1TopLevelSpans` for all six nodejs weblogs (and `Test_V1SpanEvents` for ruby `rack`). **#7447 must merge first.**

An earlier revision of this PR carried its own per-class deactivation block to stay independently mergeable, but it duplicated what #7447's file-level entry already covers and attached to context lines #7447 deletes, so the two conflicted. Dropped it in favour of a clean split: #7447 owns manifests, this PR owns test logic.

## Reviewer notes

`Test_V1SpanLinks` and `Test_V1SpanEvents` already assert non-emptiness and are unchanged.

java and golang have `Test_V1TopLevelSpans` activated too (java: `ratpack`, `uds-spring-boot`, `spring-boot-wildfly`, `spring-boot-undertow`; golang: `net-http`, `net-http-orchestrion`). The guard should be a no-op there — both also have `Test_V1Payloads` activated, which asserts real v1 payload structure, so spans are demonstrably being collected. Worth confirming on CI rather than assuming.

The upstream cause is the auto-activation script treating a vacuous pass as an easy win. This PR removes the vacuous passes; whether the script needs its own fix is a question for #apm-shared-testing.

## Workflow

1. Create your PR as draft
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

Once your PR is reviewed and the CI green, you can merge it!

[#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) — only `tests/` is modified
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

