### PR TITLE
Print log file tail in case of error in SSI

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -430,9 +430,6 @@ class TestedContainer:
                 pytest.exit(f"Container {self.name} is not healthy, please check logs", 1)
 
     def collect_logs(self):
-        TAIL_LIMIT = 50  # noqa: N806
-        SEP = "=" * 30  # noqa: N806
-
         data = (
             ("stdout", self._container.logs(stdout=True, stderr=False)),
             ("stderr", self._container.logs(stdout=False, stderr=True)),
@@ -444,13 +441,7 @@ class TestedContainer:
 
             if not self.healthy:
                 decoded_output = raw_output.decode("utf-8")
-
-                logger.stdout(f"\n{SEP} {self.name} {output_name.upper()} last {TAIL_LIMIT} lines {SEP}")
-                logger.stdout(f"-> See {filename} for full logs")
-                logger.stdout("")
-                # print last <tail> lines in stdout
-                logger.stdout("\n".join(decoded_output.splitlines()[-TAIL_LIMIT:]))
-                logger.stdout("")
+                logger.log_file_to_stdout(filename, decoded_output.splitlines())
 
     def remove(self):
         logger.debug(f"Removing container {self.name}")

--- a/utils/_logger.py
+++ b/utils/_logger.py
@@ -27,6 +27,25 @@ class Logger(logging.Logger):
                 # so directly print in stdout
                 print(message)  # noqa: T201
 
+    def log_file_to_stdout(self, logfile: str, lines: list[str], tail_limit: int = 50) -> None:
+        """When some important informations is stored inside a log file, it can be very handy to also print it
+        in stdout. This function does not print in inside test.logs, as the data already exists in another log file
+        """
+
+        SEP = "=" * 30  # noqa: N806
+
+        # if the logger is not yet be configured with the pytest terminal, directly use print in stdout
+        print_method = self.terminal.write_line if hasattr(self, "terminal") else print
+
+        print_method(f"\n{SEP} {logfile} last {tail_limit} lines {SEP}")
+        print_method("")
+        # print last <tail> lines in stdout
+        print_method("".join(lines[-tail_limit:]))
+        print_method("")
+
+        if hasattr(self, "terminal"):
+            self.terminal.flush()
+
 
 logging.setLoggerClass(Logger)
 logging.getLogger("requests").setLevel(logging.WARNING)

--- a/utils/docker_fixtures/_test_clients/_core.py
+++ b/utils/docker_fixtures/_test_clients/_core.py
@@ -104,14 +104,7 @@ class TestClientFactory:
                 with Path(log_path).open() as f:
                     lines = f.readlines()
 
-                TAIL_LIMIT = 50  # noqa: N806
-                SEP = "=" * 30  # noqa: N806
-
-                logger.stdout(f"\n{SEP} {log_path} last {TAIL_LIMIT} lines {SEP}")
-                logger.stdout("")
-                # print last <tail> lines in stdout
-                logger.stdout("".join(lines[-TAIL_LIMIT:]))
-                logger.stdout("")
+                logger.log_file_to_stdout(log_path, lines)
 
                 pytest.exit(f"Failed to build framework test server image. See {log_path} for details", 1)
 

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -90,7 +90,12 @@ class AWSPulumiProvider(VmProvider):
             )
         except pulumi.automation.errors.CommandError as pulumi_command_exception:
             logger.stdout("❌ Exception launching aws provision step remote command ❌")
-            logger.stdout(f"(Please, check the log file: {context.scenario.host_log_folder}/{context.vm_name}.log)")
+
+            logfile = f"{context.scenario.host_log_folder}/{context.vm_name}.log"
+
+            with pathlib.Path(logfile).open() as f:
+                logger.log_file_to_stdout(logfile, f.readlines())
+
             logger.stdout(
                 "📖 Learn more in the Troubleshooting guide: https://github.com/DataDog/system-tests/blob/main/docs/understand/scenarios/onboarding.md#troubleshooting"
             )

--- a/utils/virtual_machine/virtual_machines.py
+++ b/utils/virtual_machine/virtual_machines.py
@@ -115,7 +115,7 @@ class _VirtualMachine:
         self.os_branch = os_branch
         self.os_cpu = os_cpu
         self._vm_provision: Provision | None = None
-        self.tested_components = {}
+        self.tested_components: dict[str, str] = {}
         self.deffault_open_port: int = 5985
         self.agent_env: dict[str, str] | None = None
         self.app_env: dict[str, str] | None = None


### PR DESCRIPTION
## Motivation

On failure, having the last lines of key log file is a game changer for user.

## Changes

Print 50 last file of log file for AWS provider

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
