### PR TITLE
fix(otel): correct trace metric status and endpoint coverage

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1292,6 +1292,8 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (HTTP server span names use Datadog semantics when sampling rules run)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: v3.52.0
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (OTel HTTP server semantics not implemented over OTLP export)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: missing_feature (OTel HTTP server semantics not implemented over OTLP export)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_resource_renaming: irrelevant (The .NET tracer creates http.endpoint from routed AppSec requests)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: missing_feature (APMAPI-2171)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1819,6 +1819,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh:
     - weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4595,6 +4595,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (OTLP export of OTel HTTP semantics not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: missing_feature (OTel HTTP semantics not implemented over both Agent and OTLP export paths)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (OTel HTTP semantics not implemented over both Agent and OTLP export paths)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: missing_feature (APMAPI-2171)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2906,7 +2906,8 @@ manifest:
     - weblog_declaration:
         "*": missing_feature
         express4: *ref_6_0_0
-  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained: missing_feature (http.endpoint is not retained under OTel semantics)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_resource_renaming: missing_feature (http.endpoint is not retained under OTel semantics)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged:  # TODO: a lower version might be supported

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1850,6 +1850,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: missing_feature (APMAPI-2171)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2448,6 +2448,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: 4.15.0-dev
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: 4.15.0-dev
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: 4.15.0-dev
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: missing_feature (APMAPI-2171)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2443,6 +2443,8 @@ manifest:
   ? tests/test_otel_http_semantics.py::Test_OtelSemantics_OTLP_Spans_Http_ErrorStatusConfiguration::test_client_error_statuses_config_overrides
   : missing_feature (DD_TRACE_HTTP_CLIENT_ERROR_STATUSES support is outside the current Python OTel semantics implementation scope)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_OTLP_TraceMetrics: 4.15.0-dev
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_OTLP_TraceMetrics::test_trace_metric_agrees_with_client_success: missing_feature (libdatadog status.code fix is not merged)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_OTLP_TraceMetrics::test_trace_metric_agrees_with_server_success: missing_feature (libdatadog status.code fix is not merged)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: 4.15.0-dev
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: 4.15.0-dev
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: 4.15.0-dev

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -3005,6 +3005,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh::test_force_keep_overrides_inherited_drop_decision: v2.42.0-dev

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -485,6 +485,7 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_SamplingRules: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Client: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server: missing_feature (DD_TRACE_OTEL_SEMANTICS_ENABLED not implemented)
+  tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: irrelevant (The AppSec endpoint retention request is specific to .NET)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: '>=0.5.2-dev'
   tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (manual keep not honored)
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: '>=0.5.2-dev'

--- a/tests/test_otel_http_semantics.py
+++ b/tests/test_otel_http_semantics.py
@@ -43,7 +43,7 @@ RFC: https://docs.google.com/document/d/1SONUGEa38eLumE5b6gnNhykFhzZL9uQpsnMFq06
 from collections.abc import Iterator
 from typing import Any
 
-from utils import features, interfaces, rfc, scenarios, weblog
+from utils import context, features, interfaces, rfc, scenarios, weblog
 from utils._weblog import HttpResponse
 from utils.dd_constants import SpanKind, StatusCode
 
@@ -505,14 +505,16 @@ class Test_OtelSemantics_Spans_Http_Server:
         _assert_int_attribute(span, "server.port", 7777)
 
     def setup_http_endpoint_retained(self) -> None:
-        # http.endpoint is the endpoint-aggregation fallback for requests the framework
-        # resolved no route for, so use an unmatched path.
-        self.response = weblog.get("/no_such_route_xyz")
+        if context.library == "dotnet":
+            self.response = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
+        else:
+            self.response = weblog.get("/resource_renaming/int/123")
 
     def test_http_endpoint_retained(self) -> None:
         """``http.endpoint`` is Datadog-only with no OTel equivalent, so it is retained."""
         span = _server_span(self.response)
-        assert _attributes(span).get("http.endpoint"), "http.endpoint must be retained on the OTLP span"
+        endpoint = _attributes(span).get("http.endpoint")
+        assert endpoint, "http.endpoint must be retained on the OTLP span"
 
     def setup_span_kind_is_server(self) -> None:
         self.response = weblog.get("/")
@@ -732,7 +734,7 @@ class Test_OtelSemantics_OTLP_TraceMetrics:
         attrs = _metric_attributes(_client_trace_metric(span))
         assert attrs.get("http.request.method") == "GET"
         assert attrs.get("http.response.status_code") == 201
-        assert "status.code" not in attrs, "successful HTTP trace metrics must leave OTel status unset"
+        assert _status_code(attrs.get("status.code")) == StatusCode.STATUS_CODE_OK.value
 
     def setup_trace_metric_agrees_with_server_error(self) -> None:
         self.response = weblog.get("/status?code=503")
@@ -756,7 +758,7 @@ class Test_OtelSemantics_OTLP_TraceMetrics:
         attrs = _metric_attributes(_server_trace_metric(span))
         assert attrs.get("http.request.method") == "GET"
         assert attrs.get("http.response.status_code") == 202
-        assert "status.code" not in attrs, "successful HTTP trace metrics must leave OTel status unset"
+        assert _status_code(attrs.get("status.code")) == StatusCode.STATUS_CODE_OK.value
 
 
 @rfc("https://docs.google.com/document/d/1SONUGEa38eLumE5b6gnNhykFhzZL9uQpsnMFq06uDMY/edit")

--- a/tests/test_otel_http_semantics.py
+++ b/tests/test_otel_http_semantics.py
@@ -43,7 +43,7 @@ RFC: https://docs.google.com/document/d/1SONUGEa38eLumE5b6gnNhykFhzZL9uQpsnMFq06
 from collections.abc import Iterator
 from typing import Any
 
-from utils import context, features, interfaces, rfc, scenarios, weblog
+from utils import features, interfaces, rfc, scenarios, weblog
 from utils._weblog import HttpResponse
 from utils.dd_constants import SpanKind, StatusCode
 
@@ -504,13 +504,19 @@ class Test_OtelSemantics_Spans_Http_Server:
         assert _attributes(span).get("server.address"), "server.port is required once server.address is set"
         _assert_int_attribute(span, "server.port", 7777)
 
-    def setup_http_endpoint_retained(self) -> None:
-        if context.library == "dotnet":
-            self.response = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
-        else:
-            self.response = weblog.get("/resource_renaming/int/123")
+    def setup_http_endpoint_retained_from_resource_renaming(self) -> None:
+        self.response = weblog.get("/resource_renaming/int/123")
 
-    def test_http_endpoint_retained(self) -> None:
+    def test_http_endpoint_retained_from_resource_renaming(self) -> None:
+        """``http.endpoint`` created by resource renaming is retained."""
+        span = _server_span(self.response)
+        endpoint = _attributes(span).get("http.endpoint")
+        assert endpoint, "http.endpoint must be retained on the OTLP span"
+
+    def setup_http_endpoint_retained_from_appsec(self) -> None:
+        self.response = weblog.get("/waf/", headers={"User-Agent": "Arachni/v1"})
+
+    def test_http_endpoint_retained_from_appsec(self) -> None:
         """``http.endpoint`` is Datadog-only with no OTel equivalent, so it is retained."""
         span = _server_span(self.response)
         endpoint = _attributes(span).get("http.endpoint")

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -270,6 +270,7 @@ class _Scenarios:
             "DD_TRACE_OTEL_SEMANTICS_ENABLED": "true",
             # OTel semantics must override both conflicting configurations.
             "DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED": "true",
+            "DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT": "true",
             "DD_TRACE_RESOURCE_RENAMING_ENABLED": "true",
             "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA": "v1",
             "DD_TRACE_OTEL_ENABLED": "true",


### PR DESCRIPTION
## Summary
- require `STATUS_CODE_OK` on successful OTLP trace metrics, while keeping Python gated until the corresponding libdatadog support merges
- generate `http.endpoint` through stable resource-renaming requests for Node.js, Python, and Go
- use a routed AppSec request for .NET so the same retention assertion is valid
- enable simplified endpoint generation only in the OTLP HTTP-semantics scenario

## Test plan
- [x] Node.js OTel branch: endpoint-retention test passes over direct OTLP
- [x] Python OTel branch: endpoint-retention test passes over direct OTLP
- [x] .NET `otel-aspnetcore` image: routed AppSec endpoint-retention test passes over direct OTLP
- [x] Go main: endpoint-retention test passes over direct OTLP
- [x] Ruff formatting/lint and mypy pass
- [x] YAML formatting, lint, and manifest parser checks pass

`./format.sh` reaches shellcheck after all checks above pass, then hits the existing macOS Bash 3 empty-array failure in `utils/scripts/shellcheck.sh` (`@: unbound variable`).

Made with [Cursor](https://cursor.com)