### PR TITLE
test(ffe): enable Node.js agentless exposure validation

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1793,8 +1793,6 @@ manifest:
     - weblog_declaration:
         "*": incomplete_test_app
         express4: *ref_5_77_0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (dd-trace-js#9527)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (dd-trace-js#9527)
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -105,6 +105,7 @@ refs:
   - &ref_6_7_0 '>=6.7.0 || ^5.118.0'
   - &ref_6_8_0 '>=6.8.0 || ^5.119.0'
   - &ref_6_10_0 '>=6.10.0 || ^5.121.0'
+  - &ref_7_0_0 '>=7.0.0-pre'
 manifest:
   tests/ai_guard/test_ai_guard_sdk.py::Test_AIGuardEvent_Tag:
     - weblog_declaration:
@@ -1793,6 +1794,8 @@ manifest:
     - weblog_declaration:
         "*": incomplete_test_app
         express4: *ref_5_77_0
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: *ref_7_0_0
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: *ref_7_0_0
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -2,7 +2,11 @@
 
 from dataclasses import dataclass
 
-from tests.ffe.utils.exposures import assert_exposure_side_effects_contract, exposure_events_from_data
+from tests.ffe.utils.exposures import (
+    assert_exposure_side_effects_contract,
+    exposure_events_from_data,
+    wait_for_exposure_event,
+)
 from tests.ffe.utils.fixtures import make_ufc_fixture
 from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
 from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
@@ -71,6 +75,13 @@ class ExposureEgressContract:
             )
             for _ in range(5)
         ]
+
+        egress = exposure_egress()
+        wait_for_exposure_event(
+            egress.interface,
+            flag_key=self.flag_key,
+            targeting_key=self.targeting_key,
+        )
 
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -8,7 +8,7 @@ from tests.ffe.utils.exposures import (
     wait_for_exposure_event,
 )
 from tests.ffe.utils.fixtures import make_ufc_fixture
-from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
+from utils import context, features, interfaces, remote_config as rc, scenarios, slow, weblog
 from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
 from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
@@ -83,6 +83,7 @@ class ExposureEgressContract:
             targeting_key=self.targeting_key,
         )
 
+    @slow
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()
         matching_requests = assert_exposure_side_effects_contract(

--- a/tests/ffe/utils/exposures.py
+++ b/tests/ffe/utils/exposures.py
@@ -44,6 +44,23 @@ def exposure_events_from_data(
     return events
 
 
+def wait_for_exposure_event(
+    interface: ProxyBasedInterfaceValidator,
+    *,
+    flag_key: str,
+    targeting_key: str,
+) -> None:
+    """Wait until the capture interface receives the expected exposure."""
+
+    def matches_exposure(data: dict) -> bool:
+        return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
+
+    assert interface.wait_for(
+        matches_exposure,
+        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
+    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
+
+
 def assert_exposure_side_effects_contract(
     interface: ProxyBasedInterfaceValidator,
     responses: Iterable[HttpResponse],
@@ -60,13 +77,10 @@ def assert_exposure_side_effects_contract(
         value = json.loads(response.text)["value"]
         assert value == expected_value, f"Evaluation {index} returned {value!r}"
 
+    wait_for_exposure_event(interface, flag_key=flag_key, targeting_key=targeting_key)
+
     def matches_exposure(data: dict) -> bool:
         return bool(exposure_events_from_data(data, {flag_key}, targeting_key))
-
-    assert interface.wait_for(
-        matches_exposure,
-        timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
-    ), f"Timed out waiting for exposure event for {flag_key!r} and {targeting_key!r}"
 
     if not interface.replay:
         interface.wait(EXPOSURE_CACHE_SETTLE_SECONDS)

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -177,6 +177,17 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
     def configure(self, config: pytest.Config) -> None:
         try:
             super().configure(config)
+            if self.exposure_egress is not None and self.weblog_infra.library_name == "nodejs":
+                library_container = self.weblog_infra.library_container
+                library_container.environment["NODE_EXTRA_CA_CERTS"] = (
+                    "/usr/local/share/ca-certificates/system-tests-mitmproxy-ca.pem"
+                )
+                library_container.volumes |= {
+                    "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.pem": {
+                        "bind": "/usr/local/share/ca-certificates/system-tests-mitmproxy-ca.pem",
+                        "mode": "ro",
+                    }
+                }
             if self.exposure_egress is not None:
                 interfaces.datadog_sidecar.configure(self.host_log_folder, replay=self.replay)
                 interfaces.datadog_direct.configure(self.host_log_folder, replay=self.replay)


### PR DESCRIPTION
## Motivation

Node.js agentless Feature Flags can send exposures through direct intake or `serverless-init`. The shared contract must validate both routes before release.

## Changes and Decisions

- Enable direct and `serverless-init` exposure validation from Node.js `7.0.0-pre`.
- Trust the controlled intake proxy certificate only for Node.js exposure scenarios.
- Wait for asynchronous exposure delivery before setup ends.
- Skip setup when the manifest deactivates this slow contract.
- Target DataDog/dd-trace-js#9742 until it merges.

## Validation

- Reproduced the CI timeout locally with production Node.js `6.11.0`.
- The same production command now exits successfully with one expected skip.
- Agent, direct, and `serverless-init` routes passed with dd-trace-js `99a97962b`.
- Five evaluations produced one exposure on each supported route.