### PR TITLE
test(otel): preserve tracestate member order

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -398,6 +398,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1298,6 +1298,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1840,6 +1840,10 @@ manifest:
     - weblog_declaration:
         "*": missing_feature (APMAPI-2171)
         envoy, apim, haproxy: irrelevant (not applicable to proxies)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder:
+    - weblog_declaration:
+        "*": missing_feature (APMAPI-2171)
+        envoy, apim, haproxy: irrelevant (not applicable to proxies)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated:
     - weblog_declaration:
         "*": missing_feature (APMAPI-2171)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4601,6 +4601,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2928,6 +2928,12 @@ manifest:
       weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
     - declaration: missing_feature (APMAPI-2171)
       excluded_weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder:  # TODO: a lower version might be supported
+    - declaration: missing_feature (APMAPI-2171)
+      component_version: <6.8.0
+      weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
+    - declaration: missing_feature (APMAPI-2171)
+      excluded_weblog: [express4-typescript, uds-express4, express4, express5, fastify, nextjs]
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated:  # TODO: a lower version might be supported
     - declaration: missing_feature (APMAPI-2171)
       component_version: <6.8.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1856,6 +1856,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2452,6 +2452,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -3012,6 +3012,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: v2.42.0-dev
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: bug (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: v2.42.0-dev
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: v2.42.0-dev

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -491,6 +491,7 @@ manifest:
   tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: '>=0.5.2-dev'
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: '>=0.5.2-dev'
   tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: '>=0.5.2-dev'
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: bug (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: '>=0.5.2-dev'
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: '>=0.5.2-dev'
   tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: '>=0.5.2-dev'

--- a/tests/test_otel_tracestate_sampling.py
+++ b/tests/test_otel_tracestate_sampling.py
@@ -275,6 +275,35 @@ class Test_PreserveDdAndOtherVendors:
 
 @scenarios.default
 @features.w3c_headers_injection_and_extraction
+class Test_PreserveTracestateMemberOrder:
+    def setup_preserve_tracestate_member_order(self):
+        self.r = weblog.get(
+            "/make_distant_call",
+            params={"url": "http://weblog:7777"},
+            headers={
+                "traceparent": _traceparent(FORWARD_TRACE_ID, sampled=True),
+                "tracestate": "dd=s:1,foo=bar,ot=rv:6e6d1a75832a2f,something=else",
+            },
+        )
+
+    def test_preserve_tracestate_member_order(self):
+        assert self.r.status_code == 200
+
+        request_headers = json.loads(self.r.text)["request_headers"]
+        raw_tracestate = next(
+            (value for key, value in request_headers.items() if key.lower() == "tracestate"),
+            None,
+        )
+        assert raw_tracestate is not None, "tracestate header was dropped"
+
+        dd_member, separator, unmodified_members = raw_tracestate.partition(",")
+        assert separator, "tracestate did not preserve the unmodified members"
+        assert dd_member.startswith("dd="), "dd= must remain the leading tracestate member"
+        assert unmodified_members == "foo=bar,ot=rv:6e6d1a75832a2f,something=else"
+
+
+@scenarios.default
+@features.w3c_headers_injection_and_extraction
 class Test_ForceKeepClearsTh:
     """A4: a non-probability (force-keep) decision erases th but still forwards an inherited rv.
 


### PR DESCRIPTION
## Motivation

The [W3C Trace Context mutation rules](https://www.w3.org/TR/trace-context/#mutating-the-tracestate-field) require unmodified `tracestate` members to retain their order. 
Thanks to @zacharycmontoya for identifing this coverage gap [here](https://github.com/DataDog/dd-trace-dotnet/pull/8983#discussion_r3826612575).

## Changes

Add an end-to-end regression using `dd=s:1,foo=bar,ot=rv:6e6d1a75832a2f,something=else` and assert the raw downstream suffix remains `foo=bar,ot=rv:6e6d1a75832a2f,something=else`.

Existing tests verify parsed `dd`, `ot`, and vendor values. This raw comparison
is complementary because parsed key/value checks cannot detect reordering.

- marks this as a bug for dd-trace-rs / dd-trace-rb implementation 
