### PR TITLE
test(ffe): use an integer agentless poll interval in the e2e scenario

### DIFF
--- a/utils/_context/_scenarios/endtoend.py
+++ b/utils/_context/_scenarios/endtoend.py
@@ -631,7 +631,12 @@ class FeatureFlaggingAgentlessEndToEndScenario(DdTraceEndToEndScenario):
         weblog_env: dict[str, str | None] | None = None,
     ) -> None:
         environment: dict[str, str | None] = {
-            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "0.2",
+            # Both variables are integer seconds across the SDKs: Java parses them with
+            # getInteger, and the shared configuration registry declares them "int" with an
+            # allowed pattern of [1-9]\d*. A fractional value only ever worked on Node, which
+            # has a single numeric type and does not enforce that pattern; it is a hard parse
+            # error in the strictly-typed libraries. 1s is the smallest legal interval.
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS": "1",
             "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS": "2",
             "DD_REMOTE_CONFIGURATION_ENABLED": "false",
         }


### PR DESCRIPTION
## Motivation

`FeatureFlaggingAgentlessEndToEndScenario` sets `DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS=0.2`, but both agentless polling variables are integer seconds in the SDK contract:

- the shared configuration registry declares them `"type": "int"`, and dd-trace-js additionally constrains them with `"allowed": "[1-9]\\d*"`, which excludes decimals outright
- dd-trace-java parses them with `ConfigProvider.getInteger`

A fractional value only ever worked on Node, which has a single numeric type and does not enforce its own `allowed` pattern. Java tolerates it silently — the parse failure is caught and the default is substituted — so the scenario just polls every 30s rather than failing.

dd-trace-py enforces the declared type, and the failure is fatal. The cast happens at module scope, so `from ddtrace.openfeature import DataDogProvider` raises at import and the weblog never starts:

```
TypeError: cannot cast 0.2 to <class 'int'>
```

The value dates from #7298, which deliberately landed the harness with all manifests disabled. It was therefore never exercised against an SDK that enforces the type until Python was enabled.

## Changes

`DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS`: `0.2` → `1`, the smallest value Node's allowed pattern permits, with a comment recording why fractional values are not portable.

The parametric FFE tests already use integer values (`"1"`, `"3"`, `"5"`), so nothing else needed changing.

Nothing depends on the faster interval: there are no fixed sleeps in `tests/ffe/`, no poll- or request-count assertions, and every wait is `wait_for(...)` with a 30–60s timeout. Worst case is roughly 0.8s of extra propagation latency per configuration change.

Whether fractional seconds *should* become a supported contract is a separate question, being discussed on DataDog/dd-trace-py#19619. This PR keeps the tests on the contract the SDKs declare today.

> **Reviewers:** this touches `utils/` rather than `tests/`/`manifests/`, so per the checklist it needs R&P approval.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
