### PR TITLE
Fix git commit error in SSI

### DIFF
--- a/utils/virtual_machine/virtual_machine_provider.py
+++ b/utils/virtual_machine/virtual_machine_provider.py
@@ -130,8 +130,14 @@ class VmProvider:
                 last_task = self.commander.remote_command(
                     vm,
                     "checkout_branch",
-                    "cd system-tests && git reset --hard HEAD && git stash && git pull && git stash "
-                    f"&& git checkout {ci_commit_branch}",
+                    # The VM's system-tests clone comes from a cached image and may be stale/dirty
+                    # (eg: CRLF renormalization can make git consider a file locally modified even
+                    # right after a reset). Force-checkout and hard-reset to the remote branch instead
+                    # of reset/stash/pull, so a falsely "dirty" tree never blocks the sync.
+                    "cd system-tests && git fetch origin "
+                    f"&& git checkout -f {ci_commit_branch} "
+                    f"&& git reset --hard origin/{ci_commit_branch} "
+                    "&& git clean -fd",
                     vm.get_command_environment(),
                     server_connection,
                     last_task,


### PR DESCRIPTION
## Motivation

Fix errors like this one : https://gitlab.ddbuild.io/DataDog/system-tests/-/jobs/1945373034#L3217

Error log on git pull : 

```
    error: Process exited with status 1: running "cd system-tests && git reset --hard HEAD && git stash && git pull && git stash && git checkout main":
    HEAD is now at 4b0b847 Remove e2e gitlab from schedules (#7388)
    warning: CRLF will be replaced by LF in lib-injection/build/docker/java/dd-lib-java-init-test-app/gradlew.bat.
    The file will have its original line endings in your working directory.

    [...]

    error: Your local changes to the following files would be overwritten by merge:
    	lib-injection/build/docker/java/dd-lib-java-init-test-app/gradlew.bat
    Please, commit your changes or stash them before you can merge.
```

## Changes

Before : 
```
git reset --hard HEAD 
git stash 
git pull 
git stash 
git checkout {ci_commit_branch}
```

Claude says : 

> The old sync sequence (`git reset --hard HEAD && git stash && git pull && git stash && git checkout {branch}`) relies on git pull's merge step, which refuses to overwrite any file it considers locally modified — and on a cached VM image, CRLF renormalization can make a tracked file appear dirty even right after a hard reset, aborting the whole pull. Merging was also the wrong operation for this use case: the goal is to make a disposable VM checkout exactly mirror origin/{branch}, not reconcile local work with upstream. This replaces it with `fetch + checkout -f + reset --hard origin/{branch} + clean -fd`, none of which perform a merge-safety check, so a stale/falsely-dirty tree can no longer block the sync.

After :
```
# fetch: bring the target branch's latest commits into the local repo,
# without touching the working tree yet.
git fetch origin

# checkout -f: switch to the target branch, force-overwriting any file
# git thinks is locally modified (this is what a plain merge/pull refuses to do).
git checkout -f {ci_commit_branch}

# reset --hard: snap the branch and working tree to exactly match origin,
# in case the local branch already existed and had diverged/lagged behind it.
git reset --hard origin/{ci_commit_branch}

# clean -fd: remove untracked files/directories left over from whatever
# branch was checked out before, so they can't leak into this test run.
git clean -fd
```

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
