### PR TITLE
test(ffe): enable .NET agentless configuration source

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -847,7 +847,7 @@ manifest:
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Ignore: v3.10.0
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart: incomplete_test_app (The parametric test app does not emit restart span links or preserve baggage)
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First: incomplete_test_app (The parametric test app does not emit restart span links or preserve baggage)
-  tests/parametric/test_ffe/test_configuration_sources.py: missing_feature (FFL-2703 tracks .NET agentless configuration-source implementation; FFL-2731 tracks system-tests configuration-source contract)
+  tests/parametric/test_ffe/test_configuration_sources.py: '>=3.x.x'  # FFL-2703
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: '>=3.36.0'  # Modified by easy win activation script
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation::test_ffe_flag_evaluation: missing_feature  # Created by easy win activation script
   tests/parametric/test_ffe/test_span_enrichment.py: missing_feature

--- a/utils/build/docker/dotnet/parametric/ApmTestApi.csproj
+++ b/utils/build/docker/dotnet/parametric/ApmTestApi.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
     <PackageReference Include="Datadog.Trace" Version="*" />
+    <PackageReference Include="Datadog.FeatureFlags.OpenFeature" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/utils/build/docker/dotnet/parametric/Endpoints/FfeTestApi.cs
+++ b/utils/build/docker/dotnet/parametric/Endpoints/FfeTestApi.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using OpenFeature;
+using OpenFeature.Constant;
+using OpenFeature.Model;
+
+namespace ApmTestApi.Endpoints;
+
+public abstract class FfeTestApi
+{
+    private static Client? _client;
+    private static ILogger? _logger;
+
+    public static void MapFfeEndpoints(WebApplication app, ILogger logger)
+    {
+        _logger = logger;
+
+        app.MapPost("/ffe/start", StartFfe);
+        app.MapPost("/ffe/evaluate", EvaluateFfe);
+    }
+
+    private static IResult StartFfe()
+    {
+        try
+        {
+            _logger?.LogInformation("Initializing FFE provider");
+
+            var provider = new DatadogProvider();
+            Api.Instance.SetProvider(provider);
+            _client = Api.Instance.GetClient();
+
+            return Results.Ok();
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Error starting FFE provider");
+            return Results.Json(new { error = e.Message }, statusCode: 500);
+        }
+    }
+
+    private static async Task<IResult> EvaluateFfe(HttpRequest request)
+    {
+        if (_client is null)
+        {
+            return Results.Json(new { error = "FFE provider not initialized" }, statusCode: 500);
+        }
+
+        try
+        {
+            using var jsonDoc = await JsonDocument.ParseAsync(request.Body);
+            var root = jsonDoc.RootElement;
+
+            var flag = root.GetProperty("flag").GetString()!;
+            var variationType = root.GetProperty("variationType").GetString()!;
+            var targetingKey = root.GetProperty("targetingKey").GetString()!;
+            var attributes = new Dictionary<string, object?>();
+
+            if (root.TryGetProperty("attributes", out var attrsEl) && attrsEl.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var prop in attrsEl.EnumerateObject())
+                {
+                    attributes[prop.Name] = prop.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => prop.Value.GetString(),
+                        JsonValueKind.Number => prop.Value.GetDouble(),
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        _ => prop.Value.GetRawText()
+                    };
+                }
+            }
+
+            var context = EvaluationContext.Builder()
+                .SetTargetingKey(targetingKey)
+                .Build();
+
+            foreach (var (key, value) in attributes)
+            {
+                context = context.Set(key, value switch
+                {
+                    string s => s,
+                    double d => d,
+                    bool b => b,
+                    _ => value?.ToString() ?? string.Empty
+                });
+            }
+
+            object? value;
+            string? errorCode = null;
+            string reason = "DEFAULT";
+
+            try
+            {
+                switch (variationType)
+                {
+                    case "BOOLEAN":
+                        {
+                            var details = await _client.ResolveBooleanValueAsync(flag, root.GetProperty("defaultValue").GetBoolean(), context);
+                            value = details.Value;
+                            reason = details.Reason ?? "DEFAULT";
+                            errorCode = ErrorTypeToString(details.ErrorCode);
+                        }
+                        break;
+                    case "STRING":
+                        {
+                            var details = await _client.ResolveStringValueAsync(flag, root.GetProperty("defaultValue").GetString()!, context);
+                            value = details.Value;
+                            reason = details.Reason ?? "DEFAULT";
+                            errorCode = ErrorTypeToString(details.ErrorCode);
+                        }
+                        break;
+                    case "INTEGER":
+                        {
+                            var details = await _client.ResolveIntegerValueAsync(flag, root.GetProperty("defaultValue").GetInt32(), context);
+                            value = details.Value;
+                            reason = details.Reason ?? "DEFAULT";
+                            errorCode = ErrorTypeToString(details.ErrorCode);
+                        }
+                        break;
+                    case "NUMERIC":
+                        {
+                            var details = await _client.ResolveDoubleValueAsync(flag, root.GetProperty("defaultValue").GetDouble(), context);
+                            value = details.Value;
+                            reason = details.Reason ?? "DEFAULT";
+                            errorCode = ErrorTypeToString(details.ErrorCode);
+                        }
+                        break;
+                    case "JSON":
+                        {
+                            var details = await _client.ResolveStructureValueAsync(flag, new Value(root.GetProperty("defaultValue").GetRawText()), context);
+                            value = details.Value;
+                            reason = details.Reason ?? "DEFAULT";
+                            errorCode = ErrorTypeToString(details.ErrorCode);
+                        }
+                        break;
+                    default:
+                        value = root.GetProperty("defaultValue").GetRawText();
+                        break;
+                }
+            }
+            catch (Exception)
+            {
+                value = GetDefaultValue(root);
+                reason = "ERROR";
+            }
+
+            return Results.Ok(new { value, reason, errorCode });
+        }
+        catch (Exception e)
+        {
+            _logger?.LogError(e, "Error evaluating flag");
+            return Results.Json(new { error = e.Message }, statusCode: 500);
+        }
+    }
+
+    private static object? GetDefaultValue(JsonElement root)
+    {
+        if (!root.TryGetProperty("defaultValue", out var dv))
+            return null;
+
+        return dv.ValueKind switch
+        {
+            JsonValueKind.String => dv.GetString(),
+            JsonValueKind.Number => dv.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => dv.GetRawText()
+        };
+    }
+
+    private static string? ErrorTypeToString(ErrorType errorType)
+    {
+        if (errorType == ErrorType.None)
+        {
+            return null;
+        }
+
+        // Convert PascalCase enum to UPPER_SNAKE_CASE (e.g. ProviderNotReady -> PROVIDER_NOT_READY)
+        var name = errorType.ToString();
+        var result = new System.Text.StringBuilder();
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (i > 0 && char.IsUpper(name[i]))
+            {
+                result.Append('_');
+            }
+            result.Append(char.ToUpper(name[i]));
+        }
+        return result.ToString();
+    }
+}

--- a/utils/build/docker/dotnet/parametric/Program.cs
+++ b/utils/build/docker/dotnet/parametric/Program.cs
@@ -11,6 +11,7 @@ var otelLogger = app.Services.GetRequiredService<ILogger<ApmTestApi.Endpoints.Ap
 // Map endpoints
 ApmTestApi.Endpoints.ApmTestApi.MapApmTraceEndpoints(app, logger);
 ApmTestApi.Endpoints.ApmTestApiOtel.MapApmOtelEndpoints(app, otelLogger);
+ApmTestApi.Endpoints.FfeTestApi.MapFfeEndpoints(app, logger);
 
 if (!int.TryParse(Environment.GetEnvironmentVariable("APM_TEST_CLIENT_SERVER_PORT"), out var port))
 {


### PR DESCRIPTION
## Motivation

[DataDog/dd-trace-dotnet#9017](https://github.com/DataDog/dd-trace-dotnet/pull/9017) implements the .NET agentless Feature Flagging configuration source (FFL-2703). This enables the shared configuration-source contract for .NET, following the Node.js ([#7355](https://github.com/DataDog/system-tests/pull/7355)), Java ([#7300](https://github.com/DataDog/system-tests/pull/7300)), and Python ([#7411](https://github.com/DataDog/system-tests/pull/7411)) activations.

## Changes

* Enable `tests/parametric/test_ffe/test_configuration_sources.py` for .NET from `>=3.x.x`.
* Add `/ffe/start` and `/ffe/evaluate` endpoints to the .NET parametric test app (`FfeTestApi.cs`), mirroring the Python and Java controllers.
* `/ffe/start` creates a `DatadogProvider`, sets it via `Api.Instance.SetProvider()`, and gets a client. The tracer's CallTarget instrumentation intercepts `FeatureFlagsSdk.InitializeAsync` to start agentless/RC delivery.
* `/ffe/evaluate` evaluates a flag using the OpenFeature client and returns `{value, reason, errorCode}` where `errorCode` is converted from the `ErrorType` enum to `UPPER_SNAKE_CASE` (e.g. `ProviderNotReady` → `PROVIDER_NOT_READY`) to match the test contract.
* Add `Datadog.FeatureFlags.OpenFeature` package reference (v2.3.1) to the parametric test app .csproj.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

🚀 Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)