### PR TITLE
[golang] Align Go proxy system tests

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -740,7 +740,7 @@ manifest:
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_And_Network_Preprocessor: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_And_Network_Preprocessor::test_fingerprinting_header_blocking:
     - weblog_declaration:
-        envoy, haproxy: missing_feature
+        envoy, apim, haproxy: missing_feature
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_Capability: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Network_Capability: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Session: v1.69.0
@@ -911,7 +911,7 @@ manifest:
         gin: v1.37.0
   tests/appsec/waf/test_addresses.py::Test_Headers::test_specific_key3:
     - weblog_declaration:
-        envoy: missing_feature
+        envoy, apim: missing_feature
   tests/appsec/waf/test_addresses.py::Test_IoFsFileWrite: "irrelevant (Java-only address: server.io.fs.file_write)"
   tests/appsec/waf/test_addresses.py::Test_PathParams:
     - weblog_declaration:
@@ -1728,7 +1728,6 @@ manifest:
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts: v2.2.3
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts::test_span_links_from_conflicting_contexts:
     - weblog_declaration:
-        apim: missing_feature (apim-callout defaults DD_TRACE_PROPAGATION_STYLE to datadog, so the conflicting W3C context is not extracted)
         haproxy: missing_feature
   tests/test_distributed.py::Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
   tests/test_distributed.py::Test_Synthetics_APM_Datadog:  # Modified by easy win activation script

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1744,8 +1744,7 @@ manifest:
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts: v2.2.3
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts::test_span_links_from_conflicting_contexts:
     - weblog_declaration:
-        apim: v2.7.1
-        envoy: v1.72.0
+        apim: missing_feature (apim-callout defaults DD_TRACE_PROPAGATION_STYLE to datadog, so the conflicting W3C context is not extracted)
         haproxy: missing_feature
   tests/test_distributed.py::Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
   tests/test_distributed.py::Test_Synthetics_APM_Datadog:  # Modified by easy win activation script

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -504,7 +504,9 @@ manifest:
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled:
     - weblog_declaration:
-        haproxy: missing_feature
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v1.73.0-dev
   tests/appsec/test_asm_standalone.py::Test_IastStandalone_UpstreamPropagation_V2: missing_feature
   tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry_V2: v2.0.0
@@ -835,10 +837,14 @@ manifest:
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules: v2.1.0-dev
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules::test_rule_with_attributes_no_keep_event:
     - weblog_declaration:
-        haproxy: missing_feature
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules::test_rule_with_attributes_no_keep_no_event:
     - weblog_declaration:
-        haproxy: missing_feature
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRulesRcCapability: v2.1.0-dev
   tests/appsec/test_traces.py:
     - weblog_declaration:
@@ -878,6 +884,16 @@ manifest:
         envoy: v1.72.0
         haproxy: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_BodyJson: v1.37.0
+  tests/appsec/waf/test_addresses.py::Test_BodyJson::test_json_array:
+    - weblog_declaration:
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
+  tests/appsec/waf/test_addresses.py::Test_BodyJson::test_json_value:
+    - weblog_declaration:
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_BodyUrlEncoded: v1.37.0
   tests/appsec/waf/test_addresses.py::Test_BodyUrlEncoded::test_body_value:
     - weblog_declaration:
@@ -1728,6 +1744,8 @@ manifest:
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts: v2.2.3
   tests/test_distributed.py::Test_Span_Links_From_Conflicting_Contexts::test_span_links_from_conflicting_contexts:
     - weblog_declaration:
+        apim: v2.7.1
+        envoy: v1.72.0
         haproxy: missing_feature
   tests/test_distributed.py::Test_Span_Links_Omit_Tracestate_From_Conflicting_Contexts: missing_feature (implementation specs have not been determined)
   tests/test_distributed.py::Test_Synthetics_APM_Datadog:  # Modified by easy win activation script
@@ -1779,7 +1797,9 @@ manifest:
   tests/test_library_conf.py::Test_HeaderTags: v1.53.0
   tests/test_library_conf.py::Test_HeaderTags::test_trace_header_tags_basic:
     - weblog_declaration:
-        haproxy: missing_feature
+        apim: v2.7.1
+        envoy: v1.72.0
+        haproxy: v2.4.0
   tests/test_library_conf.py::Test_HeaderTags_Colon_Leading: v1.53.0
   tests/test_library_conf.py::Test_HeaderTags_Colon_Trailing: v1.70.0
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig: v1.70.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -504,7 +504,7 @@ manifest:
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_APMDisabledMarker: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_NotEnabled:
     - weblog_declaration:
-        envoy, apim, haproxy: missing_feature
+        haproxy: missing_feature
   tests/appsec/test_asm_standalone.py::Test_AppSecStandalone_UpstreamPropagation_V2: v1.73.0-dev
   tests/appsec/test_asm_standalone.py::Test_IastStandalone_UpstreamPropagation_V2: missing_feature
   tests/appsec/test_asm_standalone.py::Test_SCAStandalone_Telemetry_V2: v2.0.0
@@ -740,7 +740,7 @@ manifest:
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_And_Network_Preprocessor: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_And_Network_Preprocessor::test_fingerprinting_header_blocking:
     - weblog_declaration:
-        envoy, apim, haproxy: missing_feature
+        envoy, haproxy: missing_feature
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Header_Capability: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Network_Capability: v1.69.0
   tests/appsec/test_fingerprinting.py::Test_Fingerprinting_Session: v1.69.0
@@ -835,10 +835,10 @@ manifest:
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules: v2.1.0-dev
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules::test_rule_with_attributes_no_keep_event:
     - weblog_declaration:
-        envoy, apim, haproxy: missing_feature
+        haproxy: missing_feature
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRules::test_rule_with_attributes_no_keep_no_event:
     - weblog_declaration:
-        envoy, apim, haproxy: missing_feature
+        haproxy: missing_feature
   tests/appsec/test_trace_tagging.py::Test_TraceTaggingRulesRcCapability: v2.1.0-dev
   tests/appsec/test_traces.py:
     - weblog_declaration:
@@ -878,12 +878,6 @@ manifest:
         envoy: v1.72.0
         haproxy: v2.4.0
   tests/appsec/waf/test_addresses.py::Test_BodyJson: v1.37.0
-  tests/appsec/waf/test_addresses.py::Test_BodyJson::test_json_array:
-    - weblog_declaration:
-        envoy, apim: missing_feature
-  tests/appsec/waf/test_addresses.py::Test_BodyJson::test_json_value:
-    - weblog_declaration:
-        envoy, apim: missing_feature
   tests/appsec/waf/test_addresses.py::Test_BodyUrlEncoded: v1.37.0
   tests/appsec/waf/test_addresses.py::Test_BodyUrlEncoded::test_body_value:
     - weblog_declaration:
@@ -917,7 +911,7 @@ manifest:
         gin: v1.37.0
   tests/appsec/waf/test_addresses.py::Test_Headers::test_specific_key3:
     - weblog_declaration:
-        envoy, apim: missing_feature
+        envoy: missing_feature
   tests/appsec/waf/test_addresses.py::Test_IoFsFileWrite: "irrelevant (Java-only address: server.io.fs.file_write)"
   tests/appsec/waf/test_addresses.py::Test_PathParams:
     - weblog_declaration:
@@ -1786,7 +1780,7 @@ manifest:
   tests/test_library_conf.py::Test_HeaderTags: v1.53.0
   tests/test_library_conf.py::Test_HeaderTags::test_trace_header_tags_basic:
     - weblog_declaration:
-        envoy, apim, haproxy: missing_feature
+        haproxy: missing_feature
   tests/test_library_conf.py::Test_HeaderTags_Colon_Leading: v1.53.0
   tests/test_library_conf.py::Test_HeaderTags_Colon_Trailing: v1.70.0
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig: v1.70.0

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1899,6 +1899,7 @@ class ApimCalloutContainer(GoProcessorContainer):
             # "false" whenever the variable is empty, which rate-limits ordinary traces to one per
             # minute and makes APM assertions nondeterministic
             "DD_APM_TRACING_ENABLED": "true",
+            "DD_TRACE_PROPAGATION_STYLE": "datadog,tracecontext",
         }
 
         if env:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1693,7 +1693,7 @@ class EnvoyContainer(TestedContainer):
             healthcheck={
                 "test": "/bin/bash -c \"\
                     exec 3<>/dev/tcp/127.0.0.1/80 || exit 1;\
-                    echo -e 'GET / HTTP/1.1\nHost: system-tests\r\n\r\n' >&3;\
+                    echo -e 'GET / HTTP/1.1\r\nHost: system-tests\r\nUser-Agent: systemtests-healthcheck\r\n\r\n' >&3;\
                     cat <&3 | grep -q '200'\"",
                 "retries": 10,
             },
@@ -1734,6 +1734,9 @@ class ExternalProcessingContainer(GoProcessorContainer):
             "DD_AGENT_HOST": "proxy",
             "DD_TRACE_AGENT_PORT": str(ProxyPorts.weblog),
             "DD_APPSEC_WAF_TIMEOUT": "1s",
+            # The callout defaults APM tracing to false, which rate-limits ordinary traces
+            # and makes APM assertions nondeterministic.
+            "DD_APM_TRACING_ENABLED": "true",
         }
 
         if env:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1728,7 +1728,6 @@ class ExternalProcessingContainer(GoProcessorContainer):
             image = "ghcr.io/datadog/dd-trace-go/service-extensions-callout:latest"
 
         environment: dict[str, str | None] = {
-            "DD_APPSEC_ENABLED": "true",
             "DD_SERVICE": "service_test",
             "DD_ENV": "system-tests",
             "DD_AGENT_HOST": "proxy",
@@ -1780,7 +1779,7 @@ class HAProxyContainer(TestedContainer):
             healthcheck={
                 "test": "/bin/bash -c \"\
                     exec 3<>/dev/tcp/127.0.0.1/80 || exit 1;\
-                    echo -e 'GET / HTTP/1.1\nHost: system-tests\r\n\r\n' >&3;\
+                    echo -e 'GET / HTTP/1.1\r\nHost: system-tests\r\nUser-Agent: systemtests-healthcheck\r\n\r\n' >&3;\
                     cat <&3 | grep -q '200'\"",
                 "retries": 10,
             },
@@ -1802,10 +1801,13 @@ class StreamProcessingOffloadContainer(GoProcessorContainer):
             image = "ghcr.io/datadog/dd-trace-go/haproxy-spoa:latest"
 
         environment: dict[str, str | None] = {
+            "DD_APPSEC_ENABLED": "true",
             "DD_SERVICE": "service_test",
             "DD_ENV": "system-tests",
             "DD_AGENT_HOST": "proxy",
             "DD_TRACE_AGENT_PORT": str(ProxyPorts.weblog),
+            "DD_APPSEC_WAF_TIMEOUT": "1s",
+            "DD_APM_TRACING_ENABLED": "true",
         }
 
         if env:

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -1728,6 +1728,7 @@ class ExternalProcessingContainer(GoProcessorContainer):
             image = "ghcr.io/datadog/dd-trace-go/service-extensions-callout:latest"
 
         environment: dict[str, str | None] = {
+            "DD_APPSEC_ENABLED": "true",
             "DD_SERVICE": "service_test",
             "DD_ENV": "system-tests",
             "DD_AGENT_HOST": "proxy",
@@ -1901,7 +1902,6 @@ class ApimCalloutContainer(GoProcessorContainer):
             # "false" whenever the variable is empty, which rate-limits ordinary traces to one per
             # minute and makes APM assertions nondeterministic
             "DD_APM_TRACING_ENABLED": "true",
-            "DD_TRACE_PROPAGATION_STYLE": "datadog,tracecontext",
         }
 
         if env:

--- a/utils/build/docker/golang/envoy/envoy.yaml
+++ b/utils/build/docker/golang/envoy/envoy.yaml
@@ -27,6 +27,7 @@ static_resources:
                   - name: envoy.filters.http.ext_proc
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                      allow_mode_override: true
                       grpc_service:
                         envoy_grpc:
                           cluster_name: ext_proc_cluster


### PR DESCRIPTION
## Motivation

Follow-up to #7516. Validation showed that the Go proxy lanes used different APM defaults, and Envoy ignored processor body-mode overrides. This made their manifest coverage diverge without exercising equivalent behavior.

## Changes

- run Envoy and HAProxy `DEFAULT` / `APPSEC_BLOCKING` lanes with APM tracing enabled
- allow Envoy ext_proc mode overrides so request-body inspection is exercised
- send valid User-Agent healthchecks from Envoy and HAProxy
- enable verified tests using explicit integration versions (`envoy: v1.72.0`, `apim: v2.7.1`, `haproxy: v2.4.0`)
- preserve APIM and HAProxy Datadog-only propagation defaults and their conflicting-context exception
- leave `APPSEC_STANDALONE` and synthetics coverage unchanged

## Validation

- `PYTHONPATH=. ./format.sh --check`
- full `DEFAULT` and `APPSEC_BLOCKING` runs for Envoy, APIM, and HAProxy
- no newly versioned row remains XPASS
- APIM conflicting-context test remains excluded under its default propagation configuration

This modifies system-test framework configuration, so R&P review is required per the reviewer checklist.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on your PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
* [ ] A scenario is added, removed or renamed?