### PR TITLE
Update yamlfmt to 0.21.0

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -95,9 +95,18 @@ else
 fi
 
 echo "Running yamlfmt checks..."
+YAMLFMT_VERSION="0.21.0"
+
+if which yamlfmt > /dev/null; then
+  YAMLFMT_INSTALLED_VERSION="$(yamlfmt -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+  if [ "$YAMLFMT_INSTALLED_VERSION" != "$YAMLFMT_VERSION" ]; then
+    echo "yamlfmt version is outdated ($YAMLFMT_INSTALLED_VERSION), removing it"
+    rm -f "$(which yamlfmt)"
+  fi
+fi
+
 if ! which yamlfmt > /dev/null; then
   echo "yamlfmt is not installed, installing it (ETA 5s)"
-  YAMLFMT_VERSION="0.21.0"
 
   YAMLFMT_OS=""
   case "$(uname -s)" in

--- a/format.sh
+++ b/format.sh
@@ -97,67 +97,74 @@ fi
 echo "Running yamlfmt checks..."
 YAMLFMT_VERSION="0.21.0"
 
-if which yamlfmt > /dev/null; then
-  YAMLFMT_INSTALLED_VERSION="$(yamlfmt -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
-  if [ "$YAMLFMT_INSTALLED_VERSION" != "$YAMLFMT_VERSION" ]; then
-    echo "yamlfmt version is outdated ($YAMLFMT_INSTALLED_VERSION), removing it"
-    rm -f "$(which yamlfmt)"
-  fi
-fi
+if [[ -n "${IN_NIX_SHELL:-}" ]]; then
+  # yamlfmt is provided (and version-pinned) by the nix flake, use it as-is
+  YAMLFMT_BIN="$(which yamlfmt)"
+else
+  YAMLFMT_BIN="$PWD/venv/bin/yamlfmt"
 
-if ! which yamlfmt > /dev/null; then
-  echo "yamlfmt is not installed, installing it (ETA 5s)"
-
-  YAMLFMT_OS=""
-  case "$(uname -s)" in
-    Darwin) YAMLFMT_OS="Darwin" ;;
-    Linux) YAMLFMT_OS="Linux" ;;
-    CYGWIN*|MINGW*|MSYS*) YAMLFMT_OS="Windows" ;;
-    *) echo "Unsupported OS"; return 1 ;;
-  esac
-
-  YAMLFMT_ARCH=""
-  case "$(uname -m)" in
-    arm64|aarch64) YAMLFMT_ARCH="arm64" ;;
-    x86_64) YAMLFMT_ARCH="x86_64" ;;
-    i386|i686) YAMLFMT_ARCH="i386" ;;
-    *) echo "Unsupported architecture"; return 1 ;;
-  esac
-
-  YAMLFMT_SHA256=""
-  case "${YAMLFMT_OS}_${YAMLFMT_ARCH}" in
-    Darwin_arm64)   YAMLFMT_SHA256="4b417ecb94339d57e4c122ecc948c1a00fe328b5853266de9806e652a92858fa" ;;
-    Darwin_x86_64)  YAMLFMT_SHA256="060e943bcb8583c456810eb1ff4721b4f46c4a0c1a4432449d5dc3bbfe29a22b" ;;
-    Linux_arm64)    YAMLFMT_SHA256="5b2689c963b177271330c5ce8ca7396751107e5a826be46f03d2cb9b6f0c7784" ;;
-    Linux_i386)     YAMLFMT_SHA256="c559e93f2a0d12c063b6c989d612318146cc92ea47f44eba8b265f814e008dcd" ;;
-    Linux_x86_64)   YAMLFMT_SHA256="1f300d9257b232bb3b541d7fb1b0e6b3c121bcbab381c86cd38cb8722be8a566" ;;
-    Windows_arm64)  YAMLFMT_SHA256="c1e64d1c72ca8986bc5b8c8edd4ec89f0627804e7e08f8de9f4b484cb5cad897" ;;
-    Windows_i386)   YAMLFMT_SHA256="3bc1faface507713109a608cf8812d3f46d2d722dda5ab1f9fe99a203985b952" ;;
-    Windows_x86_64) YAMLFMT_SHA256="07f80ce5d741eb4b0a9380ac78a19c7cb5bd44e2a9a47a5a04839e3ba54dd463" ;;
-    *) echo "No known checksum for ${YAMLFMT_OS}_${YAMLFMT_ARCH}"; return 1 ;;
-  esac
-
-  YAMLFMT_URL="https://github.com/google/yamlfmt/releases/download/v${YAMLFMT_VERSION}/yamlfmt_${YAMLFMT_VERSION}_${YAMLFMT_OS}_${YAMLFMT_ARCH}.tar.gz"
-  curl -Lo "$PWD"/venv/bin/yamlfmt.tar.gz "$YAMLFMT_URL"
-
-  # Validate checksum of downloaded archive
-  if command -v sha256sum > /dev/null; then
-    echo "$YAMLFMT_SHA256 *$PWD/venv/bin/yamlfmt.tar.gz" | sha256sum --check --strict
-  elif command -v shasum > /dev/null; then
-    echo "$YAMLFMT_SHA256 *$PWD/venv/bin/yamlfmt.tar.gz" | shasum -a 256 --check --strict
-  else
-    echo "ERROR: no sha256sum or shasum found, cannot verify download"; return 1
+  if [ -x "$YAMLFMT_BIN" ]; then
+    YAMLFMT_INSTALLED_VERSION="$("$YAMLFMT_BIN" -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+    if [ "$YAMLFMT_INSTALLED_VERSION" != "$YAMLFMT_VERSION" ]; then
+      echo "$YAMLFMT_BIN is version $YAMLFMT_INSTALLED_VERSION, expected $YAMLFMT_VERSION, reinstalling it"
+      rm -f "$YAMLFMT_BIN"
+    fi
   fi
 
-  tar -xzf "$PWD"/venv/bin/yamlfmt.tar.gz -C "$PWD"/venv/bin/
-  chmod +x "$PWD"/venv/bin/yamlfmt
+  if [ ! -x "$YAMLFMT_BIN" ]; then
+    echo "yamlfmt is not installed, installing it (ETA 5s)"
+
+    YAMLFMT_OS=""
+    case "$(uname -s)" in
+      Darwin) YAMLFMT_OS="Darwin" ;;
+      Linux) YAMLFMT_OS="Linux" ;;
+      CYGWIN*|MINGW*|MSYS*) YAMLFMT_OS="Windows" ;;
+      *) echo "Unsupported OS"; return 1 ;;
+    esac
+
+    YAMLFMT_ARCH=""
+    case "$(uname -m)" in
+      arm64|aarch64) YAMLFMT_ARCH="arm64" ;;
+      x86_64) YAMLFMT_ARCH="x86_64" ;;
+      i386|i686) YAMLFMT_ARCH="i386" ;;
+      *) echo "Unsupported architecture"; return 1 ;;
+    esac
+
+    YAMLFMT_SHA256=""
+    case "${YAMLFMT_OS}_${YAMLFMT_ARCH}" in
+      Darwin_arm64)   YAMLFMT_SHA256="4b417ecb94339d57e4c122ecc948c1a00fe328b5853266de9806e652a92858fa" ;;
+      Darwin_x86_64)  YAMLFMT_SHA256="060e943bcb8583c456810eb1ff4721b4f46c4a0c1a4432449d5dc3bbfe29a22b" ;;
+      Linux_arm64)    YAMLFMT_SHA256="5b2689c963b177271330c5ce8ca7396751107e5a826be46f03d2cb9b6f0c7784" ;;
+      Linux_i386)     YAMLFMT_SHA256="c559e93f2a0d12c063b6c989d612318146cc92ea47f44eba8b265f814e008dcd" ;;
+      Linux_x86_64)   YAMLFMT_SHA256="1f300d9257b232bb3b541d7fb1b0e6b3c121bcbab381c86cd38cb8722be8a566" ;;
+      Windows_arm64)  YAMLFMT_SHA256="c1e64d1c72ca8986bc5b8c8edd4ec89f0627804e7e08f8de9f4b484cb5cad897" ;;
+      Windows_i386)   YAMLFMT_SHA256="3bc1faface507713109a608cf8812d3f46d2d722dda5ab1f9fe99a203985b952" ;;
+      Windows_x86_64) YAMLFMT_SHA256="07f80ce5d741eb4b0a9380ac78a19c7cb5bd44e2a9a47a5a04839e3ba54dd463" ;;
+      *) echo "No known checksum for ${YAMLFMT_OS}_${YAMLFMT_ARCH}"; return 1 ;;
+    esac
+
+    YAMLFMT_URL="https://github.com/google/yamlfmt/releases/download/v${YAMLFMT_VERSION}/yamlfmt_${YAMLFMT_VERSION}_${YAMLFMT_OS}_${YAMLFMT_ARCH}.tar.gz"
+    curl -Lo "$YAMLFMT_BIN.tar.gz" "$YAMLFMT_URL"
+
+    # Validate checksum of downloaded archive
+    if command -v sha256sum > /dev/null; then
+      echo "$YAMLFMT_SHA256 *$YAMLFMT_BIN.tar.gz" | sha256sum --check --strict
+    elif command -v shasum > /dev/null; then
+      echo "$YAMLFMT_SHA256 *$YAMLFMT_BIN.tar.gz" | shasum -a 256 --check --strict
+    else
+      echo "ERROR: no sha256sum or shasum found, cannot verify download"; return 1
+    fi
+
+    tar -xzf "$YAMLFMT_BIN.tar.gz" -C "$PWD"/venv/bin/
+    chmod +x "$YAMLFMT_BIN"
+  fi
 fi
 
 echo "Running yamlfmt formatter..."
 if [ "$COMMAND" == "fix" ]; then
- yamlfmt manifests/
+ "$YAMLFMT_BIN" manifests/
 else
- yamlfmt -lint manifests/
+ "$YAMLFMT_BIN" -lint manifests/
 fi
 
 echo "Running yamllint checks..."

--- a/format.sh
+++ b/format.sh
@@ -97,7 +97,7 @@ fi
 echo "Running yamlfmt checks..."
 if ! which yamlfmt > /dev/null; then
   echo "yamlfmt is not installed, installing it (ETA 5s)"
-  YAMLFMT_VERSION="0.16.0"
+  YAMLFMT_VERSION="0.21.0"
 
   YAMLFMT_OS=""
   case "$(uname -s)" in
@@ -117,14 +117,14 @@ if ! which yamlfmt > /dev/null; then
 
   YAMLFMT_SHA256=""
   case "${YAMLFMT_OS}_${YAMLFMT_ARCH}" in
-    Darwin_arm64)   YAMLFMT_SHA256="fcffb2efdfdd27fb5bb658a8156972fda14f0864f336c181705b98eee5f6c139" ;;
-    Darwin_x86_64)  YAMLFMT_SHA256="740d23864fffcf1865a9e0a221840baae6b5f40b8a20ad2d5e79c1b9de9eaec7" ;;
-    Linux_arm64)    YAMLFMT_SHA256="208b9c0c4e67472e5205d3f826205b2f20da59a180b548cff02621401355bead" ;;
-    Linux_i386)     YAMLFMT_SHA256="1c20a6a7ca58736ba10e5c4fc02743d1163815d38e5332872033e775f9f048a1" ;;
-    Linux_x86_64)   YAMLFMT_SHA256="7819fa7c7e994d239009d30cbd58897149d7e7dd5847aedf7abd19c332298033" ;;
-    Windows_arm64)  YAMLFMT_SHA256="1adc6fa71e6e2fad3da09df409e2454e96a5c4a61a8669a6ae4023c163fc2a14" ;;
-    Windows_i386)   YAMLFMT_SHA256="de013077d923d9064cdd1ffedfd6d56274271772007fe214c6db7afdf571228d" ;;
-    Windows_x86_64) YAMLFMT_SHA256="dea055eb85a30d923850e46b462bb5f0e8f3ca9aee3b33b76a55f22995224e1b" ;;
+    Darwin_arm64)   YAMLFMT_SHA256="4b417ecb94339d57e4c122ecc948c1a00fe328b5853266de9806e652a92858fa" ;;
+    Darwin_x86_64)  YAMLFMT_SHA256="060e943bcb8583c456810eb1ff4721b4f46c4a0c1a4432449d5dc3bbfe29a22b" ;;
+    Linux_arm64)    YAMLFMT_SHA256="5b2689c963b177271330c5ce8ca7396751107e5a826be46f03d2cb9b6f0c7784" ;;
+    Linux_i386)     YAMLFMT_SHA256="c559e93f2a0d12c063b6c989d612318146cc92ea47f44eba8b265f814e008dcd" ;;
+    Linux_x86_64)   YAMLFMT_SHA256="1f300d9257b232bb3b541d7fb1b0e6b3c121bcbab381c86cd38cb8722be8a566" ;;
+    Windows_arm64)  YAMLFMT_SHA256="c1e64d1c72ca8986bc5b8c8edd4ec89f0627804e7e08f8de9f4b484cb5cad897" ;;
+    Windows_i386)   YAMLFMT_SHA256="3bc1faface507713109a608cf8812d3f46d2d722dda5ab1f9fe99a203985b952" ;;
+    Windows_x86_64) YAMLFMT_SHA256="07f80ce5d741eb4b0a9380ac78a19c7cb5bd44e2a9a47a5a04839e3ba54dd463" ;;
     *) echo "No known checksum for ${YAMLFMT_OS}_${YAMLFMT_ARCH}"; return 1 ;;
   esac
 

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -149,7 +149,7 @@ manifest:
   tests/appsec/api_security/test_endpoint_discovery.py::Test_Endpoint_Discovery:
     - weblog_declaration:
         "*": v3.13.0.dev
-        *django: v3.12.0.dev
+        *django : v3.12.0.dev
         tornado: v4.7.0-rc1
   tests/appsec/api_security/test_endpoint_discovery.py::Test_Endpoint_Discovery::test_optional_authentication: irrelevant
   tests/appsec/api_security/test_endpoint_discovery.py::Test_Endpoint_Discovery::test_optional_metadata: irrelevant
@@ -239,23 +239,23 @@ manifest:
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRoute:
     - weblog_declaration:
         "*": missing_feature
-        *django: v4.11.0-rc1
+        *django : v4.11.0-rc1
         fastapi: v4.11.0-rc1
-        *flask: v4.11.0-rc1
+        *flask : v4.11.0-rc1
         tornado: v4.12.0-rc1
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRouteMultiParamsInSegment:
     - weblog_declaration:
         "*": missing_feature
-        *django: v4.12.0-rc1
+        *django : v4.12.0-rc1
         fastapi: v4.11.0-rc1
-        *flask: v4.11.0-rc1
+        *flask : v4.11.0-rc1
         tornado: v4.12.0-rc1
   tests/appsec/api_security_testing/test_normalized_route.py::Test_NormalizedRouteOptionalParams:
     - weblog_declaration:
         "*": missing_feature
-        *django: v4.12.0-rc1
+        *django : v4.12.0-rc1
         fastapi: v4.11.0-rc1
-        *flask: v4.11.0-rc1
+        *flask : v4.11.0-rc1
         tornado: v4.12.0-rc1
   tests/appsec/iast:
     - weblog_declaration:
@@ -304,7 +304,7 @@ manifest:
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjection:
     - weblog_declaration:
         "*": irrelevant (was v2.10.0.dev but algorithm was updated will be updated)
-        *django: v3.10.0.dev
+        *django : v3.10.0.dev
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjectionExclusionAccessControlAllow: missing_feature
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjectionExclusionContentEncoding: missing_feature
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjectionExclusionPragma: missing_feature
@@ -312,11 +312,11 @@ manifest:
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjection_ExtendedLocation:
     - weblog_declaration:
         "*": irrelevant (was v3.1.0.dev but algorithm was updated will be updated)
-        *django: v3.10.0.dev
+        *django : v3.10.0.dev
   tests/appsec/iast/sink/test_header_injection.py::TestHeaderInjection_StackTrace:
     - weblog_declaration:
         "*": irrelevant (was v3.9.0.dev but algorithm was updated will be updated)
-        *django: v3.10.0.dev
+        *django : v3.10.0.dev
   tests/appsec/iast/sink/test_hsts_missing_header.py:
     - weblog_declaration:
         tornado: missing_feature
@@ -593,7 +593,7 @@ manifest:
     - weblog_declaration:
         "*": v1.18.0
         fastapi: v2.13.0
-        *flask: v3.1.0.dev
+        *flask : v3.1.0.dev
   tests/appsec/iast/source/test_kafka_key.py::TestKafkaKey: missing_feature
   tests/appsec/iast/source/test_kafka_value.py::TestKafkaValue: missing_feature
   tests/appsec/iast/source/test_multipart.py::TestMultipart: missing_feature
@@ -612,12 +612,12 @@ manifest:
     - weblog_declaration:
         "*": v2.9.0
         fastapi: v2.13.0
-        *flask: v2.13.0
+        *flask : v2.13.0
   tests/appsec/iast/source/test_path_parameter.py::TestPathParameter:
     - weblog_declaration:
         "*": v2.9.0
         fastapi: v2.13.0
-        *flask: v2.13.0
+        *flask : v2.13.0
   tests/appsec/iast/source/test_sql_row.py::TestSqlRow: missing_feature
   tests/appsec/iast/source/test_uri.py::TestURI: missing_feature
   tests/appsec/iast/test_sampling_by_route_method_count.py:  # Created by easy win activation script
@@ -630,7 +630,7 @@ manifest:
   tests/appsec/iast/test_security_controls.py::TestSecurityControls:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.11.0.dev
+        *flask : v3.11.0.dev
   ? tests/appsec/iast/test_security_controls.py::TestSecurityControls::test_no_vulnerability_suppression_with_a_sanitizer_configured_for_an_overloaded_method_with_specific_signature
   : irrelevant (no overloaded methods with different signatures in python)
   tests/appsec/iast/test_vulnerability_schema.py::TestIastVulnerabilitySchema: v3.8.0.dev
@@ -638,23 +638,23 @@ manifest:
   tests/appsec/rasp/test_api10.py::Test_API10_downstream_request_tag:
     - weblog_declaration:
         "*": v3.18.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_downstream_ssrf_telemetry:
     - weblog_declaration:
         "*": v3.18.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_redirect: v4.3.0-dev
   tests/appsec/rasp/test_api10.py::Test_API10_redirect_status:
     - weblog_declaration:
         "*": v4.1.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_request_body: v4.5.0-rc1
   tests/appsec/rasp/test_api10.py::Test_API10_request_headers: v4.3.0-dev
   tests/appsec/rasp/test_api10.py::Test_API10_request_method:
     - weblog_declaration:
         "*": v3.14.0.rc
         fastapi: v3.15.0.dev (with requests support)
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_response_body: v4.5.0-rc1
   tests/appsec/rasp/test_api10.py::Test_API10_response_body_ignored_content_length_missing: missing_feature
   tests/appsec/rasp/test_api10.py::Test_API10_response_body_ignored_content_length_too_big: missing_feature
@@ -663,12 +663,12 @@ manifest:
     - weblog_declaration:
         "*": v3.14.0.rc
         fastapi: v3.15.0.dev (with requests support)
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_response_status:
     - weblog_declaration:
         "*": v3.14.0.rc
         fastapi: v3.15.0.dev (with requests support)
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_api10.py::Test_API10_without_downstream_body_analysis_using_max: v3.15.0
   tests/appsec/rasp/test_api10.py::Test_API10_without_downstream_body_analysis_using_sample_rate: v4.5.0-rc1
   tests/appsec/rasp/test_cmdi.py::Test_Cmdi_BodyJson: v2.20.0.dev
@@ -726,41 +726,41 @@ manifest:
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyJson:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyUrlEncoded:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_BodyXml:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Capability: v2.11.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Mandatory_SpanTags:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Optional_SpanTags:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Rules_Version: v2.16.0
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_StackTrace:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Telemetry_V2:
     - weblog_declaration:
         "*": v3.5.0.dev
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_UrlQuery:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v4.3.0-dev0 (with httpx support)
+        *django : v4.3.0-dev0 (with httpx support)
   tests/appsec/rasp/test_ssrf.py::Test_Ssrf_Waf_Version: v2.15.0
   tests/appsec/smoke_tests/test_apm_standalone.py: v4.6.0
   tests/appsec/test_agentic_onboarding.py::Test_AppsecAgenticOnboarding: v4.13.0rc1
@@ -801,23 +801,23 @@ manifest:
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events:
     - weblog_declaration:
         "*": v2.20.0.dev
-        *django: v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events::test_signup_local:
     - weblog_declaration:
         "*": irrelevant (No signup in frameworks except django)
-        *django: v3.7.0.dev (is v3.2.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v3.2.0 but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Anon:
     - weblog_declaration:
         "*": v2.20.0.dev
-        *django: v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Anon::test_signup_local:
     - weblog_declaration:
         "*": irrelevant (No signup in frameworks except django)
-        *django: v3.7.0.dev (is v3.2.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v3.2.0 but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_Blocking:
     - weblog_declaration:
         "*": v2.20.0.dev
-        *django: v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.20.0.dev but weblog use new SDK now)
   tests/appsec/test_automated_login_events.py::Test_V3_Login_Events_RC: v2.11.0
   tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_Custom_Rules: v4.2.0
   tests/appsec/test_automated_payment_events.py::Test_Automated_Payment_Events_Stripe_Default_Rules:
@@ -829,11 +829,11 @@ manifest:
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_Session_Blocking:
     - weblog_declaration:
         "*": v3.11.0.dev
-        *django: v3.3.0.dev
+        *django : v3.3.0.dev
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking:
     - weblog_declaration:
         "*": v3.0.0.rc
-        *django: v3.7.0.dev (is v3.0.0.rc but weblog use new SDK now)
+        *django : v3.7.0.dev (is v3.0.0.rc but weblog use new SDK now)
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Blocking::test_user_blocking_auto:
     - weblog_declaration:
         "*": irrelevant (no possible auto-instrumentation for python except on Django)
@@ -843,7 +843,7 @@ manifest:
   tests/appsec/test_automated_user_and_session_tracking.py::Test_Automated_User_Tracking:
     - weblog_declaration:
         "*": v3.1.0.dev
-        *django: v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
+        *django : v3.7.0.dev (is v3.1.0.dev but weblog use new SDK now)
   tests/appsec/test_blocking_addresses.py::Test_BlockingGraphqlResolvers: missing_feature
   tests/appsec/test_blocking_addresses.py::Test_Blocking_client_ip:
     - weblog_declaration:
@@ -856,7 +856,7 @@ manifest:
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_body:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_body_filenames: missing_feature
@@ -870,37 +870,37 @@ manifest:
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_cookies:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_headers:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_method:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_path_params:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.13
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_query:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Blocking_request_uri:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.15 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.15 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.15
   tests/appsec/test_blocking_addresses.py::Test_Blocking_response_headers:
@@ -918,13 +918,13 @@ manifest:
   tests/appsec/test_blocking_addresses.py::Test_Blocking_user_id:
     - weblog_declaration:
         "*": v1.16.1
-        *django: v3.7.0.dev (is v1.10 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10 but weblog use new SDK now)
         fastapi: v2.4.0
         flask-poc: v1.10
   tests/appsec/test_blocking_addresses.py::Test_Suspicious_Request_Blocking:
     - weblog_declaration:
         "*": v2.4.0
-        *django: v3.7.0.dev (is v2.4.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.4.0 but weblog use new SDK now)
   tests/appsec/test_client_ip.py::Test_StandardTagsClientIp: v1.5.0
   tests/appsec/test_conf.py::Test_ConfigurationVariables:
     - weblog_declaration:
@@ -937,17 +937,17 @@ manifest:
   tests/appsec/test_event_tracking.py::Test_CustomEvent:
     - weblog_declaration:
         "*": v1.10.0
-        *django: v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v1.10.0 but weblog use new SDK now)
   tests/appsec/test_event_tracking.py::Test_CustomEvent_Metrics: v3.10.0.dev
   tests/appsec/test_event_tracking.py::Test_UserLoginFailureEvent:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
   tests/appsec/test_event_tracking.py::Test_UserLoginFailureEvent_Metrics: v3.10.0.dev
   tests/appsec/test_event_tracking.py::Test_UserLoginSuccessEvent:
     - weblog_declaration:
         "*": v2.10.0
-        *django: v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.10.0 but weblog use new SDK now)
   tests/appsec/test_event_tracking.py::Test_UserLoginSuccessEvent_Metrics: v3.10.0.dev
   tests/appsec/test_event_tracking_v2.py::Test_UserLoginFailureEventV2_HeaderCollection_AppsecDisabled:
     - weblog_declaration:
@@ -1050,23 +1050,23 @@ manifest:
   tests/appsec/test_sca_reachability.py::Test_SCA_Reachability_CVE_After_Vulnerable_Call:
     - weblog_declaration:
         "*": irrelevant (endpoint only implemented in flask weblog)
-        *flask: v4.8.0.dev
+        *flask : v4.8.0.dev
   tests/appsec/test_sca_reachability.py::Test_SCA_Reachability_CVE_Registered_At_Load_Time:
     - weblog_declaration:
         "*": irrelevant (endpoint only implemented in flask weblog)
-        *flask: v4.8.0.dev
+        *flask : v4.8.0.dev
   tests/appsec/test_sca_reachability.py::Test_SCA_Reachability_Deduplication:
     - weblog_declaration:
         "*": irrelevant (endpoint only implemented in flask weblog)
-        *flask: v4.8.0.dev
+        *flask : v4.8.0.dev
   tests/appsec/test_sca_reachability.py::Test_SCA_Reachability_Dependencies_Have_Metadata:
     - weblog_declaration:
         "*": irrelevant (endpoint only implemented in flask weblog)
-        *flask: v4.8.0.dev
+        *flask : v4.8.0.dev
   tests/appsec/test_sca_reachability.py::Test_SCA_Reachability_First_Hit_Wins:
     - weblog_declaration:
         "*": irrelevant (endpoint only implemented in flask weblog)
-        *flask: v4.8.0.dev
+        *flask : v4.8.0.dev
   tests/appsec/test_service_activation_metric.py::TestServiceActivationEnvVarConfigurationMetric: v3.12.0.dev
   tests/appsec/test_service_activation_metric.py::TestServiceActivationEnvVarMetric: irrelevant (drop support in v3.12.0.dev)
   tests/appsec/test_service_activation_metric.py::TestServiceActivationRemoteConfigMetric: irrelevant (drop support in v3.12.0.dev)
@@ -1094,7 +1094,7 @@ manifest:
   tests/appsec/test_user_blocking_full_denylist.py::Test_UserBlocking_FullDenylist:
     - weblog_declaration:
         "*": v2.11.0
-        *django: v3.7.0.dev (is v2.11.0 but weblog use new SDK now)
+        *django : v3.7.0.dev (is v2.11.0 but weblog use new SDK now)
   tests/appsec/test_versions.py::Test_Events: v0.58.5
   tests/appsec/waf/test_addresses.py::Test_BodyJson:
     - weblog_declaration:
@@ -1110,7 +1110,7 @@ manifest:
         fastapi: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_Cookies:
     - weblog_declaration:
-        *django: v1.1.0
+        *django : v1.1.0
         fastapi: v2.4.0
         flask-poc: v1.4.0-rc1
         uds-flask: v1.4.0-rc1
@@ -1123,7 +1123,7 @@ manifest:
   tests/appsec/waf/test_addresses.py::Test_IoFsFileWrite: "irrelevant (Java-only address: server.io.fs.file_write)"
   tests/appsec/waf/test_addresses.py::Test_PathParams:
     - weblog_declaration:
-        *django: v1.1.0
+        *django : v1.1.0
         fastapi: v2.4.0
         flask-poc: v1.4.0-rc1
         uds-flask: v1.4.0-rc1
@@ -1272,20 +1272,20 @@ manifest:
   tests/debugger/test_debugger_code_origins.py::Test_Debugger_Code_Origins:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL::test_invalid_condition_dsl_probe_rejected: bug (DEBUG-5709)
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Runtime_Condition_Error:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.4.0
+        *flask : v3.4.0
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_firsthit: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_outofmemory: missing_feature (Implemented only for dotnet)
   tests/debugger/test_debugger_exception_replay.py::Test_Debugger_Exception_Replay::test_exception_replay_recursion_inlined: irrelevant (Test for specific bug in dotnet)
@@ -1293,7 +1293,7 @@ manifest:
   tests/debugger/test_debugger_expression_language.py::Test_Debugger_Expression_Language:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_guardrails.py::Test_Debugger_Capture_Timeout_Guardrail: missing_feature (Configurable capture timeout is not available)
   tests/debugger/test_debugger_guardrails.py::Test_Debugger_Evaluation_Timeout_Line_Probe: irrelevant (Line-probe variant is only used by Node.js and Ruby)
   tests/debugger/test_debugger_guardrails.py::Test_Debugger_Evaluation_Timeout_Method_Probe: missing_feature (Debugger evaluation timeout guardrail not implemented yet)
@@ -1301,22 +1301,22 @@ manifest:
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.5.0
+        *flask : v3.5.0
     - declaration: missing_feature
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Code_Origin_Default_On:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v4.9.0-dev
+        *flask : v4.9.0-dev
     - component_version: 4.13.1
       declaration: flaky (APMRP-360)
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.5.0
+        *flask : v3.5.0
   tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.5.0
+        *flask : v3.5.0
   ? tests/debugger/test_debugger_inproduct_enablement.py::Test_Debugger_InProduct_Enablement_Exception_Replay::test_inproduct_enablement_exception_replay
   : - declaration: bug (DEBUG-5579)
       component_version: <4.9.0
@@ -1325,7 +1325,7 @@ manifest:
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction::test_pii_redaction_method_full:
     - declaration: bug (DEBUG-3127)
       component_version: 2.16.0
@@ -1334,7 +1334,7 @@ manifest:
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v3.7.0
+        *flask : v3.7.0
   tests/debugger/test_debugger_pii.py::Test_Debugger_PII_Redaction_Excluded_Identifiers::test_pii_redaction_excluded_identifiers:  # Modified by easy win activation script
     - declaration: bug (DEBUG-3746)
       component_version: <4.3.1
@@ -1342,13 +1342,13 @@ manifest:
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_log_line_capture_expression_budgets: bug (DEBUG-5743)
   tests/debugger/test_debugger_probe_budgets.py::Test_Debugger_Probe_Budgets::test_span_probe_expression_budgets: irrelevant (Python emits evaluation errors as span tags, not error snapshots to the debugger endpoint)
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots::test_log_line_snapshot_debug_track:
     - declaration: missing_feature (Python 3.15.0 introduced the track change)
       component_version: <3.15.0
@@ -1364,19 +1364,19 @@ manifest:
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Line_Probe_Snaphots_With_SCM:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Method_Probe_Snaphots:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_probe_snapshot.py::Test_Debugger_Method_Probe_Snaphots_With_SCM:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Line_Probe_Statuses:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
     - declaration: bug (DEBUG-3127)
       component_version: 2.16.0
     - declaration: bug (DEBUG-3127)
@@ -1392,7 +1392,7 @@ manifest:
   tests/debugger/test_debugger_probe_status.py::Test_Debugger_Method_Probe_Statuses:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
     - declaration: bug (DEBUG-3127)
       component_version: 2.16.0
     - declaration: bug (DEBUG-3127)
@@ -1400,7 +1400,7 @@ manifest:
   tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb:
     - weblog_declaration:
         "*": missing_feature
-        *flask: v2.11.0
+        *flask : v2.11.0
   # TODO(andrei): un-skip when v4.10.0 is released
   tests/debugger/test_debugger_symdb.py::Test_Debugger_SymDb::test_event_metadata:  # TODO: a lower version might be supported
     - declaration: missing_feature (extended event schema not yet shipped)
@@ -1682,7 +1682,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Aiomysql:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Aiomysql::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
@@ -1690,7 +1690,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_MysqlConnector:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_MysqlConnector::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
@@ -1698,7 +1698,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Mysqldb:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Mysqldb::test_dbm_comment:
     - declaration: flaky (APMAPI-724)
     - weblog_declaration:
@@ -1718,7 +1718,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Pymysql:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Batch_Python_Pymysql::test_dbm_comment:
     - declaration: flaky (APMAPI-724)
     - weblog_declaration:
@@ -1731,7 +1731,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Aiomysql:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Aiomysql::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
@@ -1739,7 +1739,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Asyncpg:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Asyncpg::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
@@ -1747,7 +1747,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_MysqlConnector:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_MysqlConnector::test_dbm_comment:
     - weblog_declaration:
         flask-poc: bug (APMAPI-1058)
@@ -1755,7 +1755,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Mysqldb::test_dbm_comment:
     - declaration: flaky (APMAPI-724)
     - weblog_declaration:
@@ -1774,7 +1774,7 @@ manifest:
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql:
     - weblog_declaration:
         "*": missing_feature (Missing on weblog)
-        *flask: v2.9.0
+        *flask : v2.9.0
   tests/integrations/test_dbm.py::Test_Dbm_Comment_Python_Pymysql::test_dbm_comment:
     - declaration: flaky (APMAPI-724)
     - weblog_declaration:

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -116,8 +116,6 @@ patterns:
         scenario_groups: null
     .shellcheckrc:
         scenario_groups: null
-    .vscode/settings.json:
-        scenario_groups: null
     .yamlfmt:
         scenario_groups: null
     .yamllint:

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -116,6 +116,8 @@ patterns:
         scenario_groups: null
     .shellcheckrc:
         scenario_groups: null
+    .vscode/settings.json:
+        scenario_groups: null
     .yamlfmt:
         scenario_groups: null
     .yamllint:


### PR DESCRIPTION
## Motivation

The `ymlfmt` version we were using had a bug : https://github.com/google/yamlfmt/issues/242

Long story short, this is a valid yml : 

```yml
values:
  domain: &domain-ext www.example.com

data:
  *domain : value
```

It resolve to 

```yml
values:
  domain: www.example.com

data:
  www.example.com : value
```

`domain-ext` is a ref, and can be used in keys. Though, `:` is a valid char for ref names (yml, go to hell). To handle this, a space must be inserted before the `:` when using this ref : `  *domain : value`. 

If one uses `  *domain: value`, then it's not a valid yml anymore, as the ref name `*domain:` does not exists (and the syntax is not even valid).

The `ymlfmt@0.16.0` we were using removes those spaces. Turns out it broke nothing, as the yml parser we're using does not consider `:` as a valid char for ref, and parses the data in success. But any other parser/linter are not happy this this.

It has been fix in `0.17.0` : https://github.com/google/yamlfmt/pull/247 


## Changes

* Use `0.21.0` for `ymlfmt`
* ~side change : ignore changes on `.vscode/settings.json`~
* side change : check `ymlfmt` version at execution

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
