### PR TITLE
Validate Java OpenFeature standalone and SSI modes

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -323,6 +323,12 @@ jobs:
     - name: Run FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS"')
       run: ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS
+    - name: Run FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE scenario
+      if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE"')
+      run: ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE
+    - name: Run FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI scenario
+      if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI"')
+      run: ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI
     - name: Run FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT"')
       run: ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3364,6 +3364,8 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.63.0
+  tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_SSI: v1.66.0-SNAPSHOT
+  tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_Standalone: v1.66.0-SNAPSHOT
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integration_frameworks/llm/openai/test_openai_ai_guard.py: missing_feature (APPSEC-68977, AI Guard/OpenAI integration not yet wired into INTEGRATION_FRAMEWORKS)
   tests/integration_frameworks/llm/openai/test_openai_apm.py: v1.61.0

--- a/tests/ffe/test_java_openfeature_deployment_modes.py
+++ b/tests/ffe/test_java_openfeature_deployment_modes.py
@@ -1,0 +1,49 @@
+"""Validate Java OpenFeature standalone and SSI deployment shapes."""
+
+import json
+
+from utils import context, features, scenarios, weblog
+from utils._context._scenarios.agentless_endtoend import JavaOpenFeatureAgentlessEndToEndScenario
+from utils.mocked_backend.ffe import CONFIG_PATH
+
+
+class JavaOpenFeatureDeploymentContract:
+    deployment_mode: str
+
+    def setup_deployment_mode(self) -> None:
+        self.response = weblog.post(
+            "/ffe",
+            json={
+                "flag": "empty-targeting-key-flag",
+                "variationType": "STRING",
+                "defaultValue": "default",
+                "targetingKey": "java-openfeature-user",
+                "attributes": {},
+            },
+        )
+
+    def test_deployment_mode(self) -> None:
+        assert self.response.status_code == 200, f"Flag evaluation failed: {self.response.text}"
+        result = json.loads(self.response.text)
+        assert result["value"] == "on-value"
+        assert result["provider"] == "datadog-openfeature-provider"
+        assert result["deploymentMode"] == self.deployment_mode
+
+        scenario = context.scenario
+        assert isinstance(scenario, JavaOpenFeatureAgentlessEndToEndScenario)
+        backend_status = scenario.mock_backend_status()
+        assert backend_status is not None
+        assert backend_status["requests_total"] >= 1
+        assert backend_status["last_path"] == CONFIG_PATH
+
+
+@scenarios.feature_flagging_and_experimentation_java_standalone
+@features.feature_flags_agentless
+class Test_FFE_Java_OpenFeature_Standalone(JavaOpenFeatureDeploymentContract):
+    deployment_mode = "standalone"
+
+
+@scenarios.feature_flagging_and_experimentation_java_ssi
+@features.feature_flags_agentless
+class Test_FFE_Java_OpenFeature_SSI(JavaOpenFeatureDeploymentContract):
+    deployment_mode = "ssi"

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -3375,6 +3375,12 @@
   "tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar::test_exposure_egress": [
     "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS"
   ],
+  "tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_SSI::test_deployment_mode": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI"
+  ],
+  "tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_Standalone::test_deployment_mode": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE"
+  ],
   "tests/integrations/test_cassandra.py::Test_Cassandra::test_main": [
     "INTEGRATIONS"
   ],

--- a/tests/test_the_test/test_ci_orchestrator.py
+++ b/tests/test_the_test/test_ci_orchestrator.py
@@ -52,6 +52,23 @@ def test_ipv6_is_not_supported_for_uds_weblogs():
 
 
 @scenarios.test_the_test
+def test_java_openfeature_deployment_scenarios_are_spring_boot_only():
+    java_openfeature_scenarios = (
+        scenarios.feature_flagging_and_experimentation_java_standalone,
+        scenarios.feature_flagging_and_experimentation_java_ssi,
+    )
+
+    for scenario in java_openfeature_scenarios:
+        supported_targets = [
+            (library, weblog.name)
+            for library in sorted(COMPONENT_GROUPS.all)
+            for weblog in WeblogMetaData.load(library)
+            if weblog.support_scenario(scenario.name, scenario.weblog_categories)
+        ]
+        assert supported_targets == [("java", "spring-boot")]
+
+
+@scenarios.test_the_test
 def test_get_endtoend_definitions_empty_scenario_map():
     # Regression: previously raised KeyError when "endtoend" or "parametric" keys were absent
     defs = get_endtoend_definitions("ruby", {}, [], "dev", 200000, 256, "123", "")
@@ -205,6 +222,12 @@ def _is_supported_legacy(weblog: WeblogMetaData, scenario: Scenario, _ci_environ
 
     library = weblog.library
     weblog_name = weblog.name
+
+    if scenario.name in (
+        "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE",
+        "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI",
+    ):
+        return (library, weblog_name) == ("java", "spring-boot")
 
     if library == "c":
         return scenario.name in ("DEFAULT", "IPV6", "SAMPLING")

--- a/tests/test_the_test/test_group_rules.py
+++ b/tests/test_the_test/test_group_rules.py
@@ -37,11 +37,24 @@ def test_tracer_release():
         assert scenario_groups.end_to_end not in exposure_scenario.scenario_groups
         assert scenario_groups.tracer_release not in exposure_scenario.scenario_groups
 
+    java_openfeature_scenarios = [
+        scenarios.feature_flagging_and_experimentation_java_standalone,
+        scenarios.feature_flagging_and_experimentation_java_ssi,
+    ]
+    for java_openfeature_scenario in java_openfeature_scenarios:
+        assert java_openfeature_scenario.include_agent is False
+        assert java_openfeature_scenario.use_proxy is False
+        assert scenario_groups.ffe in java_openfeature_scenario.scenario_groups
+        assert scenario_groups.all not in java_openfeature_scenario.scenario_groups
+        assert scenario_groups.end_to_end not in java_openfeature_scenario.scenario_groups
+        assert scenario_groups.tracer_release not in java_openfeature_scenario.scenario_groups
+
     not_in_tracer_release_group = [
         # list of scenario that will never be part of tracer release
         scenarios.fuzzer,
         dormant_agentless_scenario,
         *agentless_exposure_scenarios,
+        *java_openfeature_scenarios,
         scenarios.mock_the_test,
         scenarios.mock_the_test_2,
         scenarios.test_the_test,

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -7,7 +7,7 @@ from utils.tools import update_environ_with_local_env
 from .aws_lambda import LambdaScenario
 from .core import Scenario, scenario_groups
 from .default import DefaultScenario
-from .agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from .agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario, JavaOpenFeatureAgentlessEndToEndScenario
 from .endtoend import (
     DockerScenario,
     DdTraceEndToEndScenario,
@@ -761,6 +761,18 @@ class _Scenarios:
 
     feature_flagging_and_experimentation_agentless = FeatureFlaggingAgentlessEndToEndScenario(
         "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS"
+    )
+
+    feature_flagging_and_experimentation_java_standalone = JavaOpenFeatureAgentlessEndToEndScenario(
+        "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE",
+        deployment_mode="standalone",
+        doc="Validate the standalone dd-openfeature runtime without a Java agent.",
+    )
+
+    feature_flagging_and_experimentation_java_ssi = JavaOpenFeatureAgentlessEndToEndScenario(
+        "FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI",
+        deployment_mode="ssi",
+        doc="Validate Java agent injection into an application that only bundles the OpenFeature SDK.",
     )
 
     feature_flagging_and_experimentation_agentless_direct = FeatureFlaggingAgentlessEndToEndScenario(

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -232,3 +232,23 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         )
         for interface in telemetry_interfaces:
             interface.load_data_from_logs()
+
+
+class JavaOpenFeatureAgentlessEndToEndScenario(FeatureFlaggingAgentlessEndToEndScenario):
+    """Java-only FFE scenario for a specific OpenFeature deployment shape."""
+
+    def __init__(self, name: str, *, deployment_mode: Literal["standalone", "ssi"], doc: str) -> None:
+        super().__init__(
+            name,
+            doc=doc,
+            weblog_env={
+                "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE": "agentless",
+                "SYSTEM_TESTS_JAVA_OPENFEATURE_MODE": deployment_mode,
+            },
+        )
+        self.deployment_mode = deployment_mode
+
+    def configure(self, config: pytest.Config) -> None:
+        if config.option.library != "java":
+            pytest.exit(f"{self.name} supports only the java library", 1)
+        super().configure(config)

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -247,8 +247,7 @@ class JavaOpenFeatureAgentlessEndToEndScenario(FeatureFlaggingAgentlessEndToEndS
             },
         )
         self.deployment_mode = deployment_mode
-
-    def configure(self, config: pytest.Config) -> None:
-        if config.option.library != "java":
-            pytest.exit(f"{self.name} supports only the java library", 1)
-        super().configure(config)
+        # These deployment shapes are implemented only by the Java spring-boot weblog.
+        # Keep them out of the generic dd_trace category; weblog metadata opts in the
+        # supported target explicitly.
+        self.weblog_categories = []

--- a/utils/build/docker/java/app.sh
+++ b/utils/build/docker/java/app.sh
@@ -6,4 +6,15 @@ if [ "${INCLUDE_OTEL_DROP_IN:-}" = "true" ]; then
   JAVA_OPTS="${JAVA_OPTS:-} -Ddd.trace.otel.enabled=true -Dotel.javaagent.extensions=/app/opentelemetry-javaagent-r2dbc.jar"
 fi
 
-exec java -Xmx362m ${JAVA_OPTS:-} -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}
+case "${SYSTEM_TESTS_JAVA_OPENFEATURE_MODE:-explicit}" in
+  standalone)
+    exec java -Xmx362m ${JAVA_OPTS:-} -jar /app/app.jar ${APP_EXTRA_ARGS:-}
+    ;;
+  ssi)
+    exec java -Xmx362m ${JAVA_OPTS:-} -Ddd.trace.enabled=false \
+      -javaagent:/app/dd-java-agent.jar -jar /app/app-ssi.jar ${APP_EXTRA_ARGS:-}
+    ;;
+  *)
+    exec java -Xmx362m ${JAVA_OPTS:-} -javaagent:/app/dd-java-agent.jar -jar /app/app.jar ${APP_EXTRA_ARGS:-}
+    ;;
+esac

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -13,6 +13,11 @@ COPY ./utils/build/docker/java/spring-boot/src ./src
 COPY ./utils/build/docker/java/install_*.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh -Dmaven.repo.local=/maven
 RUN mvn -Dmaven.repo.local=/maven package
+RUN cp /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app-explicit.jar
+RUN jar tf /app/app-explicit.jar | grep -q '^BOOT-INF/lib/dd-openfeature-.*\.jar$'
+RUN mvn -Dmaven.repo.local=/maven -Ptomcat,openfeature-ssi clean package
+RUN cp /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app-ssi.jar
+RUN ! jar tf /app/app-ssi.jar | grep -q '^BOOT-INF/lib/dd-openfeature-.*\.jar$'
 
 RUN /binaries/install_drop_in.sh
 
@@ -21,7 +26,8 @@ FROM eclipse-temurin:11-jre
 WORKDIR /app
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
 
-COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar
+COPY --from=build /app/app-explicit.jar /app/app.jar
+COPY --from=build /app/app-ssi.jar /app/app-ssi.jar
 COPY --from=build /dd-tracer/opentelemetry-javaagent-r2dbc.jar .
 COPY --from=build /dd-tracer/dd-java-agent.jar .
 

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -51,11 +51,6 @@
             <version>${dd-trace-api.version}</version>
         </dependency>
         <dependency>
-            <groupId>dev.openfeature</groupId>
-            <artifactId>sdk</artifactId>
-            <version>1.20.2</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
             <version>1.41.0</version>
@@ -251,7 +246,7 @@
         <dependency>
             <groupId>dev.openfeature</groupId>
             <artifactId>sdk</artifactId>
-            <version>1.18.2</version>
+            <version>1.20.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.junrar</groupId>

--- a/utils/build/docker/java/spring-boot/pom.xml
+++ b/utils/build/docker/java/spring-boot/pom.xml
@@ -51,9 +51,9 @@
             <version>${dd-trace-api.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.datadoghq</groupId>
-            <artifactId>dd-openfeature</artifactId>
-            <version>${dd-openfeature.version}</version>
+            <groupId>dev.openfeature</groupId>
+            <artifactId>sdk</artifactId>
+            <version>1.20.2</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -463,6 +463,22 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>datadog-openfeature-provider</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.datadoghq</groupId>
+                    <artifactId>dd-openfeature</artifactId>
+                    <version>${dd-openfeature.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>openfeature-ssi</id>
         </profile>
     </profiles>
 

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -179,7 +179,14 @@ public class App {
             }
             version = line;
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Can't get version");
+            try (Scanner scanner = new Scanner(new File("SYSTEM_TESTS_LIBRARY_VERSION"), StandardCharsets.ISO_8859_1.name())) {
+                if (!scanner.hasNextLine()) {
+                    throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Can't get version");
+                }
+                version = scanner.nextLine();
+            } catch (Exception fallbackException) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Can't get version");
+            }
         }
 
         Map<String, String> library = new HashMap<>();

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/featureflag/FeatureFlagEvaluatorController.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/featureflag/FeatureFlagEvaluatorController.java
@@ -2,7 +2,6 @@ package com.datadoghq.system_tests.springboot.featureflag;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import datadog.trace.api.openfeature.Provider;
 import dev.openfeature.sdk.Client;
 import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.FeatureProvider;
@@ -26,9 +25,13 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @RestController
 public class FeatureFlagEvaluatorController {
+
+    private static final String DEPLOYMENT_MODE = System.getenv().getOrDefault("SYSTEM_TESTS_JAVA_OPENFEATURE_MODE", "explicit");
+    private static volatile String providerName = "uninitialized";
 
     @Configuration
     public static class FeatureFlagEvaluatorConfig {
@@ -44,7 +47,9 @@ public class FeatureFlagEvaluatorController {
                             || Boolean.parseBoolean(System.getenv("DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"));
             final FeatureProvider provider;
             if (featureFlaggingConfigured) {
-                provider = new Provider();
+                provider = "ssi".equalsIgnoreCase(DEPLOYMENT_MODE)
+                        ? api.getProvider()
+                        : createDatadogProvider();
             } else {
                 provider = new NoOpProvider() {
                     @Override
@@ -53,8 +58,39 @@ public class FeatureFlagEvaluatorController {
                     }
                 };
             }
-            api.setProviderAndWait(provider);
-            return api.getClient();
+            if (!"ssi".equalsIgnoreCase(DEPLOYMENT_MODE)) {
+                api.setProviderAndWait(provider);
+            }
+            providerName = api.getProviderMetadata().getName();
+            final Client client = api.getClient();
+            if ("ssi".equalsIgnoreCase(DEPLOYMENT_MODE)) {
+                waitForInjectedProvider(client);
+            }
+            return client;
+        }
+
+        private static void waitForInjectedProvider(final Client client) {
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (client.getProviderState() == ProviderState.NOT_READY && System.nanoTime() < deadline) {
+                try {
+                    TimeUnit.MILLISECONDS.sleep(25);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while waiting for the injected provider", e);
+                }
+            }
+            if (client.getProviderState() != ProviderState.READY) {
+                throw new IllegalStateException("Injected provider did not become ready: " + client.getProviderState());
+            }
+        }
+
+        private static FeatureProvider createDatadogProvider() {
+            try {
+                final Class<?> providerClass = Class.forName("datadog.trace.api.openfeature.Provider");
+                return (FeatureProvider) providerClass.getConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Datadog OpenFeature provider is not on the application classpath", e);
+            }
         }
     }
 
@@ -112,6 +148,8 @@ public class FeatureFlagEvaluatorController {
         result.put("reason", reason);
         result.put("value", value);
         result.put("count", targetingKeys.size());
+        result.put("deploymentMode", DEPLOYMENT_MODE);
+        result.put("provider", providerName);
         return ResponseEntity.ok(result);
     }
 

--- a/utils/build/docker/java/weblog_metadata.yml
+++ b/utils/build/docker/java/weblog_metadata.yml
@@ -16,6 +16,9 @@ resteasy-netty3:
   categories: [dd_trace]
 spring-boot:
   categories: [dd_trace]
+  supported_scenarios:
+    - FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE
+    - FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI
 spring-boot-3-native:
   categories: [dd_trace]
 spring-boot-jetty:


### PR DESCRIPTION
## Motivation

Java customers need two explicit OpenFeature deployment choices: a standalone `dd-openfeature` runtime that works without `dd-java-agent`, and SSI injection for applications that carry only the OpenFeature SDK. The system-test suite previously exercised neither artifact boundary, so a provider accidentally supplied by the application classpath or an implicit dependency on the Datadog Agent could go unnoticed.

## Changes

This adds Java-only standalone and SSI feature-flagging scenarios backed by the existing mock UFC service. The spring-boot fixture now builds two artifacts from the same source: the standalone artifact contains `dd-openfeature`, while the SSI artifact deliberately excludes it. Runtime selection starts standalone without `-javaagent`, or starts SSI with the local Java agent and tracing disabled. The `/ffe` contract reports deployment mode and provider identity, waits for injected-provider readiness, evaluates a real flag, and verifies that the mock backend received the UFC request. Both scenarios are registered in the end-to-end workflow and test activation map. Weblog metadata restricts both scenarios to the Java spring-boot target so generic CI matrices do not schedule them against unsupported libraries or weblogs.

## Decisions

Both scenarios remain agentless at the infrastructure level: no Datadog Agent container is present. This separates the Java agent used for SSI bytecode injection from the Datadog Agent service and proves that standalone does not load the Java agent at all. The application compiles against OpenFeature SDK 1.20.2 rather than the Datadog Provider type, so SSI cannot pass through a hidden compile-time provider dependency. These scenarios are intentionally excluded from tracer-release grouping until the deployment modes have established CI stability. This PR is downstream of [DataDog/dd-trace-java#12252](https://github.com/DataDog/dd-trace-java/pull/12252); the exact branch artifact is used for local cross-repository proof until that Java stack reaches `master`.

## Validation

- `SYSTEM_TEST_BUILD_ATTEMPTS=3 ./build.sh java -i weblog -w spring-boot`
- Inspected both packaged artifacts: standalone contains `sdk-1.20.2.jar` and `dd-openfeature`, while SSI contains `sdk-1.20.2.jar` and no `dd-openfeature`.
- `./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_STANDALONE tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_Standalone` — 1 passed against `java@1.66.0-SNAPSHOT+6b47adb9d3`.
- `./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_JAVA_SSI tests/ffe/test_java_openfeature_deployment_modes.py::Test_FFE_Java_OpenFeature_SSI` — 1 passed against `java@1.66.0-SNAPSHOT+6b47adb9d3`.
- `./run.sh TEST_THE_TEST tests/test_the_test/test_manifest.py tests/test_the_test/test_version.py tests/test_the_test/test_ci_orchestrator.py tests/test_the_test/test_group_rules.py` — 186 passed.
- `./format.sh`
- [Final-head `java/prod` Spring Boot instance 2](https://github.com/DataDog/system-tests/actions/runs/32445343679/job/96666540701) completed both standalone and SSI steps successfully under the production-version manifest treatment.
- [Final-head `java/dev` Spring Boot instance 2](https://github.com/DataDog/system-tests/actions/runs/32445343679/job/96666626875) runs both scenarios against current Java `master` (`1.66.0-SNAPSHOT~2d8d93dd6b`); both fail until the downstream Java stack above lands. The exact `6b47adb9d3` branch artifact passes both local scenarios as recorded above.
