### PR TITLE
[debugger] Test PII redaction in log probe messages

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -695,6 +695,13 @@ manifest:
     - declaration: missing_feature (keywords are not fully redacted)
       component_version: <2.51
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers: v2.50.0
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_computed_key: bug (DEBUG-5960)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_identifiers: bug (DEBUG-5962)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_key: bug (DEBUG-5962)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_rendering
+  : bug (DEBUG-5963)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_sensitive_type
+  : bug (DEBUG-5961)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets: v2.53.0
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_budgets:  # Modified by easy win activation script
     - declaration: bug (DEBUG-4746)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3170,6 +3170,8 @@ manifest:
         spring-boot-undertow: v1.49.0
         spring-boot-wildfly: v1.49.0
         uds-spring-boot: v1.49.0
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_rendering
+  : bug (DEBUG-5958)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1710,6 +1710,13 @@ manifest:
     - weblog_declaration:
         "*": *ref_5_39_0
         nextjs: irrelevant
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_computed_key: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_identifiers: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_key: missing_feature (Not yet implemented)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_rendering
+  : missing_feature (Not yet implemented)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_sensitive_type
+  : missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets: missing_feature
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_budgets: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1339,6 +1339,8 @@ manifest:
     - declaration: bug (DEBUG-3746)
       component_version: <4.3.1
       weblog: [uds-flask, uwsgi-poc, flask-poc]
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_sensitive_type
+  : bug (DEBUG-5959)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1879,6 +1879,13 @@ manifest:
     - declaration: bug (DEBUG-3747)
       component_version: <2.28.0
       weblog: [rails72, uds-rails, rails80]
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_computed_key: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_identifiers: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_key: missing_feature (Not yet implemented)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_rendering
+  : missing_feature (Not yet implemented)
+  ? tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_sensitive_type
+  : missing_feature (Not yet implemented)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -125,8 +125,11 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
         if not lines:
             # Placeholder for manifest-disabled languages without a PII line-probe workload.
             return "0"
-        assert len(lines) == 1, f"Expected one PII probe line, got {lines!r}"
         return str(lines[0])
+
+    def _assert_pii_line_mapping(self) -> None:
+        lines = self.method_and_language_to_line_number("Pii", self.get_tracer()["language"])
+        assert len(lines) == 1, f"Expected one PII probe line, got {lines!r}"
 
     def _setup(self, *, line_probe: bool = False):
         self.initialize_weblog_remote_config()
@@ -162,6 +165,8 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
 
     ############ assert ############
     def _assert(self, excluded_identifiers: list[str] | None = None, *, line_probe: bool = False):
+        if line_probe:
+            self._assert_pii_line_mapping()
         self.collect()
         self.assert_setup_ok()
         self.assert_rc_state_not_error()
@@ -276,18 +281,27 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
         self,
         redacted_expressions: dict[str, dict[str, Any]],
         visible_expressions: dict[str, tuple[dict[str, Any], str]] | None = None,
+        *,
+        require_exact_redaction: bool = True,
+        required_redacted_message_values: tuple[str, ...] = (),
     ) -> None:
         self.initialize_weblog_remote_config()
         visible_expressions = visible_expressions or {}
 
         probes: list[dict[str, Any]] = []
         self.redacted_log_message_probe_ids: set[str] = set()
+        self.exact_redacted_log_message_values: dict[str, str] = {}
+        self.redacted_log_message_required_values: dict[str, tuple[str, ...]] = {}
         self.visible_log_message_values: dict[str, str] = {}
 
         for label, expression in redacted_expressions.items():
             probe = self._create_log_message_probe(label, expression)
             probes.append(probe)
             self.redacted_log_message_probe_ids.add(probe["id"])
+            if require_exact_redaction:
+                self.exact_redacted_log_message_values[probe["id"]] = f"{label}={REDACTED_MESSAGE_PLACEHOLDER}"
+            if required_redacted_message_values:
+                self.redacted_log_message_required_values[probe["id"]] = required_redacted_message_values
 
         for label, (expression, expected_value) in visible_expressions.items():
             probe = self._create_log_message_probe(label, expression)
@@ -328,10 +342,21 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
 
         for probe_id in self.redacted_log_message_probe_ids:
             for message in messages[probe_id]:
-                assert REDACTED_MESSAGE_PLACEHOLDER in message, (
-                    f"Expected {REDACTED_MESSAGE_PLACEHOLDER!r} in rendered message for probe {probe_id}, "
-                    f"got {message!r}"
-                )
+                expected_message = self.exact_redacted_log_message_values.get(probe_id)
+                if expected_message is not None:
+                    assert message == expected_message, (
+                        f"Expected rendered message {expected_message!r} for probe {probe_id}, got {message!r}"
+                    )
+                else:
+                    assert REDACTED_MESSAGE_PLACEHOLDER in message, (
+                        f"Expected {REDACTED_MESSAGE_PLACEHOLDER!r} in rendered message for probe {probe_id}, "
+                        f"got {message!r}"
+                    )
+                for required_value in self.redacted_log_message_required_values.get(probe_id, ()):
+                    assert required_value in message, (
+                        f"Expected visible value {required_value!r} in rendered message for probe {probe_id}, "
+                        f"got {message!r}"
+                    )
 
         for probe_id, expected_value in self.visible_log_message_values.items():
             for message in messages[probe_id]:
@@ -345,6 +370,7 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
             assert secret not in rendered_messages, f"Raw secret {secret!r} leaked in rendered log-probe messages"
 
     def _assert_log_probe_messages(self) -> None:
+        self._assert_pii_line_mapping()
         self.collect()
         self.assert_setup_ok()
         self.assert_rc_state_not_error()
@@ -405,7 +431,11 @@ class Test_Debugger_PII_Redaction_Excluded_Identifiers(BaseDebuggerPIIRedactionT
         self._assert_log_probe_messages()
 
     def setup_pii_redaction_log_probe_map_rendering(self) -> None:
-        self._setup_log_probe_messages(redacted_expressions={"map": {"ref": "user"}})
+        self._setup_log_probe_messages(
+            redacted_expressions={"map": {"ref": "user"}},
+            require_exact_redaction=False,
+            required_redacted_message_values=(EXCLUDED_IDENTIFIER_VALUE, NON_SENSITIVE_VALUE),
+        )
 
     @slow
     def test_pii_redaction_log_probe_map_rendering(self) -> None:

--- a/tests/debugger/test_debugger_pii.py
+++ b/tests/debugger/test_debugger_pii.py
@@ -2,6 +2,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2021 Datadog, Inc.
 
+from typing import Any
+
 import tests.debugger.utils as debugger
 
 from utils import context, features, scenarios, slow
@@ -103,6 +105,13 @@ REDACTED_KEYS = [
 
 REDACTED_TYPES = ["customPii"]
 
+DIRECT_SECRET = "DIRECT_SECRET_VALUE"
+MAP_SECRET = "MAP_SECRET_VALUE"
+EXCLUDED_IDENTIFIER_VALUE = "EXCLUDED_IDENTIFIER_VALUE"
+NON_SENSITIVE_VALUE = "NON_SENSITIVE_VALUE"
+REDACTED_MESSAGE_PLACEHOLDER = "{redacted}"
+RAW_SECRETS = (DIRECT_SECRET, MAP_SECRET, "SHOULD_BE_REDACTED")
+
 
 @features.debugger_pii_redaction
 class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
@@ -111,11 +120,21 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
     _timeout_first = 5
     _timeout_next = 60
 
+    def _pii_line(self) -> str:
+        lines = self.method_and_language_to_line_number("Pii", self.get_tracer()["language"])
+        if not lines:
+            # Placeholder for manifest-disabled languages without a PII line-probe workload.
+            return "0"
+        assert len(lines) == 1, f"Expected one PII probe line, got {lines!r}"
+        return str(lines[0])
+
     def _setup(self, *, line_probe: bool = False):
         self.initialize_weblog_remote_config()
 
         if line_probe:
             probes = debugger.read_probes("pii_line")
+            for probe in probes:
+                probe["where"]["lines"] = [self._pii_line()]
         else:
             probes = debugger.read_probes("pii")
 
@@ -170,7 +189,7 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
             snapshot = base.get("debugger", {}).get("snapshot") or base["debugger.snapshot"]
 
             if line_probe:
-                fields = snapshot["captures"]["lines"]["64"]["locals"]["pii"]["fields"]
+                fields = snapshot["captures"]["lines"][self._pii_line()]["locals"]["pii"]["fields"]
             else:
                 fields = snapshot["captures"]["return"]["locals"]["pii"]["fields"]
 
@@ -224,7 +243,7 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
 
             for type_name in REDACTED_TYPES:
                 if line_probe:
-                    type_info = snapshot["captures"]["lines"]["64"]["locals"][type_name]
+                    type_info = snapshot["captures"]["lines"][self._pii_line()]["locals"][type_name]
                 else:
                     type_info = snapshot["captures"]["return"]["locals"][type_name]
 
@@ -238,6 +257,100 @@ class BaseDebuggerPIIRedactionTest(debugger.BaseDebuggerTest):
 
         if error_message != "":
             raise ValueError(error_message)
+
+    def _create_log_message_probe(self, label: str, expression: dict[str, Any]) -> dict[str, Any]:
+        probe: dict[str, Any] = debugger.read_probes("expression_probe_base")[0]
+        probe["id"] = debugger.generate_probe_id("log")
+        probe["where"] = {
+            "typeName": None,
+            "sourceFile": "ACTUAL_SOURCE_FILE",
+            "lines": [self._pii_line()],
+        }
+        probe["segments"] = [
+            {"str": f"{label}="},
+            {"dsl": "", "json": expression},
+        ]
+        return probe
+
+    def _setup_log_probe_messages(
+        self,
+        redacted_expressions: dict[str, dict[str, Any]],
+        visible_expressions: dict[str, tuple[dict[str, Any], str]] | None = None,
+    ) -> None:
+        self.initialize_weblog_remote_config()
+        visible_expressions = visible_expressions or {}
+
+        probes: list[dict[str, Any]] = []
+        self.redacted_log_message_probe_ids: set[str] = set()
+        self.visible_log_message_values: dict[str, str] = {}
+
+        for label, expression in redacted_expressions.items():
+            probe = self._create_log_message_probe(label, expression)
+            probes.append(probe)
+            self.redacted_log_message_probe_ids.add(probe["id"])
+
+        for label, (expression, expected_value) in visible_expressions.items():
+            probe = self._create_log_message_probe(label, expression)
+            probes.append(probe)
+            self.visible_log_message_values[probe["id"]] = expected_value
+
+        self.set_probes(probes)
+        self.send_rc_probes()
+        if not self.wait_for_all_probes(statuses=["INSTALLED"]):
+            self.setup_failures.append("Log probes did not reach INSTALLED status")
+            return
+
+        retries = 0
+        timeout = self._timeout_first
+        snapshots_found = False
+        while not snapshots_found and retries < self._max_retries:
+            self.send_weblog_request("/debugger/pii", reset=(retries == 0))
+            snapshots_found = self.wait_for_all_snapshots(timeout=timeout)
+            timeout = self._timeout_next
+            retries += 1
+
+        if not snapshots_found:
+            self.setup_failures.append("Rendered log-probe messages were not received")
+        else:
+            self.wait_for_all_probes(statuses=["EMITTING"])
+
+    def _validate_log_probe_message_redaction(self) -> None:
+        messages: dict[str, list[str]] = {}
+        for probe_id in self.probe_ids:
+            snapshots = self.probe_snapshots.get(probe_id, [])
+            for snapshot in snapshots:
+                message = snapshot.get("message")
+                if isinstance(message, str):
+                    messages.setdefault(probe_id, []).append(message)
+
+        missing_probe_ids = set(self.probe_ids) - messages.keys()
+        assert not missing_probe_ids, f"Rendered messages were not received for probes: {sorted(missing_probe_ids)}"
+
+        for probe_id in self.redacted_log_message_probe_ids:
+            for message in messages[probe_id]:
+                assert REDACTED_MESSAGE_PLACEHOLDER in message, (
+                    f"Expected {REDACTED_MESSAGE_PLACEHOLDER!r} in rendered message for probe {probe_id}, "
+                    f"got {message!r}"
+                )
+
+        for probe_id, expected_value in self.visible_log_message_values.items():
+            for message in messages[probe_id]:
+                assert expected_value in message, (
+                    f"Expected visible value {expected_value!r} in rendered message for probe {probe_id}, "
+                    f"got {message!r}"
+                )
+
+        rendered_messages = "\n".join(message for probe_messages in messages.values() for message in probe_messages)
+        for secret in RAW_SECRETS:
+            assert secret not in rendered_messages, f"Raw secret {secret!r} leaked in rendered log-probe messages"
+
+    def _assert_log_probe_messages(self) -> None:
+        self.collect()
+        self.assert_setup_ok()
+        self.assert_rc_state_not_error()
+        self.assert_all_probes_are_emitting()
+        self.assert_all_weblog_responses_ok()
+        self._validate_log_probe_message_redaction()
 
 
 @scenarios.debugger_pii_redaction
@@ -268,3 +381,62 @@ class Test_Debugger_PII_Redaction_Excluded_Identifiers(BaseDebuggerPIIRedactionT
     def test_pii_redaction_excluded_identifiers(self):
         excluded_identifiers = ["_2fa", "cookie", "sessionid"]
         self._assert(excluded_identifiers, line_probe=True)
+
+    def setup_pii_redaction_log_probe_identifiers(self) -> None:
+        self._setup_log_probe_messages(
+            redacted_expressions={
+                "direct": {"ref": "password"},
+                "member": {"getmember": [{"ref": "pii"}, "password"]},
+            },
+            visible_expressions={
+                "excluded_identifier": (
+                    {"index": [{"ref": "user"}, "_2fa"]},
+                    EXCLUDED_IDENTIFIER_VALUE,
+                ),
+                "non_sensitive": (
+                    {"index": [{"ref": "user"}, "name"]},
+                    NON_SENSITIVE_VALUE,
+                ),
+            },
+        )
+
+    @slow
+    def test_pii_redaction_log_probe_identifiers(self) -> None:
+        self._assert_log_probe_messages()
+
+    def setup_pii_redaction_log_probe_map_rendering(self) -> None:
+        self._setup_log_probe_messages(redacted_expressions={"map": {"ref": "user"}})
+
+    @slow
+    def test_pii_redaction_log_probe_map_rendering(self) -> None:
+        self._assert_log_probe_messages()
+
+    def setup_pii_redaction_log_probe_map_key(self) -> None:
+        self._setup_log_probe_messages(redacted_expressions={"literal_key": {"index": [{"ref": "user"}, "password"]}})
+
+    @slow
+    def test_pii_redaction_log_probe_map_key(self) -> None:
+        self._assert_log_probe_messages()
+
+    def setup_pii_redaction_log_probe_computed_key(self) -> None:
+        self._setup_log_probe_messages(
+            redacted_expressions={
+                "computed_key": {
+                    "index": [
+                        {"ref": "user"},
+                        {"substring": ["xpasswordx", 1, 9]},
+                    ]
+                }
+            }
+        )
+
+    @slow
+    def test_pii_redaction_log_probe_computed_key(self) -> None:
+        self._assert_log_probe_messages()
+
+    def setup_pii_redaction_log_probe_sensitive_type(self) -> None:
+        self._setup_log_probe_messages(redacted_expressions={"sensitive_type": {"ref": "customPii"}})
+
+    @slow
+    def test_pii_redaction_log_probe_sensitive_type(self) -> None:
+        self._assert_log_probe_messages()

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -189,21 +189,22 @@ class BaseDebuggerTest:
     def method_and_language_to_line_number(self, method: str, language: str) -> list:
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         definitions: dict[str, dict[str, list[int]]] = {
-            "Budgets": {"java": [138], "dotnet": [136], "python": [142], "golang": [117]},
+            "Budgets": {"java": [140], "dotnet": [138], "python": [144], "golang": [117]},
             "LogProbe": {"nodejs": [20]},
-            "Expression": {"java": [71], "dotnet": [74], "python": [72], "ruby": [82], "nodejs": [82], "golang": [71]},
+            "Pii": {"java": [66], "dotnet": [66], "python": [66], "ruby": [66], "nodejs": [64]},
+            "Expression": {"java": [73], "dotnet": [76], "python": [74], "ruby": [82], "nodejs": [82], "golang": [71]},
             # In-scope line for the probe_capture_expressions_line line probe. Kept separate
             # from "Expression" because Node.js captures at a different line (71) than its
             # expression-language probe (82); Ruby's weblog layout puts the line at 82, not 71.
-            "CaptureExpressionsLine": {"java": [71], "nodejs": [71], "golang": [71], "ruby": [82]},
+            "CaptureExpressionsLine": {"java": [73], "nodejs": [71], "golang": [71], "ruby": [82]},
             # The `@exception` variable is not available in the context of line probes.
             "ExpressionException": {},
-            "ExpressionOperators": {"java": [82], "dotnet": [90], "python": [87], "ruby": [102], "nodejs": [90]},
-            "StringOperations": {"java": [87], "dotnet": [97], "python": [96], "ruby": [122], "nodejs": [96]},
-            "CollectionOperations": {"java": [114], "dotnet": [114], "python": [123], "ruby": [162], "nodejs": [120]},
-            "Nulls": {"java": [130], "dotnet": [127], "python": [136], "ruby": [192], "nodejs": [126]},
-            "SnapshotLimits": {"java": [153], "python": [172], "nodejs": [136], "ruby": [233], "dotnet": [150]},
-            "CaptureTimeout": {"java": [172], "nodejs": [155], "dotnet": [171]},
+            "ExpressionOperators": {"java": [84], "dotnet": [92], "python": [89], "ruby": [102], "nodejs": [90]},
+            "StringOperations": {"java": [89], "dotnet": [99], "python": [98], "ruby": [122], "nodejs": [96]},
+            "CollectionOperations": {"java": [116], "dotnet": [116], "python": [125], "ruby": [162], "nodejs": [120]},
+            "Nulls": {"java": [132], "dotnet": [129], "python": [138], "ruby": [192], "nodejs": [126]},
+            "SnapshotLimits": {"java": [155], "python": [174], "nodejs": [136], "ruby": [233], "dotnet": [152]},
+            "CaptureTimeout": {"java": [174], "nodejs": [155], "dotnet": [173]},
         }
 
         return definitions.get(method, {}).get(language, [])

--- a/tests/debugger/utils/probes/pii_line.json
+++ b/tests/debugger/utils/probes/pii_line.json
@@ -8,7 +8,7 @@
             "typeName": null,
             "sourceFile": "ACTUAL_SOURCE_FILE",
             "lines": [
-                "64"
+                "ACTUAL_LINE"
             ]
         },
         "captureSnapshot": true,

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -3267,6 +3267,21 @@
   "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_excluded_identifiers": [
     "TRACING_CONFIG_NONDEFAULT_4"
   ],
+  "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_computed_key": [
+    "TRACING_CONFIG_NONDEFAULT_4"
+  ],
+  "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_identifiers": [
+    "TRACING_CONFIG_NONDEFAULT_4"
+  ],
+  "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_key": [
+    "TRACING_CONFIG_NONDEFAULT_4"
+  ],
+  "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_map_rendering": [
+    "TRACING_CONFIG_NONDEFAULT_4"
+  ],
+  "tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_log_probe_sensitive_type": [
+    "TRACING_CONFIG_NONDEFAULT_4"
+  ],
   "tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_budgets": [
     "DEBUGGER_PROBES_SNAPSHOT"
   ],

--- a/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
+++ b/utils/build/docker/dotnet/weblog/Controllers/DebuggerController.cs
@@ -57,11 +57,13 @@ namespace weblog
         [Consumes("application/json", "application/xml")]
         public async Task<IActionResult> Pii()
         {
-            PiiBase? pii = await Task.FromResult<PiiBase>(new Pii());
-            PiiBase? customPii = await Task.FromResult<PiiBase>(new CustomPii());
+            Pii? pii = await Task.FromResult(new Pii());
+            CustomPii? customPii = await Task.FromResult(new CustomPii());
             var value = pii?.TestValue;
             var customValue = customPii?.TestValue;
-            return Content($"PII {value}. CustomPII {customValue}"); // must be line 64
+            var password = "DIRECT_SECRET_VALUE";
+            var user = CreatePiiUser();
+            return Content($"PII {value}. CustomPII {customValue}. Data size {password.Length + user.Count}"); // must be line 66
         }
 
         [HttpGet("expression")]
@@ -147,7 +149,7 @@ namespace weblog
             var manyFields = data["manyFields"];
             var largeCollection = data["largeCollection"];
             var longString = data["longString"];
-            return Content("Capture limits probe"); // must be line 150
+            return Content("Capture limits probe"); // must be line 152
         }
 
         [HttpGet("snapshot/capture-timeout")]
@@ -168,7 +170,17 @@ namespace weblog
                 }
                 largeCollection.Add(nested);
             }
-            return "Capture timeout probe"; // must be line 171
+            return "Capture timeout probe"; // must be line 173
+        }
+
+        private static Dictionary<string, string> CreatePiiUser()
+        {
+            return new Dictionary<string, string>
+            {
+                ["password"] = "MAP_SECRET_VALUE",
+                ["_2fa"] = "EXCLUDED_IDENTIFIER_VALUE",
+                ["name"] = "NON_SENSITIVE_VALUE",
+            };
         }
     }
 }

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
@@ -57,11 +57,13 @@ public class DebuggerController {
 // Dummy line
     @GetMapping("/pii")
     public String pii() {
-        PiiBase pii = new Pii();
-        PiiBase customPii = new CustomPii();
+        Pii pii = new Pii();
+        CustomPii customPii = new CustomPii();
         String value = pii.TestValue;
         String customValue = customPii.TestValue;
-        return "PII " + value + ". CustomPII" + customValue; // must be line 64
+        String password = "DIRECT_SECRET_VALUE";
+        java.util.Map<String, String> user = createPiiUser();
+        return "PII " + value + ". CustomPII" + customValue + ". Data size " + (password.length() + user.size()); // must be line 66
     }
 
     @GetMapping("/expression")
@@ -169,6 +171,14 @@ public class DebuggerController {
             }
             largeCollection.add(nested);
         }
-        return "Capture timeout probe"; // Line probe is instrumented here (line 172).
+        return "Capture timeout probe"; // Line probe is instrumented here (line 174).
+    }
+
+    private static Map<String, String> createPiiUser() {
+        Map<String, String> user = new HashMap<>();
+        user.put("password", "MAP_SECRET_VALUE");
+        user.put("_2fa", "EXCLUDED_IDENTIFIER_VALUE");
+        user.put("name", "NON_SENSITIVE_VALUE");
+        return user;
     }
 }

--- a/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
+++ b/utils/build/docker/java_otel/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/debugger/DebuggerController.java
@@ -57,11 +57,13 @@ public class DebuggerController {
 // Dummy line
     @GetMapping("/pii")
     public String pii() {
-        PiiBase pii = new Pii();
-        PiiBase customPii = new CustomPii();
+        Pii pii = new Pii();
+        CustomPii customPii = new CustomPii();
         String value = pii.TestValue;
         String customValue = customPii.TestValue;
-        return "PII " + value + ". CustomPII" + customValue; // must be line 64
+        String password = "DIRECT_SECRET_VALUE";
+        Map<String, String> user = createPiiUser();
+        return "PII " + value + ". CustomPII" + customValue + ". Data size " + (password.length() + user.size()); // must be line 66
     }
 
     @GetMapping("/expression")
@@ -154,5 +156,13 @@ public class DebuggerController {
         } catch (ResponseStatusException ex) {
             throw new ResponseStatusException(org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR, "Outer exception", ex);
         }
+    }
+
+    private static Map<String, String> createPiiUser() {
+        Map<String, String> user = new HashMap<>();
+        user.put("password", "MAP_SECRET_VALUE");
+        user.put("_2fa", "EXCLUDED_IDENTIFIER_VALUE");
+        user.put("name", "NON_SENSITIVE_VALUE");
+        return user;
     }
 }

--- a/utils/build/docker/nodejs/express/debugger/index.js
+++ b/utils/build/docker/nodejs/express/debugger/index.js
@@ -1,7 +1,7 @@
 'use strict'
 /* eslint-disable no-unused-vars, camelcase */
 
-const Pii = require('./pii')
+const { Pii, createPiiLocals } = require('./pii')
 const dataGenerator = require('./data_generator')
 
 module.exports = {
@@ -60,7 +60,7 @@ module.exports = {
     // Padding
 
     app.get('/debugger/pii', (req, res) => {
-      const pii = new Pii()
+      const { pii, password, user, customPii } = createPiiLocals()
       res.send('Hello World') // This needs to be line 64
     })
 

--- a/utils/build/docker/nodejs/express/debugger/pii.js
+++ b/utils/build/docker/nodejs/express/debugger/pii.js
@@ -105,4 +105,23 @@ class Pii {
   }
 }
 
-module.exports = Pii
+class CustomPii {
+  constructor () {
+    this.customkey = VALUE
+  }
+}
+
+function createPiiLocals () {
+  return {
+    pii: new Pii(),
+    customPii: new CustomPii(),
+    password: 'DIRECT_SECRET_VALUE',
+    user: {
+      password: 'MAP_SECRET_VALUE',
+      _2fa: 'EXCLUDED_IDENTIFIER_VALUE',
+      name: 'NON_SENSITIVE_VALUE'
+    }
+  }
+}
+
+module.exports = { Pii, createPiiLocals }

--- a/utils/build/docker/nodejs/express4-typescript/debugger/index.ts
+++ b/utils/build/docker/nodejs/express4-typescript/debugger/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars, camelcase */
 
 import type { Express, Request, Response } from 'express'
-import { Pii } from './pii'
+import { Pii, createPiiLocals } from './pii'
 import { dataGenerator } from './data_generator'
 
 export function initRoutes (app: Express) {
@@ -60,7 +60,7 @@ export function initRoutes (app: Express) {
   // Padding
 
   app.get('/debugger/pii', (req: Request, res: Response) => {
-    const pii = new Pii()
+    const { pii, password, user, customPii } = createPiiLocals()
     res.send('Hello World') // This needs to be line 64
   })
 

--- a/utils/build/docker/nodejs/express4-typescript/debugger/pii.ts
+++ b/utils/build/docker/nodejs/express4-typescript/debugger/pii.ts
@@ -104,3 +104,25 @@ export class Pii {
     })
   }
 }
+
+class CustomPii {
+  customkey = VALUE
+}
+
+export function createPiiLocals (): {
+  pii: Pii
+  customPii: CustomPii
+  password: string
+  user: Record<string, string>
+} {
+  return {
+    pii: new Pii(),
+    customPii: new CustomPii(),
+    password: 'DIRECT_SECRET_VALUE',
+    user: {
+      password: 'MAP_SECRET_VALUE',
+      _2fa: 'EXCLUDED_IDENTIFIER_VALUE',
+      name: 'NON_SENSITIVE_VALUE'
+    }
+  }
+}

--- a/utils/build/docker/nodejs/fastify/debugger/index.js
+++ b/utils/build/docker/nodejs/fastify/debugger/index.js
@@ -1,7 +1,7 @@
 'use strict'
 /* eslint-disable no-unused-vars, camelcase */
 
-const Pii = require('./pii')
+const { Pii, createPiiLocals } = require('./pii')
 const dataGenerator = require('./data_generator')
 
 module.exports = {
@@ -60,7 +60,7 @@ module.exports = {
     // Padding
 
     fastify.get('/debugger/pii', async (request, reply) => {
-      const pii = new Pii()
+      const { pii, password, user, customPii } = createPiiLocals()
       return 'Hello World' // This needs to be line 64
     })
 

--- a/utils/build/docker/nodejs/fastify/debugger/pii.js
+++ b/utils/build/docker/nodejs/fastify/debugger/pii.js
@@ -105,4 +105,23 @@ class Pii {
   }
 }
 
-module.exports = Pii
+class CustomPii {
+  constructor () {
+    this.customkey = VALUE
+  }
+}
+
+function createPiiLocals () {
+  return {
+    pii: new Pii(),
+    customPii: new CustomPii(),
+    password: 'DIRECT_SECRET_VALUE',
+    user: {
+      password: 'MAP_SECRET_VALUE',
+      _2fa: 'EXCLUDED_IDENTIFIER_VALUE',
+      name: 'NON_SENSITIVE_VALUE'
+    }
+  }
+}
+
+module.exports = { Pii, createPiiLocals }

--- a/utils/build/docker/python/flask/debugger/debugger_controller.py
+++ b/utils/build/docker/python/flask/debugger/debugger_controller.py
@@ -61,7 +61,9 @@ def pii():
     customPii = CustomPii()
     value = pii.test_value
     custom_value = customPii.test_value
-    return f"PII {value}. CustomPII {custom_value}"  # must be line 64
+    password = "DIRECT_SECRET_VALUE"
+    user = {"password": "MAP_SECRET_VALUE", "_2fa": "EXCLUDED_IDENTIFIER_VALUE", "name": "NON_SENSITIVE_VALUE"}
+    return f"PII {value}. CustomPII {custom_value}. Data size {len(password) + len(user)}"  # must be line 66
 
 
 @debugger_blueprint.route("/expression", methods=["GET"])

--- a/utils/build/docker/ruby/shared/rails/app/controllers/debugger_controller.rb
+++ b/utils/build/docker/ruby/shared/rails/app/controllers/debugger_controller.rb
@@ -61,7 +61,9 @@ class DebuggerController < ActionController::Base
     customPii = CustomPii.new
     value = pii.test_value
     custom_value = customPii.test_value
-    render inline: "PII #{value}. CustomPII #{custom_value}" # must be line 64
+    password = "DIRECT_SECRET_VALUE"
+    user = { "password" => "MAP_SECRET_VALUE", "_2fa" => "EXCLUDED_IDENTIFIER_VALUE", "name" => "NON_SENSITIVE_VALUE" }
+    render inline: "PII #{value}. CustomPII #{custom_value}. Data size #{password.length + user.length}" # must be line 66
   end
 
   # Padding
@@ -69,8 +71,6 @@ class DebuggerController < ActionController::Base
   def run_expression
     expression(params[:inputValue])
   end
-  # Padding
-  # Padding
   # Padding
 
   def expression(inputValue)


### PR DESCRIPTION
## Motivation

Dynamic Instrumentation / Live Debugger already redacts PII in snapshots, but rendered log-probe messages use separate evaluation and serialization paths that can expose secrets or emit non-canonical placeholders. We need end-to-end coverage that verifies every sensitive expression emits the exact lowercase `{redacted}` placeholder and never includes the raw value.

## Changes

* Add separate rendered-message tests for sensitive identifiers and object members, whole-map rendering, literal map keys, computed map keys, and configured sensitive types.
* Validate excluded identifiers and a non-sensitive control while checking every emitted message for raw-secret leakage.
* Preserve existing workload locals and add the required password, map, and `CustomPii` fixtures across Java, Java OTel, Python, .NET, and Node.js weblogs.
* Replace the shared hardcoded PII line number with language-specific mappings while preserving all existing downstream line-probe locations.
* Record confirmed implementation bugs in [DEBUG-5958](https://datadoghq.atlassian.net/browse/DEBUG-5958), [DEBUG-5959](https://datadoghq.atlassian.net/browse/DEBUG-5959), [DEBUG-5960](https://datadoghq.atlassian.net/browse/DEBUG-5960), [DEBUG-5961](https://datadoghq.atlassian.net/browse/DEBUG-5961), [DEBUG-5962](https://datadoghq.atlassian.net/browse/DEBUG-5962), and [DEBUG-5963](https://datadoghq.atlassian.net/browse/DEBUG-5963).
* Keep currently unimplemented Node.js and Ruby capabilities independently gated so they can be activated incrementally.

## Validation

* `./format.sh`
* Java: PII class, full expression-language class, and representative budget/snapshot line probes.
* Python: PII class, full expression-language class, and representative budget/snapshot line probes.
* .NET: PII class, full expression-language class, and representative budget/snapshot line probes.
* Node.js and Ruby: existing excluded-identifiers coverage passes, with unsupported new capabilities skipped by manifests.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

[DEBUG-5958]: https://datadoghq.atlassian.net/browse/DEBUG-5958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ