### PR TITLE
Revert "Auto-activate nodejs easy wins for asm-libraries (#6942)"

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -236,15 +236,7 @@ manifest:
   tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_latest_responses_create: missing_feature
   tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_chat_completions_create: missing_feature
   tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_openai_legacy_completions_create: missing_feature
-  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_root_has_no_llm_tags:  # TODO: a lower version might be supported
-    - weblog_declaration:
-        '*': missing_feature
-        express4-typescript: '>=6.8.0'
-        uds-express4: '>=6.8.0'
-        express4: '>=6.8.0'
-        express5: '>=6.8.0'
-        fastify: '>=6.8.0'
-        nextjs: '>=6.8.0'
+  tests/appsec/api_security/test_endpoints.py::Test_LLM_Endpoint::test_root_has_no_llm_tags: missing_feature
   tests/appsec/api_security/test_schemas.py::Test_Scanners:
     - weblog_declaration:
         "*": *ref_4_21_0
@@ -584,12 +576,7 @@ manifest:
         "*": *ref_4_3_0
         fastify: *ref_5_61_0
         nextjs: missing_feature
-  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect::test_secure:  # TODO: a lower version might be supported
-    - declaration: missing_feature (weblog does not respond)
-      component_version: <6.8.0
-      weblog: [express4-typescript, uds-express4, express4, express5, fastify]
-    - declaration: missing_feature (weblog does not respond)
-      excluded_weblog: [express4-typescript, uds-express4, express4, express5, fastify]
+  tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect::test_secure: missing_feature (weblog does not respond)
   tests/appsec/iast/sink/test_unvalidated_redirect.py::TestUnvalidatedRedirect_ExtendedLocation:
     - weblog_declaration:
         "*": *ref_5_37_0
@@ -1009,7 +996,7 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py: v5.92.0
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_Rasp:
     - weblog_declaration:
-        nextjs: v6.8.0  # TODO: a lower version might be supported
+        nextjs: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecAPMStandalone_RemoteConfig::test_rasp_blocking_smoke:
     - weblog_declaration:
         nextjs: missing_feature
@@ -1019,7 +1006,7 @@ manifest:
         nextjs: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_Rasp:
     - weblog_declaration:
-        nextjs: v6.8.0  # TODO: a lower version might be supported
+        nextjs: missing_feature
   tests/appsec/smoke_tests/test_apm_standalone.py::Test_AppSecStandaloneAPMStandalone_RemoteConfig::test_rasp_blocking_smoke:
     - weblog_declaration:
         nextjs: missing_feature
@@ -1169,18 +1156,6 @@ manifest:
         "*": *ref_3_19_0
         express5: *ref_5_29_0
         fastify: *ref_5_57_0
-        nextjs: v6.8.0  # TODO: a lower version might be supported
-  tests/appsec/test_blocking_addresses.py::Test_Blocking_request_query::test_blocking:
-    - weblog_declaration:
-        nextjs: missing_feature
-  tests/appsec/test_blocking_addresses.py::Test_Blocking_request_query::test_blocking_before:
-    - weblog_declaration:
-        nextjs: missing_feature
-  tests/appsec/test_blocking_addresses.py::Test_Blocking_request_query::test_blocking_case_sensitive:
-    - weblog_declaration:
-        nextjs: missing_feature
-  tests/appsec/test_blocking_addresses.py::Test_Blocking_request_query::test_non_blocking:
-    - weblog_declaration:
         nextjs: missing_feature
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_uri: *ref_3_19_0
   tests/appsec/test_blocking_addresses.py::Test_Blocking_response_headers: *ref_5_17_0
@@ -1832,12 +1807,7 @@ manifest:
   : bug (MLOB-5070)
   ? tests/integration_frameworks/llm/google_genai/test_google_genai_llmobs.py::TestGoogleGenAiGenerateContentWithTools::test_generate_content_with_tools
   : missing_feature (Node.js LLM Observability Google GenAI integration does not submit tool definitions)
-  tests/integration_frameworks/llm/openai/test_openai_ai_guard.py::TestOpenAiAiGuard:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APPSEC-68977, AI Guard/OpenAI integration not yet wired into INTEGRATION_FRAMEWORKS)
-      component_version: <6.8.0
-      weblog: [openai-js@6.0.0]
-    - declaration: missing_feature (APPSEC-68977, AI Guard/OpenAI integration not yet wired into INTEGRATION_FRAMEWORKS)
-      excluded_weblog: [openai-js@6.0.0]
+  tests/integration_frameworks/llm/openai/test_openai_ai_guard.py::TestOpenAiAiGuard: missing_feature (APPSEC-68977, AI Guard/OpenAI integration not yet wired into INTEGRATION_FRAMEWORKS)
   tests/integration_frameworks/llm/openai/test_openai_apm.py::TestOpenAiApmChatCompletions: *ref_5_76_0
   tests/integration_frameworks/llm/openai/test_openai_apm.py::TestOpenAiApmCompletions: *ref_5_76_0
   tests/integration_frameworks/llm/openai/test_openai_apm.py::TestOpenAiApmEmbeddings: *ref_5_76_0
@@ -2888,13 +2858,7 @@ manifest:
   tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag:
     - weblog_declaration:
         "*": *ref_5_81_0
-        nextjs: v6.8.0  # Next.js have file based routing, resource renaming is supported if we are not able to get route from insturmantation that we can't reprocude it.
-  tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag::test_http_endpoint_basic:
-    - weblog_declaration:
-        nextjs: missing_feature
-  tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag::test_http_endpoint_edge_cases:
-    - weblog_declaration:
-        nextjs: missing_feature
+        nextjs: missing_feature  # Next.js have file based routing, resource renaming is supported if we are not able to get route from insturmantation that we can't reprocude it.
   tests/test_resource_renaming.py::Test_Resource_Renaming_HTTP_Endpoint_Tag::test_http_endpoint_root:
     - weblog_declaration:
         fastify: missing_feature (Fasitfy root route is always '/' not empty string)


### PR DESCRIPTION
This reverts commit 77512c8329647719b4423f84de031285d67ddfbd.

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
