### PR TITLE
Add DD_TRACE_SAMPLING_RULES in OTel Tracestate Sampling tests

### DIFF
--- a/tests/parametric/test_otel_tracestate_sampling.py
+++ b/tests/parametric/test_otel_tracestate_sampling.py
@@ -1,5 +1,7 @@
 """Cross-tracer conformance for OpenTelemetry consistent probability sampling (ot.th / ot.rv) on the wire."""
 
+import json
+
 import pytest
 
 from utils import features, scenarios
@@ -47,6 +49,7 @@ def _library_env(rate: float) -> dict[str, str]:
     return {
         "DD_TRACE_RATE_LIMIT": "10000000",
         "DD_TRACE_SAMPLE_RATE": str(rate),
+        "DD_TRACE_SAMPLING_RULES": json.dumps([{"sample_rate": rate}]),
         "DD_TRACE_STATS_COMPUTATION_ENABLED": "false",
     }
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
dd-trace-py does not support DD_TRACE_SAMPLE_RATE anymore

## Changes

<!-- A brief description of the change being made with this pull request. -->
Set DD_TRACE_SAMPLING_RULES with `sample_rate` set to the same value as DD_TRACE_SAMPLE_RATE in OTel Tracestate Sampling tests

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
