### PR TITLE
Rename gitlab e2e trigger jobs to `system_tests_e2e_run_pipeline_*`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,11 @@ jobs:
         polling-interval-seconds: '60'
         max-retries: '120'
         # Ignore gitlab jobs that are not K8S_LIB* (K8s lib injection),
-        # system_tests_run_pipeline_[0-2], *DOC (docker ssi), or *DO5A
+        # system_tests_e2e_run_pipeline_[0-2], *DOC (docker ssi), or *DO5A
         # (docker ssi crashtracking).
-        # https://regex101.com/r/Bo5Kpn/1
         # Also ignore the job that waits for the tests to succeed before adding
         # to the merge queue.
 
         ignored-name-patterns: |
-          dd-gitlab/(?!(?:K8S_LIB|system_tests_run_pipeline_[0-2]$)).*$(?<!DOC)(?<!DO5A)
+          dd-gitlab/(?!(?:K8S_LIB|system_tests_e2e_run_pipeline_[0-2]$)).*$(?<!DOC)(?<!DO5A)
           devflow/merge

--- a/tests/test_the_test/test_native_c_ci.py
+++ b/tests/test_the_test/test_native_c_ci.py
@@ -28,7 +28,7 @@ class Test_NativeCGitLabCI:
         patterns = ignored_patterns.splitlines()
 
         for index in range(3):
-            check_name = f"dd-gitlab/system_tests_run_pipeline_{index}"
+            check_name = f"dd-gitlab/system_tests_e2e_run_pipeline_{index}"
             assert not any(re.search(pattern, check_name) for pattern in patterns)
 
         assert any(re.search(pattern, "dd-gitlab/unrelated-job") for pattern in patterns)

--- a/utils/ci/gitlab/main.yml
+++ b/utils/ci/gitlab/main.yml
@@ -170,7 +170,7 @@ system_tests_build_pipeline:
     LIBRARIES: $LIBRARIES
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
 
-system_tests_run_pipeline_0:
+system_tests_e2e_run_pipeline_0:
   extends: .run_test_pipeline_base
   trigger:
     include:
@@ -178,7 +178,7 @@ system_tests_run_pipeline_0:
         job: system_tests_build_pipeline
     strategy: depend
 
-system_tests_run_pipeline_1:
+system_tests_e2e_run_pipeline_1:
   extends: .run_test_pipeline_base
   rules:
     - if: $SYSTEM_TESTS_SPLIT_PIPELINE != "true"
@@ -191,7 +191,7 @@ system_tests_run_pipeline_1:
         job: system_tests_build_pipeline
     strategy: depend
 
-system_tests_run_pipeline_2:
+system_tests_e2e_run_pipeline_2:
   extends: .run_test_pipeline_base
   rules:
     - if: $SYSTEM_TESTS_SPLIT_PIPELINE != "true"


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
