### PR TITLE
Fix flaky test_session_blocking on python django weblogs

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -830,9 +830,6 @@ manifest:
     - weblog_declaration:
         "*": v3.11.0.dev
         *django: v3.3.0.dev
-  tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_Session_Blocking::test_session_blocking:
-    - weblog_declaration:
-        *django: flaky (APPSEC-69650)
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking:
     - weblog_declaration:
         "*": v3.0.0.rc

--- a/utils/build/docker/python/django/app/urls.py
+++ b/utils/build/docker/python/django/app/urls.py
@@ -980,6 +980,10 @@ MAGIC_SESSION_KEY = "random_session_id"
 def session_new(request):
     request.session.save()
     session_id = request.session.session_key
+    # The signed_cookies backend re-derives session_key from a fresh timestamp on every save(), and
+    # SessionMiddleware saves again in process_response. Without pinning, the key we return here and
+    # the one set in the cookie differ whenever the clock second ticks in between.
+    request.session.save = lambda *args, **kwargs: None
     return HttpResponse(session_id)
 
 


### PR DESCRIPTION
APPSEC-69650

The django weblogs use the `signed_cookies` session backend, whose `save()` re-derives `session_key` from a fresh `int(time.time())`. `session_new()` returned the key from its own `save()`, but `SessionMiddleware` saves again in `process_response` before setting the cookie — so body and cookie disagreed whenever the clock second ticked in between, and the test blocked a session id the weblog never sent back.

Pin `save()` after reading the key, and drop the flaky marker from #7521.

Verified on django 4.2 → 6.0: reproduces without the pin, passes with it, `Set-Cookie` still emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)