### PR TITLE
Guard against vacuous passes in get_root_spans() loops

### DIFF
--- a/manifests/c.yml
+++ b/manifests/c.yml
@@ -16,6 +16,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py: missing_feature (APMAPI-2171, dd-trace-c does not implement OpenTelemetry ot.th/ot.rv sampling)
   tests/test_rum_injection.py: irrelevant (dd-trace-c does not implement RUM injection)
   tests/test_sampling_manual.py: missing_feature (dd-trace-c does not implement manual keep/drop)
+  tests/test_sampling_rate_capping.py::Test_SamplingRateCappedIncrease: missing_feature (dd-trace-c does not implement agent-driven sampling rate capping)
   tests/test_sampling_rates.py::Test_SampleRateFunction: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingDecisions: missing_feature (dd-trace-c does not implement static trace sampling rules)
   tests/test_sampling_rates.py::Test_SamplingRates: missing_feature (dd-trace-c does not implement static trace sampling rules)

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -40,14 +40,14 @@ class Test_HeaderTags:
     def test_trace_header_tags_basic(self):
         """Test that http.request.headers.user-agent is in all web spans"""
 
-        # get_root_spans() yields nothing when no root span was collected, so the loop below would
-        # pass vacuously without this guard
-        root_spans = list(interfaces.library.get_root_spans())
-        assert root_spans, "Expected at least one root span"
+        # get_root_spans() yields nothing when no root span was collected, and filtering by
+        # type == "web" can also empty out the collection, so the loop below would pass
+        # vacuously without this guard
+        web_spans = [span for _, span in interfaces.library.get_root_spans() if span.get("type") == "web"]
+        assert web_spans, "Expected at least one web root span"
 
-        for _, span in root_spans:
-            if span.get("type") == "web":
-                assert "http.request.headers.user-agent" in span.get("meta", {})
+        for span in web_spans:
+            assert "http.request.headers.user-agent" in span.get("meta", {})
 
 
 @scenarios.library_conf_custom_header_tags

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -40,7 +40,12 @@ class Test_HeaderTags:
     def test_trace_header_tags_basic(self):
         """Test that http.request.headers.user-agent is in all web spans"""
 
-        for _, span in interfaces.library.get_root_spans():
+        # get_root_spans() yields nothing when no root span was collected, so the loop below would
+        # pass vacuously without this guard
+        root_spans = list(interfaces.library.get_root_spans())
+        assert root_spans, "Expected at least one root span"
+
+        for _, span in root_spans:
             if span.get("type") == "web":
                 assert "http.request.headers.user-agent" in span.get("meta", {})
 

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -37,7 +37,12 @@ def get_trace_request_path(root_span: DataDogLibrarySpan) -> str | None:
 def assert_all_traces_requests_forwarded(paths: list[str] | set[str]) -> None:
     path_to_logfile = {}
 
-    for trace, span in interfaces.library.get_root_spans():
+    # get_root_spans() yields nothing when no root span was collected. Report that explicitly instead
+    # of letting it surface as "every path is missing" below.
+    root_spans = list(interfaces.library.get_root_spans())
+    assert root_spans, "Expected at least one root span"
+
+    for trace, span in root_spans:
         path = get_trace_request_path(span)
         path_to_logfile[path] = trace.data["log_filename"]
 
@@ -171,8 +176,13 @@ class Test_SamplingDecisions:
                     f"sampling decision {sampling_decision} differs from the expected {expected_decision}"
                 )
 
-        for data, span in interfaces.library.get_root_spans():
-            validator(data, span)
+        # get_root_spans() yields nothing when no root span was collected, so the validator below
+        # would never run without this guard
+        root_spans = list(interfaces.library.get_root_spans())
+        assert root_spans, "Expected at least one root span"
+
+        for trace, root_span in root_spans:
+            validator(trace, root_span)
 
 
 @scenarios.sampling


### PR DESCRIPTION
## Motivation

`interfaces.library.get_root_spans()` ([utils/interfaces/_library/core.py:145](https://github.com/DataDog/system-tests/blob/main/utils/interfaces/_library/core.py#L145)) is a generator that yields nothing when no root span was collected — unlike its singular sibling `get_root_span()` (line 152), which asserts `"No root spans found"`. A test whose only assertions live *inside* the loop body therefore **passes when zero root spans exist**.

That is not a harmless soft spot. The easy-win auto-activation script records whatever it observes passing, so a vacuous pass gets written into `manifests/<lang>.yml` as genuine tracer support. This already happened once: `Test_V1TopLevelSpans` was activated for 6 nodejs weblogs even though dd-trace-js ships no v1 trace encoder (fixed separately).

## Changes

Two commits, reviewable independently.

**`86807464f` — add non-empty guards** (`tests/` only)

| Test | Why it was vacuous |
|---|---|
| `Test_HeaderTags::test_trace_header_tags_basic` | Only assertion sits inside an `if span.get("type") == "web"` branch |
| `Test_SamplingDecisions::test_sampling_decision` | `validator(...)` is only called from the loop body, so it never runs |

`Test_SamplingRates::test_sampling_rates` *looks* like a third instance — with zero traces the tolerance band collapses to `0 - 0 <= 0 <= 0 + 0`, which is trivially true. It turns out to be already protected: `assert_all_traces_requests_forwarded(self.paths)` runs first and raises because all 2000 paths from setup are missing from an empty `path_to_logfile`. Rather than add unreachable dead code at the band check, the guard went **inside that helper**, where the root-span iteration actually happens — so the guarantee is explicit and local, and the failure message names the real cause instead of "every path is missing".

Also checked and deliberately **left alone**: `tests/test_sampling_rate_capping.py:65` is a `wait_for` polling predicate that *must* be able to return `False` on no data, and `:74` is a baseline count whose zero case is caught downstream by `assert any(...)` — `any([])` is `False`, so empty data is already red, not green.

**`611ebd563` — deactivate the capping test for dd-trace-c** (`manifests/c.yml`, +1 line)

Unrelated gap found while computing blast radius. `test_sampling_rate_capped_increase` was the only manifest-activated `(library, weblog)` pair across all 12 libraries — `c`/perl-mojolicious — because `manifests/c.yml` had no entry for a test file that postdates it. dd-trace-c implements no static trace sampling rules at all (already declared for the three sibling `Test_Sampling*` classes), and agent-driven rate capping is a strict superset.

Latent rather than failing: `SAMPLING_RATE_CAPPING` requires weblog category `dd_trace`, and perl-mojolicious declares no categories with `supported_scenarios: [DEFAULT, IPV6, SAMPLING]`, so `support_scenario()` returns `False` and the scenario never ran for `c`.

## Blast radius

Adding these guards can flip green→red wherever a manifest activated a test off a vacuous pass, so activation was computed with the Manifest API across all 12 libraries × every weblog rather than by reading YAML:

- `test_trace_header_tags_basic` — activated for dotnet, golang, java (15/16), nodejs, php, python, ruby
- `test_sampling_decision` — activated broadly, including rust/axum and cpp_httpd

**No manifest deactivations are needed for the guards.** Both only require *at least one root span anywhere in the scenario* — not the feature under test. Root spans are the most basic output every one of these tracers produces, and both scenarios have abundant ambient traffic. This is materially different from the v1 case that motivated the work, where the missing data was a *v1-format* trace that dd-trace-js provably cannot emit. Pre-emptively deactivating would be worse than useless here: `missing_feature` is a non-strict xfail, so an incorrect declaration XPASSes silently and rots.

The pairs worth watching in CI are **rust/axum** and **cpp_httpd**, which have no `/sample_rate_route` implementation — though they should still produce traced 404s. Note these counts are manifest-level upper bounds; a weblog must also match the scenario via `weblog_metadata.yml` to actually run.

`Manifest.validate()` passes (nodeid existence + sort order). `./format.sh` is clean: mypy on 528 files, ruff, yamlfmt, yamllint, parser checks.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) — **N/A: only `tests/` and `manifests/` are touched**
* [ ] A docker base image is modified? — **No**
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed? — **No**
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

---

Test logic is modified, so this needs an RFC-owner review. The `manifests/c.yml` commit also touches territory regenerated by the easy-win auto-activation script — worth a heads-up in #apm-shared-testing, though there's no urgency since that test never runs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
