### PR TITLE
test_dd_agent_host_ipv6 supported by latest dd-trace-cpp version, v2.2.0

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -69,8 +69,8 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Config_RateLimit::test_setting_trace_rate_limit_strict: missing_feature
   tests/parametric/test_config_consistency.py::Test_Config_Tags: ">=2.0.0"  # auto activation: might not be the earliest working version
   tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL: ">1.0.0"
-  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_agent_host_ipv6: missing_feature
-  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_trace_agent_http_url_ipv6: '>=2.0.0'  # Modified by easy win activation script
+  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_agent_host_ipv6: '>=2.2.0'
+  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_trace_agent_http_url_ipv6: '>=2.0.0'
   tests/parametric/test_config_consistency.py::Test_Config_TraceEnabled: ">1.0.0"
   tests/parametric/test_config_consistency.py::Test_Config_TraceLogDirectory: missing_feature
   tests/parametric/test_config_consistency.py::Test_Config_UnifiedServiceTagging: ">1.0.0"

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -69,7 +69,7 @@ manifest:
   tests/parametric/test_config_consistency.py::Test_Config_RateLimit::test_setting_trace_rate_limit_strict: missing_feature
   tests/parametric/test_config_consistency.py::Test_Config_Tags: ">=2.0.0"  # auto activation: might not be the earliest working version
   tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL: ">1.0.0"
-  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_agent_host_ipv6: '>=2.2.0'
+  tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_agent_host_ipv6: '>=2.2.1'
   tests/parametric/test_config_consistency.py::Test_Config_TraceAgentURL::test_dd_trace_agent_http_url_ipv6: '>=2.0.0'
   tests/parametric/test_config_consistency.py::Test_Config_TraceEnabled: ">1.0.0"
   tests/parametric/test_config_consistency.py::Test_Config_TraceLogDirectory: missing_feature


### PR DESCRIPTION
## Motivation

[dd-trace-cpp v2.2.0](https://github.com/DataDog/dd-trace-cpp/releases/tag/v2.2.0) adds support for IPv6 agent host addresses.

Jira ticket: [IDML-563 [C++ Tracer] [Delivery] Deliver C++ Tracer v2.2.0](https://datadoghq.atlassian.net/browse/IDMPL-758)

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
