### PR TITLE
Move pooled agent's host-port band to 5600 to avoid collision with local agent listening on port 5000

### DIFF
--- a/utils/_context/_scenarios/_docker_fixtures.py
+++ b/utils/_context/_scenarios/_docker_fixtures.py
@@ -117,9 +117,9 @@ class DockerFixturesScenario(Scenario):
                         # since a parametrized custom OTLP port needs an agent listening on it.
                         container_otlp_http_port=DEFAULT_OTLP_HTTP_PORT,
                         container_otlp_grpc_port=DEFAULT_OTLP_GRPC_PORT,
-                        agent_port_base=5000,
-                        otlp_http_port_base=5100,
-                        otlp_grpc_port_base=5200,
+                        agent_port_base=5600,
+                        otlp_http_port_base=5700,
+                        otlp_grpc_port_base=5800,
                     ) as api:
                         yield api
                 finally:


### PR DESCRIPTION
## Motivation

One month ago, in https://github.com/DataDog/system-tests/pull/7235, the pooled agent's host-port band was moved from `4900` to `5000`, to avoid colliding with Feature Flag Evaluation mock back-end which is bound to port `4900`.

But, on MacOS, port `5000` is used by the local Datadog Agent.
When running locally the System Tests, Docker publishes the container port, but requests to localhost:5000 hit the Agent instead of the container, so the readiness poll in start_agent fails:
```
Run container ddapm-test-agent-worker-gw0-[xxx]] from image ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.64.1 with ports {'8126/tcp': 5000, '4318/tcp': 5100, '4317/tcp': 5200}
Test agent unexpected 404 response: 404 page not found
```

## Changes

Move pooled agent's host-port band from `5000` to `5600`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
