### PR TITLE
fix(parametric): use harness agent port in telemetry tests

### DIFF
--- a/tests/parametric/test_telemetry.py
+++ b/tests/parametric/test_telemetry.py
@@ -487,7 +487,6 @@ class Test_Environment:
         "library_env",
         [
             {
-                "DD_TRACE_AGENT_PORT": "agent.port",
                 "DD_TRACE_OTEL_ENABLED": 1,
                 "DD_TELEMETRY_HEARTBEAT_INTERVAL": 1,
                 "TIMEOUT": 1500,
@@ -572,7 +571,6 @@ class Test_Environment:
         "library_env",
         [
             {
-                "DD_TRACE_AGENT_PORT": "agent.port",
                 "DD_TELEMETRY_HEARTBEAT_INTERVAL": 1,
                 "TIMEOUT": 1500,
                 "OTEL_SERVICE_NAME": "otel_service",


### PR DESCRIPTION
## Motivation

Two parametric telemetry tests overwrite the numeric agent port supplied by the harness with the literal value `agent.port`. Python ddtrace 3.3.0rc1 and later parse `DD_TRACE_AGENT_PORT` as an optional integer during startup, so both test servers exit before the tests run.

This failure is deterministic for affected Python versions. It looked intermittent because the Python manifest marks the assertions in these tests as missing features, which normally turns the cases into expected failures and hides the setup crash.

[Root-cause report with before/after results](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/c08a909f-a2b7-4187-b319-6ff077505047) (AppGate required)

## Changes

Remove the two invalid `DD_TRACE_AGENT_PORT` overrides so both tests keep the numeric port supplied by the parametric harness.

Scope: one test file, two deleted lines. No harness, tracer, or manifest changes.

### Verification

* Before the change, a forced focused run ended with 2 setup errors from the `agent.port` integer cast.
* After the change, the same forced run started both servers and reached the known missing-feature assertions.
* The manifest-aware focused run completed with 2 expected xfails and exit code 0.
* The repository formatting and static-check suite passed.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
