### PR TITLE
Removing auto request for change on easy win PRs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -272,20 +272,19 @@ jobs:
                 --title "Auto-activate ${{ matrix.library }} easy wins for $OWNER" \
                 --body "Automated activation of easy-win tests for \`${{ matrix.library }}\` owned by \`$OWNER\`
           [View nightly workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - This PR starts with an automated request-for-changes review to block automatic merge.
-          - If you approve this PR, please merge it manually or dismiss that review according to repository rules.
+          - This PR is created ready for review and can be merged according to repository rules.
           - If the tests are failing it might be due to a change made since the last nightly system-tests run. You can close the PR, an updated one will be available tomorrow.
           - If you close the PR please also delete the branch" \
                 --head "$BRANCH_NAME" \
-                --base main \
-                --draft
+                --base main
               PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
 
-              echo "Requesting changes on newly created PR #$PR_NUMBER to block automatic merge..."
-              GH_TOKEN="$PR_REVIEW_TOKEN" gh pr review "$PR_NUMBER" --request-changes --body "$REVIEW_BODY"
-
-              echo "Marking PR #$PR_NUMBER as ready for review..."
-              gh pr ready "$PR_NUMBER"
+              # This block can be activated to add a change request on new PRs to block auto merge (you also need to add --draft to gh pr create)
+              # echo "Requesting changes on newly created PR #$PR_NUMBER to block automatic merge..."
+              # GH_TOKEN="$PR_REVIEW_TOKEN" gh pr review "$PR_NUMBER" --request-changes --body "$REVIEW_BODY"
+              #
+              # echo "Marking PR #$PR_NUMBER as ready for review..."
+              # gh pr ready "$PR_NUMBER"
             fi
 
             # # Enable auto-merge on the PR


### PR DESCRIPTION
This is not necessary anymore now that the auto approver policy has been updated to not auto merge

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
