### PR TITLE
Remove chance of failure in OTEL runtime metrics tests 

### DIFF
--- a/tests/test_otlp_runtime_metrics.py
+++ b/tests/test_otlp_runtime_metrics.py
@@ -238,6 +238,11 @@ DD_PROPRIETARY_PREFIXES: dict[str, str] = {
     "java": "jvm.heap_memory",
 }
 
+# Hit an endpoint that deliberately throws instead of relying on incidental exceptions that may not happen
+EXCEPTION_TRIGGER_ENDPOINTS: dict[str, str] = {
+    "dotnet": "/exceptionreplay/simple",
+}
+
 
 def get_runtime_metrics_by_name() -> dict[str, list[dict[str, str]]]:
     """Return observed runtime metrics grouped by name.
@@ -276,6 +281,11 @@ class Test_OtlpRuntimeMetrics:
 
     def setup_otel_metrics_are_present_and_attributed(self) -> None:
         self.req = weblog.get("/")
+
+        trigger = EXCEPTION_TRIGGER_ENDPOINTS.get(context.library.name)
+        if trigger is not None:
+            weblog.get(trigger)
+
         wait_for_runtime_metrics(context.library.name)
 
     def test_otel_metrics_are_present_and_attributed(self) -> None:


### PR DESCRIPTION
## Motivation

A PR in dd-trace-dotnet (https://github.com/DataDog/dd-trace-dotnet/pull/9005) reduces the number of exceptions we throw, but that's causing the OTLP metrics tests to fail, because the "exceptions" metric is not emitted (normal when there are no exceptions)

## Changes

Update the test to optionally hit an endpoint that explicitly throws an exception, to ensure the metric is included

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
