### PR TITLE
feat(otel): enable Ruby OTLP trace export tests

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2161,7 +2161,7 @@ manifest:
         "*": incomplete_test_app (endpoint not implemented)
         rails72: v2.0.0
   tests/otel/test_context_propagation.py::Test_Otel_Context_Propagation_Default_Propagator_Api::test_propagation_extract: incomplete_test_app (Ruby extract seems to fail even though it should be supported)
-  tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP: missing_feature
+  tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP: v2.41.0-dev
   tests/otel/test_tracing_otlp.py::Test_Otlp_Carries_Ot: missing_feature (APMAPI-2172)
   tests/otel/test_tracing_otlp.py::Test_Otlp_Forwards_Inherited_Ot: missing_feature (APMAPI-2172)
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant


### PR DESCRIPTION
## Motivation

[Concise implementation report](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/7bd01f1e-e3e2-46b1-9212-977775ca1cfd)

AI was used to help implement and review this change. I read and verified the resulting change.

dd-trace-rb 2.41 adds native OTLP trace export through libdatadog. The shared OTLP trace suite should run for Ruby once that development version is under test.

## Changes

Activates `Test_Otel_Tracing_OTLP` for Ruby from `v2.41.0-dev`. The suite covers routing, sampling behavior, trace identity, and HTTP/protobuf payloads.

Companion changes: [dd-trace-rb #6152](https://github.com/DataDog/dd-trace-rb/pull/6152) and [libdatadog #2317](https://github.com/DataDog/libdatadog/pull/2317).

Validation: `./format.sh --check` passes, including manifest parsing and YAML checks.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
