### PR TITLE
[ruby] enable passing ot.th/ot.rv tracestate sampling E2E scenarios

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2988,64 +2988,16 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
-  tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh::test_force_keep_overrides_inherited_drop_decision:
-    - weblog_declaration:
-        sinatra22: missing_feature (APMAPI-2171)
-        rails61: missing_feature (APMAPI-2171)
-        sinatra32: missing_feature (APMAPI-2171)
-        rails72: missing_feature (APMAPI-2171)
-        uds-sinatra: missing_feature (APMAPI-2171)
-        rails52: missing_feature (APMAPI-2171)
-        sinatra14: missing_feature (APMAPI-2171)
-        sinatra41: missing_feature (APMAPI-2171)
-        rails80: missing_feature (APMAPI-2171)
-        uds-rails: missing_feature (APMAPI-2171)
-        rack: missing_feature (APMAPI-2171)
-        rails42: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <2.40.0
-      weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [rails52, rails42, sinatra14, uds-rails, rails72, sinatra32, sinatra22, rails61, sinatra41, rack, uds-sinatra, rails80]
+  tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh::test_force_keep_overrides_inherited_drop_decision: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: v2.42.0-dev
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics:  # TODO: a lower version might be supported
     - weblog_declaration:
         '*': missing_feature


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
The feature has been merged on dd-trace-rb (and the tests force-executed)
The parametric tests are already activated

## Changes

<!-- A brief description of the change being made with this pull request. -->
Activate E2E otel tracestate sampling scenarios for dd-trace-rb

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
