### PR TITLE
Exit with exit code 0 when there is no change to make

### DIFF
--- a/tests/test_the_test/test_easy_win.py
+++ b/tests/test_the_test/test_easy_win.py
@@ -407,7 +407,7 @@ def test_e2e_activation_modifies_manifest():
 
 
 def test_split_code_owner_activation_skips_commit_when_manifest_write_has_no_diff(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     skipped_nodes_file = tmp_path / "skip.yml"
     skipped_nodes_file.write_text("{}\n", encoding="utf-8")
@@ -457,10 +457,10 @@ def test_split_code_owner_activation_skips_commit_when_manifest_write_has_no_dif
     monkeypatch.setattr(activate_easy_wins_main, "update_manifest", fake_update_manifest)
     monkeypatch.setattr(activate_easy_wins_main.subprocess, "run", fake_subprocess_run)
 
-    with pytest.raises(SystemExit) as exception:
-        activate_easy_wins_main.main()
+    activate_easy_wins_main.main()
 
-    assert exception.value.code == 1
+    captured = capsys.readouterr()
+    assert "No update were made" in captured.out
     assert ["git", "commit", "-m", "chore: activate easy wins for @DataDog/team-a"] not in recorded_commands
 
 

--- a/tests/test_the_test/test_github_nightly.py
+++ b/tests/test_the_test/test_github_nightly.py
@@ -166,7 +166,7 @@ class Test_GithubNightly:
                 result(),  # git config user.email
                 result(),  # gh auth setup-git
                 result(),  # git checkout main
-                result(returncode=1),  # activate_easy_wins exits 1 for no changes
+                result("No update were made\n"),  # activate_easy_wins exits 0 for no changes
                 result(""),  # no easy-win branches
             ]
         )
@@ -216,7 +216,7 @@ class Test_GithubNightly:
                 result(returncode=2, stderr="activation exploded"),  # python activation
                 result(""),  # no branches
                 result(),  # git checkout main
-                result(returncode=1),  # ruby no changes
+                result("No update were made\n"),  # ruby no changes
                 result(""),  # no branches
             ]
         )
@@ -229,7 +229,12 @@ class Test_GithubNightly:
 
         captured = capsys.readouterr()
         assert exit_code == 1
-        assert captured.out.rstrip().endswith("python: activation exploded")
+        failure_summary = captured.out.rsplit("============ Nightly activation failures ============", maxsplit=1)[
+            1
+        ].strip()
+        assert failure_summary.startswith("python: Activation command failed:")
+        assert failure_summary.endswith("activation exploded")
+        assert "ruby:" not in failure_summary
 
     def test_branch_failure_does_not_skip_other_branches(
         self,

--- a/utils/ci/github/nightly.py
+++ b/utils/ci/github/nightly.py
@@ -209,9 +209,6 @@ def activate_library(config: ActivationConfig, runner: CommandRunner) -> list[st
 
     activation = runner.run(command)
     branches = _list_activation_branches(config.library, runner)
-    if activation.returncode == 1 and not branches and not activation.stderr.strip():
-        print(f"No activation changes for {config.library}")  # noqa: T201
-        return []
     if activation.returncode != 0:
         raise RuntimeError(_command_error("Activation command failed", activation))
     return branches

--- a/utils/scripts/activate_easy_wins/__main__.py
+++ b/utils/scripts/activate_easy_wins/__main__.py
@@ -140,7 +140,7 @@ def main() -> None:
 
     # Exit with status 1 if no updates were made
     if not has_updates:
-        sys.exit(1)
+        print("No update were made")
 
 
 if __name__ == "__main__":

--- a/utils/scripts/activate_easy_wins/__main__.py
+++ b/utils/scripts/activate_easy_wins/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import subprocess
-import sys
 from os import environ
 from pathlib import Path
 
@@ -138,7 +137,7 @@ def main() -> None:
 
         manifest_editor.write(dry_run=args.dry_run)
 
-    # Exit with status 1 if no updates were made
+    # Keep no-change activations successful so scheduled workflows can continue.
     if not has_updates:
         print("No update were made")
 


### PR DESCRIPTION
Exit code 1 was emitted when there was no activation found because the caller used to be responsible for creating the branches, but that's not the case anymore

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
