### PR TITLE
[Go] Fix misleading reason on Test_V1PayloadByDefault declaration

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -2079,5 +2079,5 @@ manifest:
         '*': missing_feature
         net-http: '>=2.5.0'
         net-http-orchestrion: '>=2.5.0'
-  tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (not implemented by default yet)
+  tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (v1 is the default since v2.10.0-rc.1, but it is gated on client-side stats, which the DEFAULT scenario disables, so the tracer downgrades to v0.4)
   tests/test_v1_payloads.py::Test_V1Payloads: v2.7.0


### PR DESCRIPTION
## Motivation

`tests/test_v1_payloads.py::Test_V1PayloadByDefault` is the only thing in CI that could pin which trace protocol a tracer uses **by default**. It is declared `missing_feature` for every library, and `missing_feature` maps to a **non-strict** `xfail` (`utils/_decorators.py` — only `IRRELEVANT` and `FLAKY` become `skip`; `xfail_strict` is not set in `pyproject.toml`). So the guard cannot fail: if a tracer's default protocol changes, the test XPASSes and CI stays green.

This came out of the work to decouple the ETP/v1 trace protocol from Client-Side Stats, where we need system-tests to be trustworthy signal. I set out to activate the test where it was stale, and audited Go, Java, Node.js and Ruby. The audit's conclusion was that **only one thing was actually wrong, and it was not a missing version — it was a false reason string.**

`manifests/golang.yml` said:

```yaml
tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (not implemented by default yet)
```

That reason is factually wrong. dd-trace-go **has** defaulted to v1 since `v2.10.0-rc.1`. The test fails for a completely different reason, and the declaration was hiding the real one.

## Changes

One line in `manifests/golang.yml`: the reason string is replaced so the declaration documents the actual blocker.

```diff
-  tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (not implemented by default yet)
+  tests/test_v1_payloads.py::Test_V1PayloadByDefault: missing_feature (v1 is the default since v2.10.0-rc.1, but it is gated on client-side stats, which the DEFAULT scenario disables, so the tracer downgrades to v0.4)
```

**Enablement is byte-for-byte unchanged** for every Go weblog and version — this only changes text. Verified by diffing `Manifest.get_declarations()` output before and after for `net-http`, `net-http-orchestrion`, `chi` and `gin` at v2.9.0 and v2.11.0.

### Why the test actually fails

1. `internal/config/config.go` resolves `DD_TRACE_AGENT_PROTOCOL_VERSION` with a default of `TraceProtocolVersionStringV1` — v1 **is** the default since `v2.10.0-rc.1`.
2. `ddtrace/tracer/option.go` then downgrades it:
   ```go
   if c.internalConfig.TraceProtocol() == traceProtocolV1 && (!af.v1ProtocolAvailable || !c.canComputeStats()) {
       c.internalConfig.SetTraceProtocol(traceProtocolV04, internalconfig.OriginCalculated)
   }
   ```
3. `canComputeStats()` requires `HasFeature("discovery") || StatsComputationEnabled()`.
4. `DefaultScenario` (`utils/_context/_scenarios/default.py`) sets `DD_TRACE_STATS_COMPUTATION_ENABLED=false` and sets neither `DD_TRACE_FEATURES=discovery` nor an explicit protocol version.

⇒ CSS off ⇒ `canComputeStats()` false ⇒ tracer emits `/v0.4/traces`, while the test asserts every trace is `/v1.0/traces`. **In released dd-trace-go, ETP/v1 is gated on Client-Side Stats** — which is precisely the coupling the decoupling work is removing.

### Why it stays `missing_feature` rather than getting a version

There is no correct boundary to activate it at yet. The decoupling fix (dd-trace-go `dac359a4d`, *"decouple trace protocol v1.0 from client-side stats"*) is **not on dd-trace-go `main`** and is in **no `v2.10`/`v2.11` tag** — it currently lives only on a topic branch. So no released version emits v1 by default under the DEFAULT scenario's configuration. Setting `v2.10.0-rc.1` would arm a test that cannot pass and turn CI red, which is a different kind of untrustworthy signal.

The correct boundary is the first release containing `dac359a4d`. That is the follow-up.

## Audit results for the other languages — no changes needed

All three were verified against tracer sources, and all are **correctly** declared `missing_feature`:

| Tracer | Default | v1 support? |
|---|---|---|
| **dd-trace-java** | `/v0.4/traces` | Added behind a flag in v1.62.0, but `ConfigDefaults.DEFAULT_TRACE_AGENT_PROTOCOL_VERSION` is `ProtocolVersion.V0_4` on master and on every tag through v1.65.0 — **the default never flipped** |
| **dd-trace-js** | `/v0.4/traces` | **None at any version** — `encode/` contains only `0.4.js` and `0.5.js`; `DD_TRACE_AGENT_PROTOCOL_VERSION` defaults to `"0.4"` |
| **dd-trace-rb** | `/v0.4/traces` | **None** — only `/v0.4/traces` and `/v0.3/traces` endpoints exist; there is no protocol-version setting at all |

Worth recording: PR #7419's statement that *"`dd-trace-java` uses `/v1.0/traces` by default"* does **not** mean the default flipped. It was defensive work — the author runs system-tests against unmerged **draft** dd-trace-java branches (#11872, #12108, both marked "DO NOT MERGE") that flip the default locally. `TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE` never sets `DD_TRACE_AGENT_PROTOCOL_VERSION`, so a released Java tracer cannot reach `/v1.0/traces` there.

## Follow-ups, not in this PR

1. **The guard still cannot fail on XPASS.** There is no per-test strict mechanism: `add_pytest_marker` builds `pytest.mark.xfail(reason=...)` and never passes `strict=`. Note `skip_if_xfail` (`@slow`/`@scenario_crash`) is the *wrong* tool — it converts an xfail into an unconditional **skip**, hiding the signal harder. Options, cheapest first:
   - Rely on the easy-win nightly (`utils/scripts/activate_easy_wins/` already tracks `xpass_nodes`) — but it only opens a PR, it never fails a build.
   - **Preferred:** let a test opt into `strict=True` on its manifest-derived xfail (~10 lines in `utils/_decorators.py` + one marker in `pyproject.toml`). Marker-level `strict` takes precedence over the ini setting, so it composes cleanly.
   - A CI job running just this test with `-o xfail_strict=True` (already-supported flag, no framework change, but duplicates DEFAULT-scenario infra).
   - Repo-wide `xfail_strict = true` is **not** viable — thousands of declarations would start failing on XPASS.

   Both preferred options touch files outside `tests/`/`manifests/`, so they need R&P approval and are deliberately excluded here.

2. `docs/edit/manifest.md` claims *"More specific rules override directory rules"*. **This is false** — declarations **accumulate**. `get_declarations` appends the declarations of *every* prefix-matching rule and `conftest.py` adds a marker per declaration; nothing picks a most-specific winner. Reproduced with the doc's own example: at a version satisfying the more specific `v2.0.0` file rule, the test is still `missing_feature` from the directory rule. A more specific entry can only ever *add* restrictions.

3. The file-level gates for `tests/test_v1_payloads.py` in `manifests/nodejs.yml` (`>=6.8.0`) and `manifests/ruby.yml` (`>=2.33.0`) assert support that does not exist at those versions. They are inert today (every class in the file is separately `missing_feature`) and are auto-activation-script artifacts — note the bot's leftover `# TODO: a lower version might be supported`. Cleaning them up needs coordination with the owning team since the bot may regenerate them.

## Testing

`manifests/validate.py`, `yamlfmt` (pinned 0.16.0) and `yamllint` all pass. Before/after `get_declarations()` comparison confirms no enablement change.

Two local-environment notes for anyone reproducing: the repo-root `venv` may point at a stale Homebrew `python@3.12` revision (rebuild with `rm -rf venv && ./build.sh -i runner`), and `./format.sh --check` fails locally for two reasons unrelated to any change — `format.sh` picks up whatever `yamlfmt` is on `PATH` rather than the pinned 0.16.0 (a newer one reports spurious diffs in `manifests/python.yml`), and `utils/scripts/shellcheck.sh:74` trips on `"${@}"` under `set -u` on macOS bash 3.2. Both reproduce on a pristine checkout.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) — **only `manifests/golang.yml` is modified, so this does not apply**
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
