### PR TITLE
debugger: rate-limit capture expressions with filter errors

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -600,6 +600,7 @@ manifest:
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions::test_complex_capture_expressions: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:  # Modified by easy win activation script
     - weblog_declaration:
         '*': missing_feature

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1095,6 +1095,7 @@ manifest:
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: v2.2.3
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: v2.2.3
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions::test_complex_capture_expressions: missing_feature (index expression not yet supported in Go system-probe)
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error: missing_feature (Go DI rejects the probe, a condition leaf LHS may not be a literal)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins: missing_feature (feature not implemented)
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL: v2.2.3
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error: v2.2.3

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2955,6 +2955,20 @@ manifest:
         uds-spring-boot: v1.38.0
     - declaration: missing_feature (Not yet implemented)
       component_version: '<=1.54.0'
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error:
+    - weblog_declaration:
+        "*": missing_feature
+        spring-boot: v1.38.0
+        spring-boot-jetty: v1.38.0
+        spring-boot-openliberty: v1.38.0
+        spring-boot-payara: v1.38.0
+        spring-boot-undertow: v1.38.0
+        spring-boot-wildfly: v1.38.0
+        uds-spring-boot: v1.38.0
+    - declaration: missing_feature (Method capture expressions are not implemented)
+      component_version: '<=1.54.0'
+  ? tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error::test_filter_rejected_no_error_spam
+  : bug (IDEAI-714)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1618,6 +1618,15 @@ manifest:
         nextjs: irrelevant
         uds-express4: *ref_5_87_0
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: missing_feature
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: *ref_5_87_0
+        express4-typescript: *ref_5_87_0
+        express5: *ref_5_87_0
+        fastify: *ref_5_87_0
+        nextjs: irrelevant
+        uds-express4: *ref_5_87_0
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -641,6 +641,11 @@ manifest:
         "*": v1.19.0
         laravel11x: incomplete_test_app
         symfony7x: incomplete_test_app
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error:
+    - weblog_declaration:
+        "*": v1.19.0
+        laravel11x: incomplete_test_app
+        symfony7x: incomplete_test_app
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins::test_code_origin_entry_present: irrelevant (HTTP entry spans in PHP-FPM/Apache are C-level; execute stack is empty at span close time so no user frames are captured)
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1234,6 +1234,7 @@ manifest:
       component_version: <3.0.0
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: missing_feature (Not yet implemented)
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -1791,6 +1791,12 @@ manifest:
         rails72: v2.38.0
         rails80: v2.38.0
         uds-rails: v2.38.0
+  tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error:
+    - weblog_declaration:
+        "*": irrelevant
+        rails72: v2.38.0
+        rails80: v2.38.0
+        uds-rails: v2.38.0
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/debugger/test_debugger_capture_expressions_errors.py
+++ b/tests/debugger/test_debugger_capture_expressions_errors.py
@@ -1,0 +1,80 @@
+import time
+
+import tests.debugger.utils as debugger
+from utils import context, features, scenarios
+
+
+class _CaptureExpressionsErrorTestBase(debugger.BaseDebuggerTest):
+    """Shared base for capture-expression-error compliance tests."""
+
+    def _convert_to_line_probe_if_needed(self, probe: dict) -> None:
+        if context.library.name != "nodejs":
+            return
+        where = probe["where"]
+        where.pop("methodName", None)
+        where["typeName"] = None
+        where["sourceFile"] = "ACTUAL_SOURCE_FILE"
+        where["lines"] = self.method_and_language_to_line_number("LogProbe", "nodejs")
+
+    def _assert_probes_installed(self) -> None:
+        for probe_id in self.probe_ids:
+            assert probe_id in self.probe_diagnostics, "Expected a diagnostic for the probe, but none was received."
+            status = self.probe_diagnostics[probe_id]["status"]
+            assert status in ("INSTALLED", "EMITTING"), (
+                f"Expected the probe to reach INSTALLED/EMITTING status, got {status!r}."
+            )
+
+
+@features.debugger_expression_language
+@scenarios.debugger_probes_snapshot
+class Test_Debugger_Filter_Rejected_Capture_Expression_Error(_CaptureExpressionsErrorTestBase):
+    """On filter-rejected hits, broken ``captureExpressions`` must not produce a flood of error events."""
+
+    def _setup_filter_rejected(self, request_count: int, spacing_s: float) -> None:
+        self.initialize_weblog_remote_config()
+
+        probes = debugger.read_probes("probe_capture_expressions_filter_rejected")
+        for probe in probes:
+            probe["id"] = debugger.generate_probe_id("log")
+            self._convert_to_line_probe_if_needed(probe)
+
+        self.set_probes(probes)
+        self.send_rc_probes()
+        if not self.wait_for_all_probes(statuses=["INSTALLED"], timeout=30):
+            self.setup_failures.append("Probes did not reach INSTALLED status within 30s")
+
+        for i in range(request_count):
+            self.send_weblog_request("/debugger/log", reset=(i == 0))
+            if spacing_s > 0 and i < request_count - 1:
+                time.sleep(spacing_s)
+
+    def setup_filter_rejected_probe_installs(self) -> None:
+        self._setup_filter_rejected(request_count=1, spacing_s=0.0)
+
+    def test_filter_rejected_probe_installs(self) -> None:
+        self.collect()
+        self.assert_setup_ok()
+        self.assert_rc_state_not_error()
+        self._assert_probes_installed()
+
+    def setup_filter_rejected_no_error_spam(self) -> None:
+        self._setup_filter_rejected(request_count=5, spacing_s=1.5)
+        # Returns as soon as a second event lands; a conforming tracer emits at most one, so it times out.
+        self.wait_for_snapshot_count(2, timeout=5)
+
+    def test_filter_rejected_no_error_spam(self) -> None:
+        """A ``captureSnapshot: false`` probe with a rejecting ``when`` and broken captures must not spam."""
+        self.collect()
+        self.assert_setup_ok()
+        # Without an installed probe and successful hits, emitting no event is vacuously true.
+        self._assert_probes_installed()
+        self.assert_all_weblog_responses_ok()
+
+        for probe_id in self.probe_ids:
+            snapshots = self.probe_snapshots.get(probe_id, [])
+            assert len(snapshots) <= 1, (
+                f"The probe emitted {len(snapshots)} event(s) for 5 filter-rejected hits spaced >1s "
+                f"apart. A conforming tracer must either skip capture-expression evaluation entirely "
+                f"on filter-rejected hits (0 events) or rate-limit any resulting eval errors to at "
+                f"most 1 event per probe per 5 minutes."
+            )

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -660,6 +660,28 @@ class BaseDebuggerTest:
 
         return False
 
+    def wait_for_snapshot_count(self, count: int, timeout: int = 5) -> bool:
+        """Wait until `count` snapshots have been received for the expected probes.
+
+        Tests that assert an upper bound on the number of emitted snapshots use this instead of
+        sleeping: it returns as soon as `count` snapshots are on disk, and otherwise waits out the
+        timeout, which is the expected outcome for a tracer respecting the bound.
+        """
+        logger.debug(f"Waiting for {count} snapshots from probes: {self.probe_ids}")
+        seen: set[tuple[str, int]] = set()
+        return interfaces.agent.wait_for(lambda data: self._count_snapshots(data, seen=seen) >= count, timeout=timeout)
+
+    def _count_snapshots(self, data: dict, seen: set[tuple[str, int]]) -> int:
+        if data["path"] in [_LOGS_PATH, _DEBUGGER_PATH]:
+            contents = data["request"].get("content", []) or []
+
+            for index, content in enumerate(_iter_snapshot_content_items(contents)):
+                snapshot = content.get("debugger", {}).get("snapshot") or content.get("debugger.snapshot")
+                if snapshot and snapshot.get("probe", {}).get("id") in self.probe_ids:
+                    seen.add((data["log_filename"], index))
+
+        return len(seen)
+
     _no_capture_reason_span_found = False
 
     def wait_for_no_capture_reason_span(self, error_message: str, timeout: int) -> bool:

--- a/tests/debugger/utils/probes/probe_capture_expressions_filter_rejected.json
+++ b/tests/debugger/utils/probes/probe_capture_expressions_filter_rejected.json
@@ -1,0 +1,32 @@
+[
+    {
+        "language": "",
+        "type": "",
+        "id": "",
+        "version": 0,
+        "where": {
+            "typeName": "ACTUAL_TYPE_NAME",
+            "methodName": "LogProbe",
+            "sourceFile": null
+        },
+        "when": {
+            "dsl": "eq(1, 2)",
+            "json": {
+                "eq": [1, 2]
+            }
+        },
+        "captureSnapshot": false,
+        "captureExpressions": [
+            {
+                "name": "brokenExpression",
+                "expr": {
+                    "dsl": "definitelyDoesNotExist",
+                    "json": {"ref": "definitelyDoesNotExist"}
+                }
+            }
+        ],
+        "segments": [
+            {"str": "filter-rejected-with-broken-captures probe should not fire"}
+        ]
+    }
+]


### PR DESCRIPTION
## Motivation

Reproduces the bug reported in [IDEAI-714](https://datadoghq.atlassian.net/browse/IDEAI-714): a Java log probe configured with `captureSnapshot: false`, a `when` filter that rejects every hit, and a `captureExpressions` entry referencing an unbound variable produced ~18,551 error-only events on production traffic.

Tracers should rate-limit resulting eval-errors to at most 1 event per probe per 5 minutes (matching the existing behavior for condition-eval errors).

## Changes

- New probe JSON `tests/debugger/utils/probes/probe_capture_expressions_filter_rejected.json`: `captureSnapshot: false`, `when: eq(1, 2)` (always false), and a `captureExpressions` entry referencing `definitelyDoesNotExist`.
- New test file `tests/debugger/test_debugger_capture_expressions_errors.py` with class `Test_Debugger_Filter_Rejected_Capture_Expression_Error`:
  - `test_filter_rejected_probe_installs` — precondition: the structurally-valid probe reaches INSTALLED (guards against the spam test trivially passing because the probe never installed).
  - `test_filter_rejected_no_error_spam` — fires 5 hits spaced >1s apart and asserts at most 1 event per probe. Reproduces the bug: an unbounded tracer emits 5 error events; a rate-limited or filter-honoring tracer emits 0 or 1.
- Manifest entry in `manifests/java.yml` activating the class at v1.38.0 across Spring Boot variants (mirroring the sibling `Test_Debugger_Runtime_Condition_Error`) and marking `test_filter_rejected_no_error_spam` as `bug (IDEAI-714)` so the reproduction is captured as a known bug rather than a red CI signal. Other language manifests are intentionally untouched pending validation.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

[IDEAI-714](https://datadoghq.atlassian.net/browse/IDEAI-714)

[IDEAI-714]: https://datadoghq.atlassian.net/browse/IDEAI-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDEAI-714]: https://datadoghq.atlassian.net/browse/IDEAI-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ