### PR TITLE
fix(aws-ssi): handle Ubuntu 23.04 EOL for Python provision

### DIFF
--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
@@ -6,6 +6,12 @@ lang_variant:
       - os_type: linux
         os_distro: deb
         remote-command: |
+          # Ubuntu 23.04 (Lunar) is EOL since January 2024, use archive repositories
+          if grep -q "lunar" /etc/os-release 2>/dev/null; then
+            echo "Ubuntu 23.04 (Lunar) detected - Configuring archive sources"
+            sudo sed -i -e 's|http://[^/]*/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+            sudo sed -i -e 's|https://[^/]*/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+          fi
           sudo apt-get update
           sudo apt install -y python-is-python3
           sudo apt install -y python3-pip

--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
@@ -11,6 +11,8 @@ lang_variant:
             echo "Ubuntu 23.04 (Lunar) detected - Configuring archive sources"
             sudo sed -i -e 's|http://[^/]*/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
             sudo sed -i -e 's|https://[^/]*/ubuntu|http://old-releases.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+            # ARM64 uses ubuntu-ports, but archives don't have that distinction
+            sudo sed -i -e 's|/ubuntu-ports|/ubuntu|g' /etc/apt/sources.list
           fi
           sudo apt-get update
           sudo apt install -y python-is-python3

--- a/utils/build/virtual_machine/weblogs/python/test-app-python/test-app-python_run.sh
+++ b/utils/build/virtual_machine/weblogs/python/test-app-python/test-app-python_run.sh
@@ -3,8 +3,12 @@ echo "START python APP"
 
 set -e
 
-export PATH="/home/datadog/.pyenv/bin:$PATH" 
-eval "$(pyenv init -)"
+# Configure pyenv if it's installed (needed for some Python versions like 2.7)
+if [ -d "/home/datadog/.pyenv" ]; then
+  export PATH="/home/datadog/.pyenv/bin:$PATH" 
+  eval "$(pyenv init -)"
+fi
+
 # shellcheck disable=SC2035
 sudo chmod -R 755 * 
 


### PR DESCRIPTION
## Summary

Fixes Python provision failures on Ubuntu_23_04_arm64 caused by Ubuntu 23.04 reaching End-of-Life.

## Problem

Since August 8th, the test `Ubuntu_23_04_arm64.HOS: [test-app-python]` has been failing with:
- `pyenv: Permission denied`
- `sudo: pip3: command not found`
- `No known runtime was detected - not injecting!`

## Root Cause

Ubuntu 23.04 (Lunar Lobster) reached EOL in January 2024. The standard Ubuntu repositories were archived/disabled in late July 2026.

**Timeline:**
- **July 18**: Cached AMI created with pip3 successfully installed ✅
- **Aug 7**: Test passes using July 18 AMI ✅
- **Aug 8**: New cached AMI created, `apt install python3-pip` fails silently ❌
- **Aug 11**: Test fails using Aug 8 AMI ❌

## Changes

1. **`provision_test-app-python.yml`**:
   - Detect Ubuntu 23.04 (Lunar) at provision time
   - Automatically configure `old-releases.ubuntu.com` as APT source
   - Ensures `python3-pip` installs successfully

2. **`test-app-python_run.sh`**:
   - Make pyenv initialization conditional (`if [ -d "/home/datadog/.pyenv" ]`)
   - Prevents script failure when pyenv is not installed
   - Preserves compatibility with provisions that use pyenv (Python 2.7)

## Test Plan

- [ ] Verify cached AMI gets rebuilt with pip3 installed
- [ ] Run `Ubuntu_23_04_arm64.HOS: [test-app-python]` test
- [ ] Verify Python is detected by the injector
- [ ] Verify Django app starts successfully

## Related Issues

- Failing job: https://gitlab.ddbuild.io/DataDog/auto_inject/-/jobs/1940027616
- Passing job (for comparison): https://gitlab.ddbuild.io/DataDog/auto_inject/-/jobs/1932006206