### PR TITLE
EX-3426: add serial ID exposure event system tests (gated as missing_feature)

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -752,6 +752,9 @@ manifest:
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py: v3.36.0
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3416)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3416)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3416)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py: v3.44.0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1142,6 +1142,9 @@ manifest:
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3414)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3414)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3414)
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation::test_ffe_evp_flagevaluation_degradation: flaky (FFL-2676)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2784)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3355,6 +3355,9 @@ manifest:
         "*": irrelevant
         spring-boot: v1.56.0
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_EXP_5_Missing_Targeting_Key: bug (FFL-1729)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3415)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3415)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3415)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1800,6 +1800,9 @@ manifest:
         "*": incomplete_test_app
         express4: *ref_5_77_0
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_EXP_5_Missing_Targeting_Key: bug (FFL-1730)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3412)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3412)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3412)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1240,7 +1240,10 @@ manifest:
         "*": v1.21.0-dev
         laravel11x: incomplete_test_app
         symfony7x: incomplete_test_app
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3425)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3425)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Events::test_ffe_multiple_remote_config_files: flaky (FFL-2676)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3425)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: bug (FFL-2676)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: bug (FFL-2676)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1444,6 +1444,9 @@ manifest:
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py: v4.2.0-dev
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3413)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3413)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3413)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py: v4.7.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2032,6 +2032,9 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: v2.23.0-dev
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3417)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3417)
+  tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3417)
   tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:

--- a/tests/ffe/test_exposures_datadog_agent.py
+++ b/tests/ffe/test_exposures_datadog_agent.py
@@ -726,6 +726,205 @@ class Test_FFE_Exposure_Caching_Variant_Cycle:
 
 @scenarios.feature_flagging_and_experimentation
 @features.feature_flags_exposures
+class Test_FFE_Exposure_Serial_Id:
+    """Test that the split serial id is reported on the exposure event.
+
+    The compiler rewrites a holdout into an ordinary allocation before an SDK receives the
+    configuration, so an exposure records no holdout. The serial id of the split the subject
+    landed in is the only link back to it. A split without a serial id is normal, and the
+    field must then be absent from the event rather than sent as null or zero.
+
+    Both flags are asserted in one test. An SDK that never sends the field would satisfy the
+    absent case on its own, so the two only discriminate together.
+    """
+
+    def setup_ffe_exposure_serial_id(self) -> None:
+        """Evaluate one flag whose split carries a serial id and one whose split does not."""
+        self.flag_with = "serial-id-present-flag"
+        self.flag_without = "serial-id-absent-flag"
+        self.targeting_key = "serial-id-user"
+
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/ffe-serial-id-present/config",
+            make_ufc_fixture(self.flag_with, serial_id=340132),
+        ).apply()
+
+        self.response_with = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_with,
+                "variationType": "STRING",
+                "defaultValue": "default",
+                "targetingKey": self.targeting_key,
+                "attributes": {},
+            },
+        )
+
+        rc.tracer_rc_state.set_config(
+            f"{RC_PATH}/ffe-serial-id-absent/config",
+            make_ufc_fixture(self.flag_without),
+        ).apply()
+
+        self.response_without = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_without,
+                "variationType": "STRING",
+                "defaultValue": "default",
+                "targetingKey": self.targeting_key,
+                "attributes": {},
+            },
+        )
+
+    def test_ffe_exposure_serial_id(self) -> None:
+        """Test that serial_id carries the split value, and is omitted when the split has none."""
+        assert self.response_with.status_code == 200, f"Flag evaluation failed: {self.response_with.text}"
+        assert self.response_without.status_code == 200, f"Flag evaluation failed: {self.response_without.text}"
+
+        wait_for_exposure_event({self.flag_with, self.flag_without}, self.targeting_key)
+
+        events_with = find_exposure_events(self.flag_with, self.targeting_key)
+        assert len(events_with) == 1, (
+            f"Expected exactly 1 exposure event for {self.flag_with}, found {len(events_with)}"
+        )
+        assert "serial_id" in events_with[0], f"Exposure event is missing 'serial_id': {events_with[0]}"
+        assert events_with[0]["serial_id"] == 340132, f"Expected serial_id 340132, got {events_with[0]['serial_id']!r}"
+
+        events_without = find_exposure_events(self.flag_without, self.targeting_key)
+        assert len(events_without) == 1, (
+            f"Expected exactly 1 exposure event for {self.flag_without}, found {len(events_without)}"
+        )
+        assert "serial_id" not in events_without[0], (
+            f"Expected 'serial_id' to be absent when the split carries none, got {events_without[0]!r}"
+        )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_exposures
+class Test_FFE_Exposure_Caching_Serial_Id_Appears:
+    """Test that a serial id appearing on an unchanged assignment generates a new exposure.
+
+    A split can gain a serial id on a later configuration refresh while the allocation and the
+    variant stay the same. That is a new assignment and must be reported. An exposure cache
+    keyed on (allocation_key, variant) alone suppresses it, which loses the only link back to
+    the holdout.
+    """
+
+    def setup_ffe_exposure_caching_serial_id_appears(self) -> None:
+        """Set up an FFE exposure test where the serial id appears on a refresh."""
+        config_id = "ffe-serial-id-appears-test"
+        self.flag_key = "serial-id-appears-flag"
+        self.targeting_key = "serial-id-appears-user"
+
+        # Step 1: same allocation and variant, no serial id
+        rc.tracer_rc_state.reset().set_config(
+            f"{RC_PATH}/{config_id}/config",
+            make_ufc_fixture(self.flag_key, "variant-a", allocation_key="default-allocation"),
+        ).apply()
+
+        self.response_1 = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_key,
+                "variationType": "STRING",
+                "defaultValue": "default",
+                "targetingKey": self.targeting_key,
+                "attributes": {},
+            },
+        )
+
+        # Step 2: same allocation and variant, serial id now present
+        rc.tracer_rc_state.set_config(
+            f"{RC_PATH}/{config_id}/config",
+            make_ufc_fixture(self.flag_key, "variant-a", allocation_key="default-allocation", serial_id=340132),
+        ).apply()
+
+        self.response_2 = weblog.post(
+            "/ffe",
+            json={
+                "flag": self.flag_key,
+                "variationType": "STRING",
+                "defaultValue": "default",
+                "targetingKey": self.targeting_key,
+                "attributes": {},
+            },
+        )
+
+    def test_ffe_exposure_caching_serial_id_appears(self) -> None:
+        """Test that no serial id then a serial id generates 2 exposures."""
+        assert self.response_1.status_code == 200, f"Request 1 failed: {self.response_1.text}"
+        assert self.response_2.status_code == 200, f"Request 2 failed: {self.response_2.text}"
+
+        exposure_count = wait_for_min_exposure_count(self.flag_key, 2, self.targeting_key)
+
+        assert exposure_count == 2, (
+            f"Expected exactly 2 exposure events for subject '{self.targeting_key}' "
+            f"(no serial id, then serial id 340132, with the allocation and variant unchanged), "
+            f"but found {exposure_count} events"
+        )
+
+        events = find_exposure_events(self.flag_key, self.targeting_key)
+        assert "serial_id" not in events[0], f"First exposure should carry no serial id, got {events[0]!r}"
+        assert events[1].get("serial_id") == 340132, f"Second exposure should carry serial id 340132, got {events[1]!r}"
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_exposures
+class Test_FFE_Exposure_Caching_Serial_Id_Cycle:
+    """Test that cycling through serial ids generates an exposure for each change.
+
+    When a subject keeps the same allocation and variant but the serial id goes 340132, then
+    340133, then 340132 again, each change is a new assignment and generates a new exposure
+    event (3 total). Returning to a previous serial id still generates one, the same way the
+    allocation and variant cycles behave.
+    """
+
+    def setup_ffe_exposure_caching_serial_id_cycle(self) -> None:
+        """Set up an FFE exposure test that cycles through serial ids."""
+        config_id = "ffe-serial-id-cycle-test"
+        self.flag_key = "serial-id-cycle-flag"
+        self.targeting_key = "serial-id-cycle-user"
+
+        self.responses = []
+        for step, serial_id in enumerate((340132, 340133, 340132)):
+            state = rc.tracer_rc_state.reset() if step == 0 else rc.tracer_rc_state
+            state.set_config(
+                f"{RC_PATH}/{config_id}/config",
+                make_ufc_fixture(self.flag_key, "variant-a", allocation_key="default-allocation", serial_id=serial_id),
+            ).apply()
+
+            self.responses.append(
+                weblog.post(
+                    "/ffe",
+                    json={
+                        "flag": self.flag_key,
+                        "variationType": "STRING",
+                        "defaultValue": "default",
+                        "targetingKey": self.targeting_key,
+                        "attributes": {},
+                    },
+                )
+            )
+
+    def test_ffe_exposure_caching_serial_id_cycle(self) -> None:
+        """Test that 340132 -> 340133 -> 340132 generates 3 exposures."""
+        for step, response in enumerate(self.responses, start=1):
+            assert response.status_code == 200, f"Request {step} failed: {response.text}"
+
+        exposure_count = wait_for_min_exposure_count(self.flag_key, 3, self.targeting_key)
+
+        assert exposure_count == 3, (
+            f"Expected exactly 3 exposure events for subject '{self.targeting_key}' "
+            f"(serial id 340132 -> 340133 -> 340132, with the allocation and variant unchanged), "
+            f"but found {exposure_count} events"
+        )
+
+        serial_ids = [event.get("serial_id") for event in find_exposure_events(self.flag_key, self.targeting_key)]
+        assert serial_ids == [340132, 340133, 340132], f"Expected serial ids [340132, 340133, 340132], got {serial_ids}"
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_exposures
 class Test_FFE_Exposure_Missing_Flag:
     """Test that evaluating a missing/non-existent flag does not generate exposure events.
 

--- a/tests/ffe/utils/fixtures.py
+++ b/tests/ffe/utils/fixtures.py
@@ -24,8 +24,13 @@ def make_ufc_fixture(
     allocation_key: str = "default-allocation",
     variation_values: dict[str, VariationValue] | None = None,
     observe_full_evaluation_data: bool | None = None,
+    serial_id: int | None = None,
 ) -> JSON:
     values = variation_values or DEFAULT_VARIATION_VALUES[variation_type]
+
+    split: JSON = {"variationKey": variant_key, "shards": []}
+    if serial_id is not None:
+        split["serialId"] = serial_id
 
     ufc: JSON = {
         "createdAt": "2024-04-17T19:40:53.716Z",
@@ -41,7 +46,7 @@ def make_ufc_fixture(
                     {
                         "key": allocation_key,
                         "rules": [],
-                        "splits": [{"variationKey": variant_key, "shards": []}],
+                        "splits": [split],
                         "doLog": True,
                     }
                 ],
@@ -57,10 +62,12 @@ def make_exposure_ufc_fixture(
     flag_key: str,
     variant_key: str = "variant-a",
     allocation_key: str = "default-allocation",
+    serial_id: int | None = None,
 ) -> JSON:
     return make_ufc_fixture(
         flag_key,
         variant_key,
         allocation_key=allocation_key,
         variation_values={"variant-a": "value-a", "variant-b": "value-b"},
+        serial_id=serial_id,
     )


### PR DESCRIPTION
## Motivation

[EX-3426](https://datadoghq.atlassian.net/browse/EX-3426) · epic [EX-3048](https://datadoghq.atlassian.net/browse/EX-3048)

The compiler rewrites a holdout into an ordinary allocation before an SDK receives the flag configuration, so an exposure event records no holdout. The serial id of the split the subject landed in is the only link back to it. Every SDK is adding a top-level `serial_id` to the exposure event, and these tests pin that contract in one place instead of once per language.

Prior art: #7316 uses the same shape for `observeFullEvaluationData`.

## Changes

`make_ufc_fixture` and `make_exposure_ufc_fixture` take an optional `serial_id`. A default of `None` omits the key, so existing tests are unchanged. The gate is a `None` test, not a truthiness test, because serial ids start at `0` for each organization and `0` is a valid value.

Three classes in `tests/ffe/test_exposures_datadog_agent.py`:

| Class | Contract |
|---|---|
| `Test_FFE_Exposure_Serial_Id` | the exact value reaches the event, and the key is absent, not `null`, when the split has none |
| `Test_FFE_Exposure_Caching_Serial_Id_Appears` | a serial id that appears on a refresh reports a new exposure, with the allocation and variant unchanged |
| `Test_FFE_Exposure_Caching_Serial_Id_Cycle` | `340132 → 340133 → 340132` reports three exposures |

The present and absent cases are one test, not two. An SDK that never sends the field satisfies the absent case on its own, so the two only discriminate together. Two separate tests report `XPASS` on every SDK that has not implemented the field.

The two caching classes follow `Test_FFE_Exposure_Caching_Allocation_Cycle`. They cover a fault that three SDKs had: a cache that stores `(allocation_key, variant)` hides a serial id that appears or changes. This is a usual event, not a rare one, because `ffe.ufc.vac_miss` is more than zero at all times in production and those misses resolve on a later configuration refresh.

Every SDK is declared `missing_feature`. Each one enables the tests when it ships the field.

## Validation

Run against `golang`, weblog `net-http`:

```
released dd-trace-go            3 xfailed
dd-trace-go DataDog/dd-trace-go#5214   3 passed in 52.91s
```

The second run used a local checkout in `binaries/dd-trace-go`. `./format.sh --check` is clean.

Only `tests/` and `manifests/` are modified.


[EX-3426]: https://datadoghq.atlassian.net/browse/EX-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EX-3048]: https://datadoghq.atlassian.net/browse/EX-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ