### PR TITLE
fix(java): declare FFE capability from 1.65

### DIFF
--- a/tests/parametric/capabilities.yml
+++ b/tests/parametric/capabilities.yml
@@ -61,6 +61,9 @@ capabilities:
     '>=1.54.0':
       - APM_TRACING_MULTICONFIG
 
+    '>=1.65.0':
+      - FFE_FLAG_CONFIGURATION_RULES
+
   nodejs:
     base:
       - APM_TRACING_CUSTOM_TAGS


### PR DESCRIPTION
## Motivation

`dd-trace-java` 1.65.0 recognizes `DD_FEATURE_FLAGS_CONFIGURATION_SOURCE=remote_config` and reports `FFE_FLAG_CONFIGURATION_RULES` during the Remote Config capability completeness test. The system-tests capability registry does not currently declare that Java capability, so released-version validation rejects the correctly reported bit as unexpected and fails the Java nightly parametric job. This makes a valid tracer release appear regressed and leaves the nightly pipeline red.

## Changes

This updates the version-aware Java capability registry so `FFE_FLAG_CONFIGURATION_RULES` is expected starting with Java 1.65.0. Earlier Java versions keep their existing expected capability set.

## Decisions

The capability is declared at `>=1.65.0` instead of in the Java base set. Java 1.64.2 contained the registration code, but its feature-flagging subsystem remained disabled under this test configuration because it did not recognize the stable configuration-source setting. Java 1.65.0 recognizes the setting and activates the Remote Config service, which makes the capability observable. This PR stays focused on correcting the released-version contract; it does not change the separate prerelease capability policy.

## Verification

- `./format.sh`
- `./run.sh TEST_THE_TEST tests/test_the_test/test_capabilities.py` — 4 passed
- Verified the resolver excludes the capability for Java 1.64.2 and includes it for Java 1.65.0