### PR TITLE
SSI PHP: Disable alpine for centos7 and rh7 due to a segmentationfault

### DIFF
--- a/utils/scripts/ci_orchestrators/aws_ssi.json
+++ b/utils/scripts/ci_orchestrators/aws_ssi.json
@@ -666,6 +666,8 @@
             {
                 "name": "test-app-php-alpine",
                 "excluded_os_branches": [
+                    "centos_7_amd64",
+                    "rhel_7_amd64",
                     "windows"
                 ]
             },


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
[datadog_php_sigsegv_jira_report.md](https://github.com/user-attachments/files/31219100/datadog_php_sigsegv_jira_report.md)


## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
