### PR TITLE
Prevent the usage of xfail in tests files

### DIFF
--- a/tests/ai_guard/conftest.py
+++ b/tests/ai_guard/conftest.py
@@ -1,13 +1,14 @@
+from collections.abc import Generator
+from typing import Any
 import pytest
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Mark all ai_guard tests as xfail when generating cassettes."""
-    if getattr(config.option, "generate_cassettes", False):
-        for item in items:
-            item.add_marker(
-                pytest.mark.xfail(
-                    reason="Generating cassettes - test assertions are not evaluated",
-                    strict=False,
-                )
-            )
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Generator[None, Any, None]:
+    """When generating cassettes, don't let setup/assertion failures fail the run."""
+    outcome = yield
+    if item.config.option.generate_cassettes and call.when in ("setup", "call") and call.excinfo is not None:
+        report = outcome.get_result()
+        report.outcome = "skipped"
+        current_filename, lineno, _ = item.location
+        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")

--- a/tests/ai_guard/conftest.py
+++ b/tests/ai_guard/conftest.py
@@ -11,4 +11,4 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Gener
         report = outcome.get_result()
         report.outcome = "skipped"
         current_filename, lineno, _ = item.location
-        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")
+        report.longrepr = (current_filename, lineno + 1, "Generating cassettes - test assertions are not evaluated")

--- a/tests/integration_frameworks/conftest.py
+++ b/tests/integration_frameworks/conftest.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-
+from typing import Any
 import pytest
 
 from utils.docker_fixtures import (
@@ -10,16 +10,15 @@ from utils.docker_fixtures import (
 from utils import context, scenarios, logger
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Mark all integration_frameworks tests as xfail when generating cassettes."""
-    if config.option.generate_cassettes:
-        for item in items:
-            item.add_marker(
-                pytest.mark.xfail(
-                    reason="Generating cassettes - test assertions are not evaluated",
-                    strict=False,
-                )
-            )
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Generator[None, Any, None]:
+    """When generating cassettes, don't let setup/assertion failures fail the run."""
+    outcome = yield
+    if item.config.option.generate_cassettes and call.when in ("setup", "call") and call.excinfo is not None:
+        report = outcome.get_result()
+        report.outcome = "skipped"
+        current_filename, lineno, _ = item.location
+        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")
 
 
 @pytest.fixture

--- a/tests/integration_frameworks/conftest.py
+++ b/tests/integration_frameworks/conftest.py
@@ -18,7 +18,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Gener
         report = outcome.get_result()
         report.outcome = "skipped"
         current_filename, lineno, _ = item.location
-        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")
+        report.longrepr = (current_filename, lineno + 1, "Generating cassettes - test assertions are not evaluated")
 
 
 @pytest.fixture

--- a/tests/parametric/test_llm_observability/conftest.py
+++ b/tests/parametric/test_llm_observability/conftest.py
@@ -1,15 +1,17 @@
+from collections.abc import Generator
+from typing import Any
 import pytest
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Generator[None, Any, None]:
     """When generating cassettes, don't let setup/assertion failures fail the run."""
     outcome = yield
     if item.config.option.generate_cassettes and call.when in ("setup", "call") and call.excinfo is not None:
         report = outcome.get_result()
         report.outcome = "skipped"
         current_filename, lineno, _ = item.location
-        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")
+        report.longrepr = (current_filename, lineno + 1, "Generating cassettes - test assertions are not evaluated")
 
 
 @pytest.fixture

--- a/tests/parametric/test_llm_observability/conftest.py
+++ b/tests/parametric/test_llm_observability/conftest.py
@@ -1,16 +1,15 @@
 import pytest
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Mark all llm_observability tests as xfail when generating cassettes."""
-    if config.option.generate_cassettes:
-        for item in items:
-            item.add_marker(
-                pytest.mark.xfail(
-                    reason="Generating cassettes - test assertions are not evaluated",
-                    strict=False,
-                )
-            )
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    """When generating cassettes, don't let setup/assertion failures fail the run."""
+    outcome = yield
+    if item.config.option.generate_cassettes and call.when in ("setup", "call") and call.excinfo is not None:
+        report = outcome.get_result()
+        report.outcome = "skipped"
+        current_filename, lineno, _ = item.location
+        report.longrepr = (current_filename, lineno, "Generating cassettes - test assertions are not evaluated")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

system-tests offers a semantics way to mark expected failure. In #7408, we plan to prevent the usage of bare `@xfail` marker, so we need to prevent the usage of it elsewhere in the code.

## Changes

Change the skip logic for cassette generation.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
