### PR TITLE
Fix flaky expression language probe test setup

### DIFF
--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -18,14 +18,21 @@ class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
     def _setup(self, probes: list[dict], request_path: str):
         self.set_probes(probes)
         self.send_rc_probes()
-        self.wait_for_all_probes(statuses=["INSTALLED"])
+        if not self.wait_for_all_probes(statuses=["INSTALLED"], timeout=60):
+            self.setup_failures.append("Probes did not reach INSTALLED status")
+            # Stop the test if the probes did not reach INSTALLED status since the probe won't exist
+            # to send a snapshot.
+            return
+
         self.send_weblog_request(request_path)
         self.wait_for_all_probes(statuses=["EMITTING"])
-        self.wait_for_all_snapshots()
+        self.wait_for_all_snapshots(timeout=60)
 
     ############ assert ############
     def _assert(self, expected_response: int):
         self.collect()
+
+        self.assert_setup_ok()
 
         assert len(self.probe_ids) > 0, (
             "Expected probes to be created for validation. "


### PR DESCRIPTION
<!-- dd-meta {"pullId":"16be7ce4-fd9d-4725-9014-bd217a216508","source":"chat","resourceId":"15bcb30d-a431-46a7-bb14-1489a2414121","workflowId":"79c77ed7-ef66-40aa-9bd4-a1cab719875e","codeChangeId":"79c77ed7-ef66-40aa-9bd4-a1cab719875e","sourceType":"assistant"} -->
## Motivation

`test_expression_language_comparison_operators` is flaky (~0.2%, 1/483 runs in the last 30 days). The test creates 96 probes (48 expressions × 2 probe types for Python). Under CI load, the default 30s timeout for `wait_for_all_probes` can expire before all probes reach `INSTALLED`. Because the return value was ignored, the test proceeded to send a weblog request against uninstalled probes that never emit, producing a confusing "probes are not emitting: RECEIVED" assertion failure instead of a clear setup error.

## Changes

- `tests/debugger/test_debugger_expression_language.py`:
  - `_setup`: check the `wait_for_all_probes(statuses=["INSTALLED"], timeout=60)` return value; on failure, append to `self.setup_failures` and return early so the test does not request against uninstalled probes. Also bumped `wait_for_all_snapshots()` to `timeout=60`.
  - `_assert`: added `self.assert_setup_ok()` as the first assertion after `self.collect()` so setup failures surface as a clear error.

This aligns `_setup`/`_assert` with the established robust pattern already used by sibling debugger tests (`test_debugger_capture_expressions.py`, `test_debugger_probe_snapshot.py`).

## Testing

- Ran `ruff check` on the modified file — all checks pass.
- Change is behavior-preserving on the happy path; it only adds a longer install timeout and converts a silent flaky failure into an explicit, deterministic setup-failure assertion.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/15bcb30d-a431-46a7-bb14-1489a2414121)

Comment @datadog to request changes