### PR TITLE
test(ffe/go): un-flaky Degradation and gate ObserveFullData PII tests to v2.11.0-dev

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1162,10 +1162,9 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance::test_unknown_operator_errors: bug (FFL-2182)
   tests/ffe/test_exposures.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation::test_ffe_evp_flagevaluation_degradation: flaky (FFL-2676)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2784)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2784)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2784)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v2.11.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v2.11.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: v2.11.0-dev
   tests/ffe/test_flag_eval_metrics.py: v2.8.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Metric_Parse_Error_Invalid_Regex: irrelevant (Go validates regex at config load time)
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)


### PR DESCRIPTION
## Motivation

The Go EVP `flagevaluation` base track shipped in dd-trace-go v2.10.0 ([#4886](https://github.com/DataDog/dd-trace-go/pull/4886)), but the PII-protection layer — `observeFullEvaluationData` consent + SHA-256 `targeting_key` hashing — landed later in [dd-trace-go#5151](https://github.com/DataDog/dd-trace-go/pull/5151) (merged to `main`, targeting v2.11.0). This PR aligns the Go system-tests manifest with that split:

- **Degradation** (`Test_FFE_EVP_Flagevaluation_Degradation`) was marked `flaky (FFL-2676)` in #7268. It now passes cleanly against the v2.10.0 base track (verified locally in dd-trace-go#5151 L3: 11/11 `test_flag_eval_evp` passed including Degradation). Remove the flaky gate so it runs on v2.10.0.
- **ObserveFullData** (`Absent_Hashed`, `False_Hashed`, `True_Unhashed`) were added as `missing_feature (FFL-2784)` in #7316. They assert the PII-hashing behavior from dd-trace-go#5151, which is **not** in v2.10.0. Re-gate them to `v2.11.0-dev` (the first dev tag containing the merged #5151) so they skip on v2.10.0 and run on v2.11.0-dev.

## Changes

\`\`\`diff
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation::test_ffe_evp_flagevaluation_degradation: flaky (FFL-2676)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2784)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2784)
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2784)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v2.11.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v2.11.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: v2.11.0-dev
\`\`\`

## Validation

- Companion SDK PR: https://github.com/DataDog/dd-trace-go/pull/5151 (MERGED)
- Local L3 from that PR: `FEATURE_FLAGGING_AND_EXPERIMENTATION` scenario, `golang@2.11.0-dev.1` / `net-http` → 26 passed, 2 skipped, 0 failed. `test_flag_eval_evp.py` 11/11 passed including Degradation and the three ObserveFullData tests.

🤖 Generated with Claude Code