### PR TITLE
Use a dedicated scenario file for agentless end-to-end

### DIFF
--- a/tests/test_the_test/test_compute_libraries_and_scenarios.py
+++ b/tests/test_the_test/test_compute_libraries_and_scenarios.py
@@ -515,8 +515,20 @@ class Test_ComputeLibrariesAndScenarios:
             default_libs_with_dev,
             3600,
             "false",
-            "DEFAULT,FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS",
+            "DEFAULT",
             "end_to_end",
+        )
+
+    def test_end_to_end_agentless_scenario_framework_file(self):
+        inputs = build_inputs(modified_files=["utils/_context/_scenarios/agentless_endtoend.py"])
+        assert_github_processor(
+            inputs,
+            default_libs_with_prod,
+            default_libs_with_dev,
+            3600,
+            "false",
+            "DEFAULT",
+            "agentless",
         )
 
     def test_json_modification(self):

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -7,6 +7,7 @@ import requests
 import pytest
 
 from utils import scenarios
+from utils._context._scenarios import agentless_endtoend as agentless_endtoend_scenarios
 from utils._context._scenarios import endtoend as endtoend_scenarios
 from utils.docker_fixtures._core import HOST_GATEWAY_EXTRA_HOSTS, extra_hosts_for_environment
 from utils.mocked_backend.ffe import (
@@ -16,7 +17,7 @@ from utils.mocked_backend.ffe import (
     MockFFEAgentlessBackendServer,
     UFC_RESPONSE_TYPE,
 )
-from utils._context._scenarios.endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
 
 
 @scenarios.test_the_test
@@ -135,7 +136,7 @@ def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     def create_backend() -> MagicMock:
         return backend
 
-    monkeypatch.setattr(endtoend_scenarios, "MockFFEAgentlessBackendServer", create_backend)
+    monkeypatch.setattr(agentless_endtoend_scenarios, "MockFFEAgentlessBackendServer", create_backend)
 
     with pytest.raises(RuntimeError, match="reset failed"):
         scenario.configure(MagicMock(spec=pytest.Config))

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -7,10 +7,10 @@ from utils.tools import update_environ_with_local_env
 from .aws_lambda import LambdaScenario
 from .core import Scenario, scenario_groups
 from .default import DefaultScenario
+from .agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
 from .endtoend import (
     DockerScenario,
     DdTraceEndToEndScenario,
-    FeatureFlaggingAgentlessEndToEndScenario,
     GraphQlEndToEndScenario,
 )
 from .integrations import (

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -18,7 +18,6 @@ from .endtoend import DdTraceEndToEndScenario
 class AgentlessEndToEndScenario(DdTraceEndToEndScenario):
     """End-to-end scenario without a Datadog Agent, using agentless delivery mechanisms."""
 
-    _default_scenario_groups: tuple[ScenarioGroup, ...] = ()
     _mock_backend_status_filename = "mock_agentless_backend_status.json"
 
     _mock_backend: MockFFEAgentlessBackendServer | None = None
@@ -30,14 +29,14 @@ class AgentlessEndToEndScenario(DdTraceEndToEndScenario):
         *,
         doc: str,
         weblog_env: dict[str, str | None] | None = None,
-        scenario_groups: list[ScenarioGroup] | None = None,
+        scenario_groups: tuple[ScenarioGroup, ...] = (),
     ) -> None:
         super().__init__(
             name,
             doc=doc,
             include_agent=False,
             library_interface_timeout=0,
-            scenario_groups=scenario_groups,
+            scenario_groups=[*scenario_groups, all_scenario_groups.agentless],
             use_proxy_for_agent=False,
             use_proxy_for_weblog=False,
             weblog_env=weblog_env,
@@ -128,6 +127,6 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         super().__init__(
             name,
             doc=doc,
-            scenario_groups=[all_scenario_groups.ffe],
+            scenario_groups=(all_scenario_groups.ffe,),
             weblog_env=environment,
         )

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -1,0 +1,133 @@
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from utils.docker_fixtures._core import extra_hosts_for_environment
+from utils.mocked_backend.ffe import (
+    EXPECTED_API_KEY,
+    MockFFEAgentlessBackendServer,
+    MockFFEAgentlessBackendStatus,
+)
+
+from .core import ScenarioGroup, scenario_groups as all_scenario_groups
+from .endtoend import DdTraceEndToEndScenario
+
+
+class AgentlessEndToEndScenario(DdTraceEndToEndScenario):
+    """End-to-end scenario without a Datadog Agent, using agentless delivery mechanisms."""
+
+    _default_scenario_groups: tuple[ScenarioGroup, ...] = ()
+    _mock_backend_status_filename = "mock_agentless_backend_status.json"
+
+    _mock_backend: MockFFEAgentlessBackendServer | None = None
+    _last_mock_backend_status: MockFFEAgentlessBackendStatus | None = None
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        doc: str,
+        weblog_env: dict[str, str | None] | None = None,
+        scenario_groups: list[ScenarioGroup] | None = None,
+    ) -> None:
+        super().__init__(
+            name,
+            doc=doc,
+            include_agent=False,
+            library_interface_timeout=0,
+            scenario_groups=scenario_groups,
+            use_proxy_for_agent=False,
+            use_proxy_for_weblog=False,
+            weblog_env=weblog_env,
+        )
+
+    def configure(self, config: pytest.Config) -> None:
+        try:
+            if self.replay:
+                self._load_mock_backend_status()
+            else:
+                self._last_mock_backend_status = None
+                self._start_mock_backend()
+
+            super().configure(config)
+        except BaseException:
+            self._stop_mock_backend(persist_status=False)
+            raise
+
+    def _start_mock_backend(self) -> None:
+        assert self._mock_backend is None, "mock FFE agentless backend is already running"
+
+        self._mock_backend = MockFFEAgentlessBackendServer()
+        self._mock_backend.reset()
+
+        environment = self.weblog_infra.library_container.environment
+        environment |= {
+            "DD_API_KEY": EXPECTED_API_KEY,
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL": self._mock_backend.library_config_url,
+        }
+        self.weblog_infra.library_container.extra_hosts = extra_hosts_for_environment(environment)
+
+    def mock_backend_status(self) -> MockFFEAgentlessBackendStatus | None:
+        if self._mock_backend is not None:
+            return self._mock_backend.status()
+        return self._last_mock_backend_status
+
+    @property
+    def _mock_backend_status_path(self) -> Path:
+        return Path(self.host_log_folder) / self._mock_backend_status_filename
+
+    def _load_mock_backend_status(self) -> None:
+        self._last_mock_backend_status = cast(
+            "MockFFEAgentlessBackendStatus",
+            json.loads(self._mock_backend_status_path.read_text(encoding="utf-8")),
+        )
+
+    def _stop_mock_backend(self, *, persist_status: bool = True) -> None:
+        backend = self._mock_backend
+        if backend is None:
+            return
+
+        self._mock_backend = None
+        try:
+            if persist_status:
+                self._last_mock_backend_status = backend.status()
+                self._mock_backend_status_path.parent.mkdir(parents=True, exist_ok=True)
+                self._mock_backend_status_path.write_text(
+                    json.dumps(self._last_mock_backend_status, indent=2) + "\n",
+                    encoding="utf-8",
+                )
+        finally:
+            backend.close()
+
+    def close_targets(self) -> None:
+        try:
+            super().close_targets()
+        finally:
+            self._stop_mock_backend()
+
+
+class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
+    """FFE end-to-end scenario with UFC available before the weblog starts."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        doc: str = "Validate default agentless UFC delivery and evaluation without a Datadog Agent.",
+        weblog_env: dict[str, str | None] | None = None,
+    ) -> None:
+        environment: dict[str, str | None] = {
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "0.2",
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": "2",
+            "DD_REMOTE_CONFIGURATION_ENABLED": "false",
+        }
+        environment.update(weblog_env or {})
+
+        super().__init__(
+            name,
+            doc=doc,
+            scenario_groups=[all_scenario_groups.ffe],
+            weblog_env=environment,
+        )

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -18,7 +18,7 @@ from .endtoend import DdTraceEndToEndScenario
 class AgentlessEndToEndScenario(DdTraceEndToEndScenario):
     """End-to-end scenario without a Datadog Agent, using agentless delivery mechanisms."""
 
-    _default_scenario_groups:tuple[ScenarioGroup,...] = ()  # exclude those scenario from tracer_release
+    _default_scenario_groups: tuple[ScenarioGroup, ...] = ()  # exclude those scenario from tracer_release
     _mock_backend_status_filename = "mock_agentless_backend_status.json"
 
     _mock_backend: MockFFEAgentlessBackendServer | None = None

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -119,7 +119,12 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         weblog_env: dict[str, str | None] | None = None,
     ) -> None:
         environment: dict[str, str | None] = {
-            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "0.2",
+            # Both variables are integer seconds across the SDKs: Java parses them with
+            # getInteger, and the shared configuration registry declares them "int" with an
+            # allowed pattern of [1-9]\d*. A fractional value only ever worked on Node, which
+            # has a single numeric type and does not enforce that pattern; it is a hard parse
+            # error in the strictly-typed libraries. 1s is the smallest legal interval.
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "1",
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": "2",
             "DD_REMOTE_CONFIGURATION_ENABLED": "false",
         }

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -18,6 +18,7 @@ from .endtoend import DdTraceEndToEndScenario
 class AgentlessEndToEndScenario(DdTraceEndToEndScenario):
     """End-to-end scenario without a Datadog Agent, using agentless delivery mechanisms."""
 
+    _default_scenario_groups:tuple[ScenarioGroup,...] = ()  # exclude those scenario from tracer_release
     _mock_backend_status_filename = "mock_agentless_backend_status.json"
 
     _mock_backend: MockFFEAgentlessBackendServer | None = None

--- a/utils/_context/_scenarios/core.py
+++ b/utils/_context/_scenarios/core.py
@@ -37,6 +37,7 @@ class _ScenarioGroups:
     2. select a set of scenario to execute in the official system-tests workflow
     """
 
+    agentless = ScenarioGroup()
     all = ScenarioGroup()
     ai_guard = ScenarioGroup()
     appsec = ScenarioGroup()

--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -1,7 +1,5 @@
-import json
 import os
-from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 import pytest
 
@@ -25,12 +23,6 @@ from utils._context.containers import (
     TestedContainer,
 )
 from utils._context.weblog_infrastructure import EndToEndWeblogInfra
-from utils.docker_fixtures._core import extra_hosts_for_environment
-from utils.mocked_backend.ffe import (
-    EXPECTED_API_KEY,
-    MockFFEAgentlessBackendServer,
-    MockFFEAgentlessBackendStatus,
-)
 from utils._context.constants import WeblogCategory
 from utils._logger import logger
 
@@ -612,105 +604,6 @@ class DdTraceEndToEndScenario(EndToEndScenario):
             weblog_env=weblog_env,
             weblog_volumes=weblog_volumes,
         )
-
-
-class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
-    """FFE end-to-end scenario with UFC available before the weblog starts."""
-
-    _default_scenario_groups: tuple[ScenarioGroup, ...] = ()
-    _mock_backend_status_filename = "mock_ffe_agentless_backend_status.json"
-
-    _mock_backend: MockFFEAgentlessBackendServer | None = None
-    _last_mock_backend_status: MockFFEAgentlessBackendStatus | None = None
-
-    def __init__(
-        self,
-        name: str,
-        *,
-        doc: str = "Validate default agentless UFC delivery and evaluation without a Datadog Agent.",
-        weblog_env: dict[str, str | None] | None = None,
-    ) -> None:
-        environment: dict[str, str | None] = {
-            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "0.2",
-            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": "2",
-            "DD_REMOTE_CONFIGURATION_ENABLED": "false",
-        }
-        environment.update(weblog_env or {})
-
-        super().__init__(
-            name,
-            doc=doc,
-            include_agent=False,
-            library_interface_timeout=0,
-            scenario_groups=[all_scenario_groups.ffe],
-            use_proxy_for_agent=False,
-            use_proxy_for_weblog=False,
-            weblog_env=environment,
-        )
-
-    def configure(self, config: pytest.Config) -> None:
-        try:
-            if self.replay:
-                self._load_mock_backend_status()
-            else:
-                self._last_mock_backend_status = None
-                self._start_mock_backend()
-
-            super().configure(config)
-        except BaseException:
-            self._stop_mock_backend(persist_status=False)
-            raise
-
-    def _start_mock_backend(self) -> None:
-        assert self._mock_backend is None, "mock FFE agentless backend is already running"
-
-        self._mock_backend = MockFFEAgentlessBackendServer()
-        self._mock_backend.reset()
-
-        environment = self.weblog_infra.library_container.environment
-        environment |= {
-            "DD_API_KEY": EXPECTED_API_KEY,
-            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL": self._mock_backend.library_config_url,
-        }
-        self.weblog_infra.library_container.extra_hosts = extra_hosts_for_environment(environment)
-
-    def mock_backend_status(self) -> MockFFEAgentlessBackendStatus | None:
-        if self._mock_backend is not None:
-            return self._mock_backend.status()
-        return self._last_mock_backend_status
-
-    @property
-    def _mock_backend_status_path(self) -> Path:
-        return Path(self.host_log_folder) / self._mock_backend_status_filename
-
-    def _load_mock_backend_status(self) -> None:
-        self._last_mock_backend_status = cast(
-            "MockFFEAgentlessBackendStatus",
-            json.loads(self._mock_backend_status_path.read_text(encoding="utf-8")),
-        )
-
-    def _stop_mock_backend(self, *, persist_status: bool = True) -> None:
-        backend = self._mock_backend
-        if backend is None:
-            return
-
-        self._mock_backend = None
-        try:
-            if persist_status:
-                self._last_mock_backend_status = backend.status()
-                self._mock_backend_status_path.parent.mkdir(parents=True, exist_ok=True)
-                self._mock_backend_status_path.write_text(
-                    json.dumps(self._last_mock_backend_status, indent=2) + "\n",
-                    encoding="utf-8",
-                )
-        finally:
-            backend.close()
-
-    def close_targets(self) -> None:
-        try:
-            super().close_targets()
-        finally:
-            self._stop_mock_backend()
 
 
 class GraphQlEndToEndScenario(EndToEndScenario):

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -222,9 +222,10 @@ patterns:
         scenario_groups: docker_fixtures
     utils/_context/_scenarios/appsec_rasp.py:
         scenario_groups: appsec_rasp_scenario
+    utils/_context/_scenarios/agentless_endtoend.py:
+        scenario_groups: agentless
     utils/_context/_scenarios/endtoend.py:
         scenario_groups: end_to_end
-        scenarios: FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS
     utils/_context/_scenarios/integration_frameworks.py:
         scenarios: INTEGRATION_FRAMEWORKS
     utils/_context/_scenarios/integrations.py:


### PR DESCRIPTION
## Motivation

We plan to have more scenario using agentless. 

## Changes

Create a dedicated file for agentless, and split FFE related stuff from the base AgentLessScenario class

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
