### PR TITLE
test(debugger): accept flat dotted dd.trace_id in correlation gate

### DIFF
--- a/tests/debugger/test_debugger_snapshot_correlation.py
+++ b/tests/debugger/test_debugger_snapshot_correlation.py
@@ -60,7 +60,9 @@ class Test_Debugger_Coordinated_Sampling(debugger.BaseDebuggerTest):
         probes_by_trace: dict[str, set[str]] = {}
         for probe_id in self.probe_ids:
             for snapshot in self.probe_snapshots.get(probe_id, []):
-                trace_id = snapshot.get("dd", {}).get("trace_id")
+                # Tolerate the nested dd object (Python/Node/Ruby nest) and the flat dotted
+                # key (Java/.NET/Go/Ruby dotted) for the trace id.
+                trace_id = snapshot.get("dd", {}).get("trace_id") or snapshot.get("dd.trace_id")
                 assert trace_id, f"snapshot for probe {probe_id} is missing dd.trace_id on the wire"
                 probes_by_trace.setdefault(trace_id, set()).add(probe_id)
 


### PR DESCRIPTION
## Motivation

Stacked on #7425, which introduces the feature-564 test `Test_Debugger_Coordinated_Sampling`. The test groups snapshots by trace using `dd.trace_id` and read only the nested form under the `dd` object. The Ruby tracer (DataDog/dd-trace-rb#6118) emits `dd.trace_id` as a flat dotted key at the envelope root, matching the Java/.NET/Go convention, so dotted-key snapshots resolved to `None` and failed the presence assertion before any sampling logic ran.

## Changes

Read `dd.trace_id` from both the nested `dd` object and the flat dotted key:

```python
trace_id = snapshot.get("dd", {}).get("trace_id") or snapshot.get("dd.trace_id")
```
