### PR TITLE
Add an option to allow failures in the e2e gitlab pipeline

### DIFF
--- a/tests/test_the_test/test_gitlab_pipeline_structure.py
+++ b/tests/test_the_test/test_gitlab_pipeline_structure.py
@@ -20,6 +20,18 @@ MINIMAL_PARAMS = {
 
 
 @scenarios.test_the_test
+def test_gitlab_component_allow_failure_input_is_wired() -> None:
+    spec, pipeline = yaml.safe_load_all(Path("utils/ci/gitlab/main.yml").read_text())
+
+    input_definition = spec["spec"]["inputs"]["allow_failure"]
+    assert input_definition["type"] == "boolean"
+    assert input_definition["default"] is False
+
+    for job_name in (".system_tests_param_base", "system_tests_build_pipeline", ".run_test_pipeline_base"):
+        assert pipeline[job_name]["allow_failure"] == "$[[ inputs.allow_failure ]]"
+
+
+@scenarios.test_the_test
 def test_generated_chunk_jobs_have_required_keys(tmp_path: Path):
     (tmp_path / "params_python.json").write_text(json.dumps(MINIMAL_PARAMS))
     out = tmp_path / "out"

--- a/utils/ci/gitlab/main.yml
+++ b/utils/ci/gitlab/main.yml
@@ -38,6 +38,10 @@ spec:
       description: "Push test results to Datadog Test Optimization"
       type: boolean
       default: false
+    allow_failure:
+      description: "Allow system-tests e2e jobs to fail without failing the parent pipeline"
+      type: boolean
+      default: false
     auto_cancel_on_new_commit:
       description: "Auto-cancel strategy when a new commit is pushed (interruptible, conservative, disabled)"
       default: "interruptible"
@@ -80,6 +84,7 @@ variables:
 
 .system_tests_param_base:
   image: $CI_IMAGE
+  allow_failure: $[[ inputs.allow_failure ]]
   tags:
     - arch:amd64
   id_tokens:
@@ -95,6 +100,7 @@ variables:
 
 system_tests_build_pipeline:
   extends: .system_tests_base
+  allow_failure: $[[ inputs.allow_failure ]]
   tags:
     - arch:amd64
   id_tokens:
@@ -150,6 +156,7 @@ system_tests_build_pipeline:
 
 .run_test_pipeline_base:
   interruptible: true
+  allow_failure: $[[ inputs.allow_failure ]]
   stage: $[[ inputs.stage ]]
   rules:
     - if: $[[ inputs.condition ]]


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
