### PR TITLE
python: update gevent version to fix startup crash

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -215,6 +215,9 @@ jobs:
         run: ls -la binaries/
       - name: Export github token to a file
         run: echo "${{ secrets.GITHUB_TOKEN }}" > "$RUNNER_TEMP/github_token.txt"
+      - name: Install runner
+        if: matrix.weblog.build_base_images
+        uses: ./.github/actions/install_runner
       - name: Build weblog base images
         if: matrix.weblog.build_base_images
         run: |

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Export github token to a file
         run: echo "${{ secrets.GITHUB_TOKEN }}" > "$RUNNER_TEMP/github_token.txt"
       - name: Build weblog base images
-        if: matrix.weblog.build_base_image
+        if: matrix.weblog.build_base_images
         run: |
           source venv/bin/activate
           ./utils/scripts/build-base-image.py ${{ inputs.library }} ${{ matrix.weblog.name }}

--- a/mirror_images.yaml
+++ b/mirror_images.yaml
@@ -1,3 +1,4 @@
+---
 # Docker images mirrored into registry.ddbuild.io/system-tests/mirror.
 #
 # This file is generated: it lists every image required by the CI scenarios.
@@ -31,7 +32,9 @@
 - "datadog/system-tests:apache-mod-8.2-zts.base-v1"
 - "datadog/system-tests:apache-mod-8.2.base-v1"
 - "datadog/system-tests:django-poc.base-v11"
+- "datadog/system-tests:django-poc.base-v12"
 - "datadog/system-tests:django-py3.13.base-v10"
+- "datadog/system-tests:django-py3.13.base-v11"
 - "datadog/system-tests:express4-typescript.base-v1"
 - "datadog/system-tests:express4-typescript.base-v2"
 - "datadog/system-tests:express4-typescript.base-v3"
@@ -48,6 +51,7 @@
 - "datadog/system-tests:flask-poc.base-v1"
 - "datadog/system-tests:flask-poc.base-v13"
 - "datadog/system-tests:flask-poc.base-v14"
+- "datadog/system-tests:flask-poc.base-v15"
 - "datadog/system-tests:golang_buddy-v2"
 - "datadog/system-tests:java_buddy-v1"
 - "datadog/system-tests:lambda-proxy-v1"
@@ -66,10 +70,12 @@
 - "datadog/system-tests:php-fpm-8.5.base-v1"
 - "datadog/system-tests:proxy-v1"
 - "datadog/system-tests:python3.12.base-v13"
+- "datadog/system-tests:python3.12.base-v14"
 - "datadog/system-tests:python_buddy-v2"
 - "datadog/system-tests:ruby_buddy-v2"
 - "datadog/system-tests:tornado.base-v2"
 - "datadog/system-tests:uwsgi-poc.base-v10"
+- "datadog/system-tests:uwsgi-poc.base-v11"
 - "datadog/system-tests:uwsgi-poc.base-v9"
 - "debian:bookworm-slim"
 - "debian:stable-slim"

--- a/utils/build/docker/python/django-poc.Dockerfile
+++ b/utils/build/docker/python/django-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-poc.base-v11
+FROM datadog/system-tests:django-poc.base-v12
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-poc.base.Dockerfile
+++ b/utils/build/docker/python/django-poc.base.Dockerfile
@@ -11,5 +11,5 @@ ENV PIP_ROOT_USER_ACTION=ignore
 COPY utils/build/docker/python/django/requirements-django-poc.txt /tmp/django-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/django-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v11 .
-# docker push datadog/system-tests:django-poc.base-v11
+# docker build --progress=plain -f utils/build/docker/python/django-poc.base.Dockerfile -t datadog/system-tests:django-poc.base-v12 .
+# docker push datadog/system-tests:django-poc.base-v12

--- a/utils/build/docker/python/django-py3.13.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:django-py3.13.base-v10
+FROM datadog/system-tests:django-py3.13.base-v11
 
 WORKDIR /app
 

--- a/utils/build/docker/python/django-py3.13.base.Dockerfile
+++ b/utils/build/docker/python/django-py3.13.base.Dockerfile
@@ -10,5 +10,5 @@ ENV PIP_ROOT_USER_ACTION=ignore
 COPY utils/build/docker/python/django/requirements-django-py3.13.txt /tmp/django-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/django-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v10 .
-# docker push datadog/system-tests:django-py3.13.base-v10
+# docker build --progress=plain -f utils/build/docker/python/django-py3.13.base.Dockerfile -t datadog/system-tests:django-py3.13.base-v11 .
+# docker push datadog/system-tests:django-py3.13.base-v11

--- a/utils/build/docker/python/django/requirements-django-poc.txt
+++ b/utils/build/docker/python/django/requirements-django-poc.txt
@@ -1,7 +1,7 @@
 django==5.2.4
 pycryptodome==3.23.0
 gunicorn==21.2.0
-gevent==25.5.1
+gevent==26.8.0
 requests==2.32.4
 httpx==0.28.1
 boto3==1.34.141

--- a/utils/build/docker/python/django/requirements-django-py3.13.txt
+++ b/utils/build/docker/python/django/requirements-django-py3.13.txt
@@ -1,7 +1,7 @@
 django==5.2.7
 pycryptodome==3.23.0
 gunicorn==23.0.0
-gevent==25.9.1
+gevent==26.8.0
 requests==2.32.4
 httpx==0.28.1
 boto3==1.40.64

--- a/utils/build/docker/python/django/requirements-python3.12.txt
+++ b/utils/build/docker/python/django/requirements-python3.12.txt
@@ -1,7 +1,7 @@
 django==5.2.4
 pycryptodome==3.23.0
 gunicorn==23.0.0
-gevent==25.5.1
+gevent==26.8.0
 requests==2.32.4
 httpx==0.28.1
 boto3==1.34.141

--- a/utils/build/docker/python/docker-bake.hcl
+++ b/utils/build/docker/python/docker-bake.hcl
@@ -15,7 +15,7 @@ group "default" {
 target "django-py3_13" {
   context    = "."
   dockerfile = "utils/build/docker/python/django-py3.13.base.Dockerfile"
-  tags       = ["datadog/system-tests:django-py3.13.base-v10"]
+  tags       = ["datadog/system-tests:django-py3.13.base-v11"]
 }
 
 target "fastapi" {
@@ -27,25 +27,25 @@ target "fastapi" {
 target "python3_12" {
   context    = "."
   dockerfile = "utils/build/docker/python/python3.12.base.Dockerfile"
-  tags       = ["datadog/system-tests:python3.12.base-v13"]
+  tags       = ["datadog/system-tests:python3.12.base-v14"]
 }
 
 target "django-poc" {
   context    = "."
   dockerfile = "utils/build/docker/python/django-poc.base.Dockerfile"
-  tags       = ["datadog/system-tests:django-poc.base-v11"]
+  tags       = ["datadog/system-tests:django-poc.base-v12"]
 }
 
 target "flask-poc" {
   context    = "."
   dockerfile = "utils/build/docker/python/flask-poc.base.Dockerfile"
-  tags       = ["datadog/system-tests:flask-poc.base-v14"]
+  tags       = ["datadog/system-tests:flask-poc.base-v15"]
 }
 
 target "uwsgi-poc" {
   context    = "."
   dockerfile = "utils/build/docker/python/uwsgi-poc.base.Dockerfile"
-  tags       = ["datadog/system-tests:uwsgi-poc.base-v10"]
+  tags       = ["datadog/system-tests:uwsgi-poc.base-v11"]
 }
 
 target "tornado" {

--- a/utils/build/docker/python/flask-poc.Dockerfile
+++ b/utils/build/docker/python/flask-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v14
+FROM datadog/system-tests:flask-poc.base-v15
 
 WORKDIR /app
 

--- a/utils/build/docker/python/flask-poc.base.Dockerfile
+++ b/utils/build/docker/python/flask-poc.base.Dockerfile
@@ -21,5 +21,5 @@ RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-confi
 COPY utils/build/docker/python/flask/requirements-flask-poc.txt /tmp/flask-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/flask-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v14 .
-# docker push datadog/system-tests:flask-poc.base-v14
+# docker build --progress=plain -f utils/build/docker/python/flask-poc.base.Dockerfile -t datadog/system-tests:flask-poc.base-v15 .
+# docker push datadog/system-tests:flask-poc.base-v15

--- a/utils/build/docker/python/flask/requirements-flask-poc.txt
+++ b/utils/build/docker/python/flask/requirements-flask-poc.txt
@@ -6,7 +6,7 @@ xmltodict==0.14.2
 flask[async]==2.2.4
 flask-login==0.6.3
 gunicorn==21.2.0
-gevent==25.9.1
+gevent==26.8.0
 requests==2.32.3
 pycryptodome==3.20.0
 psycopg2-binary==2.9.9

--- a/utils/build/docker/python/flask/requirements-uwsgi-poc.txt
+++ b/utils/build/docker/python/flask/requirements-uwsgi-poc.txt
@@ -1,7 +1,7 @@
 flask[async]==2.2.4
 flask-login==0.6.3
 uWSGI==2.0.31
-gevent==24.2.1
+gevent==26.8.0
 requests==2.32.3
 pycryptodome==3.20.0
 psycopg2-binary==2.9.9

--- a/utils/build/docker/python/python3.12.Dockerfile
+++ b/utils/build/docker/python/python3.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:python3.12.base-v13
+FROM datadog/system-tests:python3.12.base-v14
 
 WORKDIR /app
 

--- a/utils/build/docker/python/python3.12.base.Dockerfile
+++ b/utils/build/docker/python/python3.12.base.Dockerfile
@@ -12,5 +12,5 @@ COPY utils/build/docker/python/django/requirements-python3.12.txt /tmp/django-re
 RUN pip install --upgrade pip && pip install -r /tmp/django-requirements.txt
 
 
-# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v13 .
-# docker push datadog/system-tests:python3.12.base-v13
+# docker build --progress=plain -f utils/build/docker/python/python3.12.base.Dockerfile -t datadog/system-tests:python3.12.base-v14 .
+# docker push datadog/system-tests:python3.12.base-v14

--- a/utils/build/docker/python/uds-flask.Dockerfile
+++ b/utils/build/docker/python/uds-flask.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:flask-poc.base-v14
+FROM datadog/system-tests:flask-poc.base-v15
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/system-tests:uwsgi-poc.base-v10
+FROM datadog/system-tests:uwsgi-poc.base-v11
 
 WORKDIR /app
 

--- a/utils/build/docker/python/uwsgi-poc.base.Dockerfile
+++ b/utils/build/docker/python/uwsgi-poc.base.Dockerfile
@@ -14,5 +14,5 @@ RUN apt update && apt install -y pkg-config default-libmysqlclient-dev pkg-confi
 COPY utils/build/docker/python/flask/requirements-uwsgi-poc.txt /tmp/flask-requirements.txt
 RUN pip install --upgrade pip && pip install -r /tmp/flask-requirements.txt
 
-# docker build --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v10 .
-# docker push datadog/system-tests:uwsgi-poc.base-v10
+# docker build --progress=plain -f utils/build/docker/python/uwsgi-poc.base.Dockerfile -t datadog/system-tests:uwsgi-poc.base-v11 .
+# docker push datadog/system-tests:uwsgi-poc.base-v11


### PR DESCRIPTION
## Motivation

python weblogs sometimes crash at startup because of a gevent semaphore issue. This issue is fixed in a recent version of gevent.

Example crash: https://github.com/DataDog/system-tests/actions/runs/28533904677/job/84590941555?pr=7179#step:51:132

## Changes

Update gevent across all weblogs and rebuild base images

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
    
APPSEC-68798
