### PR TITLE
fix(sampling): fix otel sampling comment

### DIFF
--- a/tests/test_otel_tracestate_sampling.py
+++ b/tests/test_otel_tracestate_sampling.py
@@ -19,7 +19,9 @@ from utils.docker_fixtures.spec.tracecontext import Tracestate, get_tracestate
 # DD's sampling decision is h = (trace_id_low64 * 1111111111111111111) mod 2**64, keep if h <= rate * (2**64 - 1)
 # (dd-trace-go/ddtrace/tracer/sampler.go:114-122). The OTel-compatible pair is:
 #   rv = (~h & (2**64 - 1)) >> 8      (56-bit, 14 hex digits) -- depends only on trace_id, not on rate
-#   th = int((1 - rate) * (2**56))   (56-bit, trailing zero nibbles trimmed when formatted) -- depends only on rate
+#   th = round((1 - rate) * (2**56)) (56-bit, trailing zero nibbles trimmed when formatted) -- depends only on rate
+#   These fixtures use the maximum available 14 hexadecimal digits of precision, rather than the 4 digits
+#   recommended by the OTel specification: https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/
 #
 # Trace IDs are the ones already used (and verified) in tests/fixtures/sampling_rates.csv, crossed with
 # 5 rates. Expected values below were computed with the formula above and cross-checked: at rate 0.5 they


### PR DESCRIPTION
## Motivation

Previous comment was mentionning the use of `int()` instead of `round()` for computing the threshold in OTel consistent sampling tests.
Added a ref to the otel spec on tracestate probability sampling.

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
