### PR TITLE
test(kafka): accept linked consumer spans

### DIFF
--- a/tests/integrations/crossed_integrations/test_kafka.py
+++ b/tests/integrations/crossed_integrations/test_kafka.py
@@ -119,12 +119,15 @@ class _BaseKafka:
         producer_span = self.get_span(self.buddy_interface, span_kind="producer", topic=self.BUDDY_TO_WEBLOG_TOPIC)
         consumer_span = self.get_span(interfaces.library, span_kind="consumer", topic=self.BUDDY_TO_WEBLOG_TOPIC)
 
-        # Both producer and consumer spans should be part of the same trace
-        # Different tracers can handle the exact propagation differently, so for now, this test avoids
-        # asserting on direct parent/child relationships
         assert producer_span is not None
         assert consumer_span is not None
-        assert producer_span.trace_id_equals(consumer_span["trace_id"])
+
+        same_trace = producer_span.trace_id_equals(consumer_span["trace_id"])
+        linked_to_producer = any(
+            producer_span.trace_id_equals(link.trace_id) and producer_span["span_id"] == link.span_id
+            for link in consumer_span.get_span_links()
+        )
+        assert same_trace or linked_to_producer
 
     def validate_kafka_spans(
         self,


### PR DESCRIPTION
## Motivation

DataDog/dd-trace-py#18667 changes Kafka consumers to start a local trace and link it to the producer. The crossed-tracing Kafka test only accepted trace continuation, so it rejected the intended linked relationship.

## Changes

Accept either a continued producer trace or a consumer span link that matches the producer's trace and span IDs.

## Testing

- Replayed the failed `CROSSED_TRACING_LIBRARIES` artifact from dd-trace-py PR #19629: 1 passed
- Ran `./format.sh`: mypy and Ruff passed with no changes

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on your PR until the CI passes
3. Mark it as ready for review

## Reviewer checklist

* [x] Only `tests/` is modified
* [x] No Docker base image is modified
* [x] No scenario is added, removed, or renamed
