### PR TITLE
Increase gitlab CI memory limit for end to end jobs

### DIFF
--- a/utils/ci/gitlab/system-tests.yml.j2
+++ b/utils/ci/gitlab/system-tests.yml.j2
@@ -125,7 +125,7 @@ system_tests_run_{{library}}_{{scenario}}_{{variant}}:
   timeout: 15 minutes
   variables:
     KUBERNETES_CPU_REQUEST: 0.5
-    KUBERNETES_MEMORY_REQUEST: 1.3Gi
+    KUBERNETES_MEMORY_REQUEST: 2Gi
   extends:
     - .system_tests_base
 {% if push_to_test_optimization %}


### PR DESCRIPTION
Reason: some jobs are failing looking like they are missing memory in the dd-trace-py CI

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
