### PR TITLE
[php] Fix laravel11x stats computation test

### DIFF
--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1749,10 +1749,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature (error traces dropped client-side under sampling; errors counted in stats but traces not sent)
-  tests/stats/test_stats.py::Test_Peer_Tags::test_peer_tags:
-    - declaration: bug (APMSP-3911)
-      component_version: ">=1.24.0+dev"
-      weblog: laravel11x
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog:
     - weblog_declaration:

--- a/utils/build/docker/php/weblogs/laravel11x/routes/web.php
+++ b/utils/build/docker/php/weblogs/laravel11x/routes/web.php
@@ -19,6 +19,11 @@ Route::get('/', function () {
     ]);
 });
 
+Route::get('/await-agent-info', function () {
+    $ready = dd_trace_internal_fn('await_agent_info');
+    return response()->json(['ready' => $ready]);
+});
+
 Route::get('/stats-unique', function (Request $request) {
     $code = (int) $request->query('code', 200);
     return response('', $code);


### PR DESCRIPTION
## Motivation

**Fix Test_Peer_Tags flaky failure on laravel11x**
 Root cause: When the plain PHP weblog was moved to its own folder (65ab5e280), await-agent-info.php moved with it and was no longer shared across weblogs. The laravel11x weblog was then added without this endpoint.


## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
