### PR TITLE
fix(ffe): make exposure event test deterministic

### DIFF
--- a/tests/ffe/test_exposures.py
+++ b/tests/ffe/test_exposures.py
@@ -133,15 +133,13 @@ class Test_FFE_Exposure_Events:
             },
         )
 
+    def test_ffe_exposure_event_generation(self) -> None:
+        """Test that FFE generates exposure events when flags are evaluated via weblog."""
         assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"
         result = json.loads(self.r.text)
         assert result["value"] == "on", f"Expected 'on', got {result['value']!r}"
-
-        # Exposure delivery is asynchronous; wait before the next setup replaces Remote Config.
         wait_for_exposure_event({self.flag}, self.targeting_key)
 
-    def test_ffe_exposure_event_generation(self) -> None:
-        """Test that FFE generates exposure events when flags are evaluated via weblog."""
         # Search for our specific flag in all exposure events
         matching_event = None
         context_validated = False

--- a/tests/ffe/test_exposures.py
+++ b/tests/ffe/test_exposures.py
@@ -87,8 +87,8 @@ UFC_FIXTURE_DATA = {
     "format": "SERVER",
     "environment": {"name": "Test"},
     "flags": {
-        "test-flag": {
-            "key": "test-flag",
+        "exposure-generation-test-flag": {
+            "key": "exposure-generation-test-flag",
             "enabled": True,
             "variationType": "STRING",
             "variations": {"on": {"key": "on", "value": "on"}, "off": {"key": "off", "value": "off"}},
@@ -108,7 +108,7 @@ UFC_FIXTURE_DATA = {
 @scenarios.feature_flagging_and_experimentation
 @features.feature_flags_exposures
 class Test_FFE_Exposure_Events:
-    def setup_ffe_exposure_event_generation(self):
+    def setup_ffe_exposure_event_generation(self) -> None:
         """Set up FFE exposure event generation."""
         # Set up Remote Config
         config_id = "ffe-test-config"
@@ -116,7 +116,7 @@ class Test_FFE_Exposure_Events:
         rc.tracer_rc_state.reset().set_config(f"{RC_PATH}/{config_id}/config", rc_config).apply()
 
         # Evaluate a feature flag
-        self.flag = "test-flag"
+        self.flag = "exposure-generation-test-flag"
         variation_type = "STRING"
         default_value = "default"
         self.targeting_key = "test-user"
@@ -133,11 +133,15 @@ class Test_FFE_Exposure_Events:
             },
         )
 
-    def test_ffe_exposure_event_generation(self):
-        """Test that FFE generates exposure events when flags are evaluated via weblog."""
         assert self.r.status_code == 200, f"Flag evaluation failed: {self.r.text}"
+        result = json.loads(self.r.text)
+        assert result["value"] == "on", f"Expected 'on', got {result['value']!r}"
+
+        # Exposure delivery is asynchronous; wait before the next setup replaces Remote Config.
         wait_for_exposure_event({self.flag}, self.targeting_key)
 
+    def test_ffe_exposure_event_generation(self) -> None:
+        """Test that FFE generates exposure events when flags are evaluated via weblog."""
         # Search for our specific flag in all exposure events
         matching_event = None
         context_validated = False


### PR DESCRIPTION
## Motivation

The FFE exposure-generation test intermittently timed out while waiting for an exposure. It used the generic `test-flag` key shared with other FFE coverage and did not confirm that the evaluation returned the configured variation. Although the original timeout was not conclusively traced to a flag-key collision, isolating the fixture removes that possible source of cross-test interference and makes evaluation failures distinguishable from exposure-delivery failures.

## Changes

- Give this test a dedicated flag key to avoid collisions with other FFE tests.
- Verify the feature flag evaluated to the configured `on` variation before checking its exposure.
- Keep all failure-producing assertions and waits in the test body so manifest xfails remain effective.
- Add return type annotations to the modified setup and test methods.

## Validation

- The focused exposure-generation test passed locally on the final commit with the configured weblog.
- The same test passed in the latest Python dev `django-py3.13` CI job; that job failed on an unrelated FFE evaluation-metric test.
- Mypy passed (529 source files).
- Ruff format and lint passed.
- `git diff --check` passed.

`./format.sh` proceeded through the Python, YAML, and parser checks, then encountered an unrelated macOS Bash 3 `set -u` failure in `utils/scripts/shellcheck.sh` when expanding an empty `$@`.