### PR TITLE
debugger: scrub API Security schema tags from exception replay span approvals

### DIFF
--- a/tests/debugger/test_debugger_exception_replay.py
+++ b/tests/debugger/test_debugger_exception_replay.py
@@ -374,7 +374,11 @@ class Test_Debugger_Exception_Replay(debugger.BaseDebuggerTest):
                 keys_to_remove = []
                 span_meta = get_span_meta(span, span_format)
                 for meta_key, meta_value in span_meta.items():
-                    if meta_key in {
+                    if meta_key.startswith("_dd.appsec.s."):
+                        # API Security samples schemas per (route, method, status) on a time window, so
+                        # which request of the test carries them is not deterministic
+                        keys_to_remove.append(meta_key)
+                    elif meta_key in {
                         "_dd.appsec.fp.http.endpoint",
                         "_dd.appsec.fp.http.header",
                         "_dd.appsec.fp.http.network",


### PR DESCRIPTION
## Motivation

`Test_Debugger_Exception_Replay::test_exception_replay_rockpaperscissors` compares the `aspnet_core.request` spans against a stored approval, and the .NET tracer is about to start emitting API Security schemas (`_dd.appsec.s.*`) on error responses ([dd-trace-dotnet#9082](https://github.com/DataDog/dd-trace-dotnet/pull/9082) makes the response phase reach the WAF for server-generated 500s).

Those tags cannot be pinned in an approval: API Security samples schemas once per (route, method, status) per `DD_API_SECURITY_SAMPLE_DELAY` (30s by default), which is the same order of magnitude as this test's own retry interval (`_timeout_next = 30`). Which of the three rock/paper/scissors requests carries the schemas is therefore a race — in the failing run it was the `rock` span, and it could just as easily be another one or none.

## Changes

Drop every `_dd.appsec.s.*` key in `_validate_spans`, the same treatment the `_dd.appsec.fp.*` fingerprints already get. No approval file currently contains those keys, so no expected data changes.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
