### PR TITLE
test(ffe): validate Java agentless exposure egress

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3348,8 +3348,6 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.56.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3348,6 +3348,9 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.56.0
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - component_version: <1.66.0-SNAPSHOT
+      declaration: missing_feature (Agentless direct exposure egress requires Java tracer 1.66.0)
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -2,7 +2,11 @@
 
 from dataclasses import dataclass
 
-from tests.ffe.utils.exposures import assert_exposure_side_effects_contract, exposure_events_from_data
+from tests.ffe.utils.exposures import (
+    assert_exposure_side_effects_contract,
+    exposure_events_from_data,
+    wait_for_exposure_event,
+)
 from tests.ffe.utils.fixtures import make_ufc_fixture
 from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
 from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
@@ -48,14 +52,19 @@ def exposure_egress() -> ExposureEgress:
 class ExposureEgressContract:
     """One exposure contract inherited by each supported topology adapter."""
 
-    flag_key = "empty-targeting-key-flag"
+    flag_key = "empty_string_flag"
     targeting_key = "exposure-egress-user"
 
     def setup_exposure_egress(self) -> None:
         if not isinstance(context.scenario, FeatureFlaggingAgentlessEndToEndScenario):
             rc.tracer_rc_state.reset().set_config(
                 f"{RC_PATH}/exposure-egress/config",
-                make_ufc_fixture(self.flag_key),
+                make_ufc_fixture(
+                    self.flag_key,
+                    variant_key="non_empty",
+                    allocation_key="allocation-test",
+                    variation_values={"empty_string": "", "non_empty": "non_empty"},
+                ),
             ).apply()
 
         self.responses = [
@@ -72,6 +81,13 @@ class ExposureEgressContract:
             for _ in range(5)
         ]
 
+        egress = exposure_egress()
+        wait_for_exposure_event(
+            egress.interface,
+            flag_key=self.flag_key,
+            targeting_key=self.targeting_key,
+        )
+
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()
         matching_requests = assert_exposure_side_effects_contract(
@@ -79,8 +95,9 @@ class ExposureEgressContract:
             self.responses,
             flag_key=self.flag_key,
             targeting_key=self.targeting_key,
-            expected_value="on-value",
-            expected_variant="on",
+            expected_value="non_empty",
+            expected_variant="non_empty",
+            expected_allocation="allocation-test",
         )
         assert len(matching_requests) == 1
 

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from tests.ffe.utils.exposures import (
     assert_exposure_side_effects_contract,
     exposure_events_from_data,
-    wait_for_exposure_event,
 )
 from tests.ffe.utils.fixtures import make_ufc_fixture
 from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
@@ -52,19 +51,14 @@ def exposure_egress() -> ExposureEgress:
 class ExposureEgressContract:
     """One exposure contract inherited by each supported topology adapter."""
 
-    flag_key = "empty_string_flag"
+    flag_key = "empty-targeting-key-flag"
     targeting_key = "exposure-egress-user"
 
     def setup_exposure_egress(self) -> None:
         if not isinstance(context.scenario, FeatureFlaggingAgentlessEndToEndScenario):
             rc.tracer_rc_state.reset().set_config(
                 f"{RC_PATH}/exposure-egress/config",
-                make_ufc_fixture(
-                    self.flag_key,
-                    variant_key="non_empty",
-                    allocation_key="allocation-test",
-                    variation_values={"empty_string": "", "non_empty": "non_empty"},
-                ),
+                make_ufc_fixture(self.flag_key),
             ).apply()
 
         self.responses = [
@@ -81,13 +75,6 @@ class ExposureEgressContract:
             for _ in range(5)
         ]
 
-        egress = exposure_egress()
-        wait_for_exposure_event(
-            egress.interface,
-            flag_key=self.flag_key,
-            targeting_key=self.targeting_key,
-        )
-
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()
         matching_requests = assert_exposure_side_effects_contract(
@@ -95,9 +82,8 @@ class ExposureEgressContract:
             self.responses,
             flag_key=self.flag_key,
             targeting_key=self.targeting_key,
-            expected_value="non_empty",
-            expected_variant="non_empty",
-            expected_allocation="allocation-test",
+            expected_value="on-value",
+            expected_variant="on",
         )
         assert len(matching_requests) == 1
 

--- a/tests/ffe/utils/exposures.py
+++ b/tests/ffe/utils/exposures.py
@@ -44,23 +44,6 @@ def exposure_events_from_data(
     return events
 
 
-def wait_for_exposure_event(
-    interface: ProxyBasedInterfaceValidator,
-    *,
-    flag_key: str,
-    targeting_key: str,
-) -> None:
-    """Wait until the capture interface receives the expected exposure."""
-
-    def matches_exposure(data: dict) -> bool:
-        return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
-
-    assert interface.wait_for(
-        matches_exposure,
-        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
-    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
-
-
 def assert_exposure_side_effects_contract(
     interface: ProxyBasedInterfaceValidator,
     responses: Iterable[HttpResponse],
@@ -77,10 +60,13 @@ def assert_exposure_side_effects_contract(
         value = json.loads(response.text)["value"]
         assert value == expected_value, f"Evaluation {index} returned {value!r}"
 
-    wait_for_exposure_event(interface, flag_key=flag_key, targeting_key=targeting_key)
-
     def matches_exposure(data: dict) -> bool:
         return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
+
+    assert interface.wait_for(
+        matches_exposure,
+        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
+    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
 
     if not interface.replay:
         interface.wait(EXPOSURE_CACHE_SETTLE_SECONDS)

--- a/tests/ffe/utils/exposures.py
+++ b/tests/ffe/utils/exposures.py
@@ -44,6 +44,23 @@ def exposure_events_from_data(
     return events
 
 
+def wait_for_exposure_event(
+    interface: ProxyBasedInterfaceValidator,
+    *,
+    flag_key: str,
+    targeting_key: str,
+) -> None:
+    """Wait until the capture interface receives the expected exposure."""
+
+    def matches_exposure(data: dict) -> bool:
+        return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
+
+    assert interface.wait_for(
+        matches_exposure,
+        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
+    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
+
+
 def assert_exposure_side_effects_contract(
     interface: ProxyBasedInterfaceValidator,
     responses: Iterable[HttpResponse],
@@ -60,13 +77,10 @@ def assert_exposure_side_effects_contract(
         value = json.loads(response.text)["value"]
         assert value == expected_value, f"Evaluation {index} returned {value!r}"
 
+    wait_for_exposure_event(interface, flag_key=flag_key, targeting_key=targeting_key)
+
     def matches_exposure(data: dict) -> bool:
         return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
-
-    assert interface.wait_for(
-        matches_exposure,
-        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
-    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
 
     if not interface.replay:
         interface.wait(EXPOSURE_CACHE_SETTLE_SECONDS)

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -170,6 +170,41 @@ def test_agentless_exposure_scenario_has_no_agent_and_two_capture_routes(
     assert serverless_init.environment["DD_PROXY_HTTP"] == f"http://proxy:{ProxyPorts.datadog_sidecar}"
 
 
+@pytest.mark.parametrize(
+    ("library", "weblog_variant", "expected_result"),
+    [
+        ("java", "spring-boot", "configured"),
+        ("java", "spring-boot-3-native", "unchanged"),
+        ("java", "spring-boot-payara", "unchanged"),
+        ("java", "play", "unchanged"),
+        ("nodejs", "express4", "unchanged"),
+    ],
+)
+@scenarios.test_the_test
+def test_agentless_exposure_proxy_ca_wrapper_only_replaces_standard_spring_boot_startup(
+    library: str,
+    weblog_variant: str,
+    expected_result: Literal["configured", "unchanged"],
+) -> None:
+    scenario = FeatureFlaggingAgentlessEndToEndScenario(
+        "MOCK_FFE_AGENTLESS_EXPOSURES",
+        doc="test",
+        exposure_egress="direct",
+    )
+    library_container = scenario.weblog_infra.library_container
+    library_container.image.labels["system-tests-library"] = library
+    library_container.weblog_variant = weblog_variant
+
+    scenario._configure_java_proxy_ca()  # noqa: SLF001 - focused startup wrapper test
+
+    wrapper_path = "./utils/build/docker/java/app-with-proxy-ca.sh"
+    certificate_path = "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer"
+    expected_wrapper = expected_result == "configured"
+    assert ("JAVA_OPTS" in library_container.environment) is expected_wrapper
+    assert (wrapper_path in library_container.volumes) is expected_wrapper
+    assert (certificate_path in library_container.volumes) is expected_wrapper
+
+
 @scenarios.test_the_test
 def test_agentless_end_to_end_scenario_closes_backend_when_startup_fails(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -191,7 +191,7 @@ def test_agentless_exposure_proxy_ca_wrapper_only_replaces_standard_spring_boot_
         doc="test",
         exposure_egress="direct",
     )
-    library_container = scenario.weblog_infra.library_container
+    library_container = scenario.weblog_infra.http_container
     library_container.image.labels["system-tests-library"] = library
     library_container.weblog_variant = weblog_variant
 

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -194,15 +194,25 @@ def test_agentless_exposure_proxy_ca_wrapper_only_replaces_standard_spring_boot_
     library_container = scenario.weblog_infra.http_container
     library_container.image.labels["system-tests-library"] = library
     library_container.weblog_variant = weblog_variant
+    library_container.environment["JAVA_OPTS"] = "-Dexisting.option=true"
 
     scenario._configure_java_proxy_ca()  # noqa: SLF001 - focused startup wrapper test
 
     wrapper_path = "./utils/build/docker/java/app-with-proxy-ca.sh"
+    canonical_startup_path = "./utils/build/docker/java/app.sh"
     certificate_path = "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer"
     expected_wrapper = expected_result == "configured"
-    assert ("JAVA_OPTS" in library_container.environment) is expected_wrapper
+    assert library_container.environment["JAVA_OPTS"] == "-Dexisting.option=true"
+    assert ("SYSTEM_TESTS_JAVA_PROXY_OPTS" in library_container.environment) is expected_wrapper
     assert (wrapper_path in library_container.volumes) is expected_wrapper
+    assert (canonical_startup_path in library_container.volumes) is expected_wrapper
     assert (certificate_path in library_container.volumes) is expected_wrapper
+
+    if expected_wrapper:
+        assert library_container.environment["SYSTEM_TESTS_JAVA_PROXY_OPTS"] == (
+            f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
+        )
+        assert library_container.volumes[canonical_startup_path]["bind"] == "/app/system-tests-java-app.sh"
 
 
 @scenarios.test_the_test

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -177,6 +177,21 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
     def configure(self, config: pytest.Config) -> None:
         try:
             super().configure(config)
+            if self.exposure_egress is not None and self.weblog_infra.library_name == "java":
+                library_container = self.weblog_infra.library_container
+                library_container.environment["JAVA_OPTS"] = (
+                    f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
+                )
+                library_container.volumes |= {
+                    "./utils/build/docker/java/app-with-proxy-ca.sh": {
+                        "bind": "/app/app.sh",
+                        "mode": "ro",
+                    },
+                    "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer": {
+                        "bind": "/app/system-tests-proxy-ca.cer",
+                        "mode": "ro",
+                    },
+                }
             if self.exposure_egress is not None:
                 interfaces.datadog_sidecar.configure(self.host_log_folder, replay=self.replay)
                 interfaces.datadog_direct.configure(self.host_log_folder, replay=self.replay)

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -177,27 +177,34 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
     def configure(self, config: pytest.Config) -> None:
         try:
             super().configure(config)
-            if self.exposure_egress is not None and self.weblog_infra.library_name == "java":
-                library_container = self.weblog_infra.library_container
-                library_container.environment["JAVA_OPTS"] = (
-                    f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
-                )
-                library_container.volumes |= {
-                    "./utils/build/docker/java/app-with-proxy-ca.sh": {
-                        "bind": "/app/app.sh",
-                        "mode": "ro",
-                    },
-                    "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer": {
-                        "bind": "/app/system-tests-proxy-ca.cer",
-                        "mode": "ro",
-                    },
-                }
             if self.exposure_egress is not None:
+                self._configure_java_proxy_ca()
                 interfaces.datadog_sidecar.configure(self.host_log_folder, replay=self.replay)
                 interfaces.datadog_direct.configure(self.host_log_folder, replay=self.replay)
         except BaseException:
             self._stop_mock_backend(persist_status=False)
             raise
+
+    def _configure_java_proxy_ca(self) -> None:
+        # The wrapper replaces /app/app.sh and uses the standard Spring Boot image layout.
+        # Other Java weblogs use different startup scripts and application paths.
+        if self.weblog_infra.library_name != "java" or self.weblog_variant != "spring-boot":
+            return
+
+        library_container = self.weblog_infra.library_container
+        library_container.environment["JAVA_OPTS"] = (
+            f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
+        )
+        library_container.volumes |= {
+            "./utils/build/docker/java/app-with-proxy-ca.sh": {
+                "bind": "/app/app.sh",
+                "mode": "ro",
+            },
+            "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer": {
+                "bind": "/app/system-tests-proxy-ca.cer",
+                "mode": "ro",
+            },
+        }
 
     @property
     def serverless_init_container(self) -> ServerlessInitContainer:

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -192,12 +192,16 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
             return
 
         library_container = self.weblog_infra.library_container
-        library_container.environment["JAVA_OPTS"] = (
+        library_container.environment["SYSTEM_TESTS_JAVA_PROXY_OPTS"] = (
             f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
         )
         library_container.volumes |= {
             "./utils/build/docker/java/app-with-proxy-ca.sh": {
                 "bind": "/app/app.sh",
+                "mode": "ro",
+            },
+            "./utils/build/docker/java/app.sh": {
+                "bind": "/app/system-tests-java-app.sh",
                 "mode": "ro",
             },
             "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer": {

--- a/utils/build/docker/java/app-with-proxy-ca.sh
+++ b/utils/build/docker/java/app-with-proxy-ca.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+trust_store=/tmp/system-tests-cacerts
+cp "${JAVA_HOME}/lib/security/cacerts" "${trust_store}"
+keytool -importcert -noprompt -trustcacerts \
+  -alias system-tests-proxy \
+  -file /app/system-tests-proxy-ca.cer \
+  -keystore "${trust_store}" \
+  -storepass changeit
+
+JAVA_OPTS="${JAVA_OPTS:-} -Djavax.net.ssl.trustStore=${trust_store} -Djavax.net.ssl.trustStorePassword=changeit"
+
+if [ "${INCLUDE_OTEL_DROP_IN:-}" = "true" ]; then
+  JAVA_OPTS="${JAVA_OPTS} -Ddd.trace.otel.enabled=true -Dotel.javaagent.extensions=/app/opentelemetry-javaagent-r2dbc.jar"
+fi
+
+# shellcheck disable=SC2086
+exec java -Xmx362m ${JAVA_OPTS} -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}

--- a/utils/build/docker/java/app-with-proxy-ca.sh
+++ b/utils/build/docker/java/app-with-proxy-ca.sh
@@ -9,11 +9,7 @@ keytool -importcert -noprompt -trustcacerts \
   -keystore "${trust_store}" \
   -storepass changeit
 
-JAVA_OPTS="${JAVA_OPTS:-} -Djavax.net.ssl.trustStore=${trust_store} -Djavax.net.ssl.trustStorePassword=changeit"
+JAVA_OPTS="${JAVA_OPTS:-} ${SYSTEM_TESTS_JAVA_PROXY_OPTS:-} -Djavax.net.ssl.trustStore=${trust_store} -Djavax.net.ssl.trustStorePassword=changeit"
+export JAVA_OPTS
 
-if [ "${INCLUDE_OTEL_DROP_IN:-}" = "true" ]; then
-  JAVA_OPTS="${JAVA_OPTS} -Ddd.trace.otel.enabled=true -Dotel.javaagent.extensions=/app/opentelemetry-javaagent-r2dbc.jar"
-fi
-
-# shellcheck disable=SC2086
-exec java -Xmx362m ${JAVA_OPTS} -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}
+exec /app/system-tests-java-app.sh


### PR DESCRIPTION
## Motivation

Java agentless Feature Flags can deliver exposures through a local EVP proxy or authenticated direct intake. System tests must validate each supported route without changing unrelated Java weblog startup.

## Changes and Decisions

- Enable direct and `serverless-init` exposure validation for Java.
- Keep one exposure contract for Agent, direct, and `serverless-init` routes.
- Capture intake requests through the controlled system-tests proxy.
- Apply the proxy trust-store wrapper only to the supported Spring Boot weblog.
- Keep native, Payara, Play, UDS, and non-Java startup scripts unchanged.

## Validation

- Tested dd-trace-java `9b8d7589aa` with the Spring Boot weblog.
- Agent, direct, and `serverless-init` routes each passed.
- Five evaluations produced one exposure on each route.
- No exposure appeared on an unused route.