### PR TITLE
[APPSEC-69800]  Stop expecting unused and sensitive `_dd.appsec.usr` tags

### DIFF
--- a/tests/appsec/smoke_tests/utils.py
+++ b/tests/appsec/smoke_tests/utils.py
@@ -337,7 +337,7 @@ class BaseUserEventsSmokeTests:
     def test_login_success_smoke(self) -> None:
         for _, span in interfaces.agent.get_spans(self.r):
             meta = span.meta
-            if meta.get("_dd.appsec.usr.login") or meta.get("appsec.events.users.login.success.usr.login"):
+            if meta.get("appsec.events.users.login.success.usr.login"):
                 return
 
         raise AssertionError("Agent spans should include user login event tags")

--- a/tests/appsec/test_asm_standalone.py
+++ b/tests/appsec/test_asm_standalone.py
@@ -1078,7 +1078,7 @@ class Test_UserEventsStandalone_Automated:
         trace_id = 1212121212121212111
         meta = self._get_standalone_span_meta(trace_id)
         assert meta is not None
-        assert meta["_dd.appsec.usr.login"] == USER
+        assert meta["appsec.events.users.login.success.usr.login"] == USER
 
     def setup_user_login_failure_event_generates_asm_event(self):
         trace_id = 1212121212121212122
@@ -1088,7 +1088,7 @@ class Test_UserEventsStandalone_Automated:
         trace_id = 1212121212121212122
         meta = self._get_standalone_span_meta(trace_id)
         assert meta is not None
-        assert meta["_dd.appsec.usr.login"] == INVALID_USER
+        assert meta["appsec.events.users.login.failure.usr.login"] == INVALID_USER
 
     def setup_user_signup_event_generates_asm_event(self):
         trace_id = 1212121212121212133

--- a/tests/appsec/test_automated_login_events.py
+++ b/tests/appsec/test_automated_login_events.py
@@ -1229,14 +1229,12 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.success.usr.login"] == login
-            assert meta["_dd.appsec.usr.login"] == login
             assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.success.track")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["usr.id"] == "social-security-id"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_success_basic(self):
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": BASIC_AUTH_USER_HEADER})
@@ -1251,14 +1249,12 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.success.usr.login"] == login
-            assert meta["_dd.appsec.usr.login"] == login
             assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.success.track")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["usr.id"] == "social-security-id"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_wrong_user_failure_local(self):
         self.r_wrong_user_failure = weblog.post("/login?auth=local", data=login_data(INVALID_USER, PASSWORD))
@@ -1271,7 +1267,6 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == INVALID_USER
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
 
@@ -1292,7 +1287,6 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == INVALID_USER
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
 
@@ -1311,7 +1305,6 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == USER
-            assert meta["_dd.appsec.usr.login"] == USER
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
 
@@ -1321,7 +1314,6 @@ class Test_V3_Login_Events:
 
             if login_failure_includes_usr_id_meta():
                 assert meta["appsec.events.users.login.failure.usr.id"] == "social-security-id"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_wrong_password_failure_basic(self):
         self.r_wrong_user_failure = weblog.get(
@@ -1336,7 +1328,6 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == USER
-            assert meta["_dd.appsec.usr.login"] == USER
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
 
@@ -1346,7 +1337,6 @@ class Test_V3_Login_Events:
 
             if login_failure_includes_usr_id_meta():
                 assert meta["appsec.events.users.login.failure.usr.id"] == "social-security-id"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_success_local(self):
         self.r_sdk_success = [
@@ -1366,7 +1356,6 @@ class Test_V3_Login_Events:
 
                 # mandatory
                 assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == USER
                 assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
                 assert_boolean_meta_tag(meta, "appsec.events.users.login.success.track")
                 assert_boolean_meta_tag(meta, "_dd.appsec.events.users.login.success.sdk")
@@ -1374,7 +1363,6 @@ class Test_V3_Login_Events:
                 # optional (to review for each library)
                 if login_success_includes_usr_id_meta():
                     assert meta["usr.id"] == "sdkUser"
-                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_success_basic(self):
         self.r_sdk_success = [
@@ -1392,11 +1380,8 @@ class Test_V3_Login_Events:
                 assert_priority(span)
                 meta = span.get("meta", {})
 
-                login = USER
-
                 # mandatory
                 assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == login
                 assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "identification"
                 assert_boolean_meta_tag(meta, "appsec.events.users.login.success.track")
                 assert_boolean_meta_tag(meta, "_dd.appsec.events.users.login.success.sdk")
@@ -1404,7 +1389,6 @@ class Test_V3_Login_Events:
                 # optional (to review for each library)
                 if login_success_includes_usr_id_meta():
                     assert meta["usr.id"] == "sdkUser"
-                    assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
     def setup_login_sdk_failure_local(self):
         self.r_sdk_failure = [
@@ -1424,7 +1408,6 @@ class Test_V3_Login_Events:
 
                 # mandatory
                 assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == INVALID_USER
                 assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
                 assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
                 assert_boolean_meta_tag(meta, "_dd.appsec.events.users.login.failure.sdk")
@@ -1448,7 +1431,6 @@ class Test_V3_Login_Events:
 
                 # mandatory
                 assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == INVALID_USER
                 assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "identification"
                 assert_boolean_meta_tag(meta, "appsec.events.users.login.failure.track")
                 assert_boolean_meta_tag(meta, "_dd.appsec.events.users.login.failure.sdk")
@@ -1465,14 +1447,12 @@ class Test_V3_Login_Events:
 
             # mandatory
             assert meta["appsec.events.users.signup.usr.login"] == NEW_USER
-            assert meta["_dd.appsec.usr.login"] == NEW_USER
             assert meta["_dd.appsec.events.users.signup.auto.mode"] == "identification"
             assert_boolean_meta_tag(meta, "appsec.events.users.signup.track")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["appsec.events.users.signup.usr.id"] == "new-user"
-                assert meta["_dd.appsec.usr.id"] == "new-user"
 
     def setup_login_success_headers(self):
         self.r_hdr_success = weblog.post(
@@ -1535,14 +1515,12 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.success.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
             assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.success.track"], expected="true")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["usr.id"] == USER_HASH
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_success_basic(self):
         self.r_success = weblog.get("/login?auth=basic", headers={"Authorization": BASIC_AUTH_USER_HEADER})
@@ -1555,14 +1533,12 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.success.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
             assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.success.track"], expected="true")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["usr.id"] == USER_HASH
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_wrong_user_failure_local(self):
         self.r_wrong_user_failure = weblog.post("/login?auth=local", data=login_data(INVALID_USER, PASSWORD))
@@ -1575,7 +1551,6 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == INVALID_USER_HASH
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
 
@@ -1596,7 +1571,6 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == INVALID_USER_HASH
-            assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
 
@@ -1615,7 +1589,6 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
 
@@ -1625,7 +1598,6 @@ class Test_V3_Login_Events_Anon:
 
             if login_failure_includes_usr_id_meta():
                 assert meta["appsec.events.users.login.failure.usr.id"] == USER_HASH
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_wrong_password_failure_basic(self):
         self.r_wrong_user_failure = weblog.get(
@@ -1640,7 +1612,6 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.login.failure.usr.login"] == USERNAME_HASH
-            assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
             assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
 
@@ -1650,7 +1621,6 @@ class Test_V3_Login_Events_Anon:
 
             if login_failure_includes_usr_id_meta():
                 assert meta["appsec.events.users.login.failure.usr.id"] == USER_HASH
-                assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_sdk_success_local(self):
         self.r_sdk_success = [
@@ -1670,7 +1640,6 @@ class Test_V3_Login_Events_Anon:
 
                 # mandatory
                 assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
                 assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
                 assert is_same_boolean(actual=meta["appsec.events.users.login.success.track"], expected="true")
                 assert is_same_boolean(actual=meta["_dd.appsec.events.users.login.success.sdk"], expected="true")
@@ -1678,7 +1647,6 @@ class Test_V3_Login_Events_Anon:
                 # optional (to review for each library)
                 if login_success_includes_usr_id_meta():
                     assert meta["usr.id"] == "sdkUser"
-                    assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_sdk_success_basic(self):
         self.r_sdk_success = [
@@ -1698,7 +1666,6 @@ class Test_V3_Login_Events_Anon:
 
                 # mandatory
                 assert meta["appsec.events.users.login.success.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == USERNAME_HASH
                 assert meta["_dd.appsec.events.users.login.success.auto.mode"] == "anonymization"
                 assert is_same_boolean(actual=meta["appsec.events.users.login.success.track"], expected="true")
                 assert is_same_boolean(actual=meta["_dd.appsec.events.users.login.success.sdk"], expected="true")
@@ -1706,7 +1673,6 @@ class Test_V3_Login_Events_Anon:
                 # optional (to review for each library)
                 if login_success_includes_usr_id_meta():
                     assert meta["usr.id"] == "sdkUser"
-                    assert meta["_dd.appsec.usr.id"] == USER_HASH
 
     def setup_login_sdk_failure_local(self):
         self.r_sdk_failure = [
@@ -1726,7 +1692,6 @@ class Test_V3_Login_Events_Anon:
 
                 # mandatory
                 assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
                 assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
                 assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
                 assert is_same_boolean(actual=meta["_dd.appsec.events.users.login.failure.sdk"], expected="true")
@@ -1750,7 +1715,6 @@ class Test_V3_Login_Events_Anon:
 
                 # mandatory
                 assert meta["appsec.events.users.login.failure.usr.login"] == "sdkUser"
-                assert meta["_dd.appsec.usr.login"] == INVALID_USER_HASH
                 assert meta["_dd.appsec.events.users.login.failure.auto.mode"] == "anonymization"
                 assert is_same_boolean(actual=meta["appsec.events.users.login.failure.track"], expected="true")
                 assert is_same_boolean(actual=meta["_dd.appsec.events.users.login.failure.sdk"], expected="true")
@@ -1767,14 +1731,12 @@ class Test_V3_Login_Events_Anon:
 
             # mandatory
             assert meta["appsec.events.users.signup.usr.login"] == NEW_USERNAME_HASH
-            assert meta["_dd.appsec.usr.login"] == NEW_USERNAME_HASH
             assert meta["_dd.appsec.events.users.signup.auto.mode"] == "anonymization"
             assert is_same_boolean(actual=meta["appsec.events.users.signup.track"], expected="true")
 
             # optional (to review for each library)
             if login_success_includes_usr_id_meta():
                 assert meta["appsec.events.users.signup.usr.id"] == NEW_USER_HASH
-                assert meta["_dd.appsec.usr.id"] == NEW_USER_HASH
 
 
 DISABLED = ("datadog/2/ASM_FEATURES/auto-user-instrum/config", {"auto_user_instrum": {"mode": "disabled"}})

--- a/tests/appsec/test_automated_user_and_session_tracking.py
+++ b/tests/appsec/test_automated_user_and_session_tracking.py
@@ -61,10 +61,8 @@ class Test_Automated_User_Tracking:
             meta = span.get("meta", {})
             if context.library in libs_without_user_id:
                 assert meta["usr.id"] == USER
-                assert meta["_dd.appsec.usr.id"] == USER
             else:
                 assert meta["usr.id"] == "social-security-id"
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
             assert meta["_dd.appsec.user.collection_mode"] == "identification"
 
@@ -79,10 +77,6 @@ class Test_Automated_User_Tracking:
         for _, _, span in interfaces.library.get_spans(request=self.r_users):
             meta = span.get("meta", {})
             assert meta["usr.id"] == "sdkUser"
-            if context.library in libs_without_user_id:
-                assert meta["_dd.appsec.usr.id"] == USER
-            else:
-                assert meta["_dd.appsec.usr.id"] == "social-security-id"
 
             assert meta["_dd.appsec.user.collection_mode"] == "sdk"
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"2cdf3fb4-5b7e-4e0c-885c-37bf11f4069d","source":"chat","resourceId":"9b4beeb3-ca15-4b8a-86ee-5a1ad8769235","workflowId":"6f27541d-398b-447d-aefd-05a0bd9b155e","codeChangeId":"6f27541d-398b-447d-aefd-05a0bd9b155e","sourceType":"slack"} -->
## Motivation

APPSEC-69800 removes system-tests expectations for sensitive user tags in the `_dd.appsec` namespace. The library follow-up work can remove `_dd.appsec.usr.id` and `_dd.appsec.usr.login` without these tests requiring those tags to stay present.

## Changes

* Removed `_dd.appsec.usr.id` assertions from automated user tracking and V3 login event tests.
* Removed `_dd.appsec.usr.login` assertions from V3 login event tests.
* Updated standalone automated user-event checks and smoke validation to rely on public `appsec.events.users.*.usr.login` tags instead of `_dd.appsec.usr.login`.

## Testing

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/9b4beeb3-ca15-4b8a-86ee-5a1ad8769235)

Comment @datadog to request changes