### PR TITLE
Use manual keep endpoint instead of ASM in OTel tracestate sampling tests

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2853,20 +2853,7 @@ manifest:
   tests/test_library_logs.py::Test_NoExceptions::test_java_logs: irrelevant (only for Java)
   tests/test_library_logs.py::Test_NoExceptions::test_java_telemetry_logs: irrelevant (only for Java)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <6.8.0
-      weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh::test_force_keep_overrides_inherited_drop_decision:
-    - weblog_declaration:
-        fastify: missing_feature (APMAPI-2171)
-        express4: missing_feature (APMAPI-2171)
-        express5: missing_feature (APMAPI-2171)
-        uds-express4: missing_feature (APMAPI-2171)
-        express4-typescript: missing_feature (APMAPI-2171)
-        nextjs: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged:  # TODO: a lower version might be supported
     - declaration: missing_feature (APMAPI-2171)
       component_version: <6.8.0

--- a/tests/test_otel_tracestate_sampling.py
+++ b/tests/test_otel_tracestate_sampling.py
@@ -278,9 +278,8 @@ class Test_PreserveDdAndOtherVendors:
 class Test_ForceKeepClearsTh:
     """A4: a non-probability (force-keep) decision erases th but still forwards an inherited rv.
 
-    Modeled on the only existing e2e lever for a local, non-probability keep decision: an ASM /waf attack
-    detection (tests/appsec/test_traces.py::Test_RetainTraces). There is no dedicated manual-keep/drop
-    weblog endpoint today (tracked as a follow-up).
+    The manual-keep endpoint applies the decision before making its downstream request, whose propagated
+    headers are returned in the response.
     """
 
     INHERITED_RV = "1234567890abcd"
@@ -293,9 +292,8 @@ class Test_ForceKeepClearsTh:
 
     def setup_force_keep_with_no_inbound_ot(self):
         self.no_ot_request = weblog.get(
-            "/make_distant_call",
-            params={"url": "http://weblog:7777"},
-            headers={"User-Agent": "Arachni/v1"},
+            "/trace/manual_keep_drop",
+            params={"decision": "keep"},
         )
 
     def test_force_keep_with_no_inbound_ot(self):
@@ -310,12 +308,11 @@ class Test_ForceKeepClearsTh:
 
     def setup_force_keep_forwards_inherited_rv(self):
         self.rv_only_request = weblog.get(
-            "/make_distant_call",
-            params={"url": "http://weblog:7777"},
+            "/trace/manual_keep_drop",
+            params={"decision": "keep"},
             headers={
                 "traceparent": _traceparent(FORWARD_TRACE_ID, sampled=False),
                 "tracestate": f"ot=rv:{self.INHERITED_RV}",
-                "User-Agent": "Arachni/v1",
             },
         )
 
@@ -333,12 +330,11 @@ class Test_ForceKeepClearsTh:
 
     def setup_force_keep_overrides_inherited_drop_decision(self):
         self.dropped_request = weblog.get(
-            "/make_distant_call",
-            params={"url": "http://weblog:7777"},
+            "/trace/manual_keep_drop",
+            params={"decision": "keep"},
             headers={
                 "traceparent": _traceparent(self.DROPPED_TRACE_ID, sampled=False),
                 "tracestate": f"ot=rv:{self.DROPPED_RV};th:{self.DROPPED_TH}",
-                "User-Agent": "Arachni/v1",
             },
         )
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

Some weblogs don't have appsec activated which makes these tests fails.
This was tested locally against the Python implem, which previously failed, and now works.

## Changes

<!-- A brief description of the change being made with this pull request. -->

Use manual keep endpoint instead of ASM event to cause a force keep in OTel tracestate sampling tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
