### PR TITLE
fix >2.1.2 in >=2.2.0

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -252,7 +252,7 @@ manifest:
   ? tests/parametric/test_otlp_trace_metrics.py::Test_FR15_Client_Computed_Stats_Header::test_fr15_3_stats_computed_resource_attr_on_otlp_traces
   : missing_feature
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)
-  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: ">2.1.2"
+  tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Add_Link: ">=2.2.0"
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Error: bug (APMAPI-778)  # The expected error status is not set
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDSpan_Set_Metric:  # TODO: a lower version might be supported
     - declaration: missing_feature (Tracer does not provide a public method for directly setting a span metric)
@@ -309,7 +309,7 @@ manifest:
     - declaration: bug (APMAPI-737)
       component_version: <2.0.0
   tests/parametric/test_span_events.py: missing_feature
-  tests/parametric/test_span_links.py: ">2.1.2"
+  tests/parametric/test_span_links.py: ">=2.2.0"
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_link_propagated_sampling_decisions: missing_feature (auto.drop not supported)
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05: missing_feature (v0.5 not implemented)
   ? tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_child_span_selected_and_root_dropped_by_sss_when_dropping_policy_is_active017


### PR DESCRIPTION
## Motivation

`2.1.2` was a temporary version number of `dd-trace-cpp`, never released.
The released version is `2.2.0`.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
