### PR TITLE
Mark test_session_blocking as flaky for python django weblogs

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -796,6 +796,9 @@ manifest:
     - weblog_declaration:
         "*": v3.11.0.dev
         *django: v3.3.0.dev
+  tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_Session_Blocking::test_session_blocking:
+    - weblog_declaration:
+        *django: flaky (APPSEC-69650)
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking:
     - weblog_declaration:
         "*": v3.0.0.rc


### PR DESCRIPTION
`Test_Automated_Session_Blocking::test_session_blocking` is flaky on python django weblogs (`django-poc`, `django-py3.13`, `python3.12`): the blocked request sometimes returns 200 with no `block-sessions` appsec event.

Example: https://github.com/DataDog/dd-trace-py/actions/runs/31798099502/job/94761662754

APPSEC-69650

🤖 Generated with [Claude Code](https://claude.com/claude-code)