### PR TITLE
fix(golang): trace non-standard HTTP methods in Chi weblog

### DIFF
--- a/utils/build/docker/golang/app/chi/main.go
+++ b/utils/build/docker/golang/app/chi/main.go
@@ -56,6 +56,10 @@ func main() {
 	}
 	defer profiler.Stop()
 
+	// Chi rejects non-standard HTTP methods before route middleware runs.
+	// Register PROPFIND because it is the method used by semantic-convention coverage;
+	// global tracing middleware is not an alternative because it breaks AppSec.
+	chi.RegisterMethod("PROPFIND")
 	mux := chi.NewRouter().With(chitrace.Middleware())
 
 	mux.HandleFunc("/stats-unique", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Motivation

Chi rejects non-standard HTTP methods before the route middleware runs.
As a result, test that exercise non-standard HTTP methods don't execute correctly.

This supports [APMAPI-2127](https://datadoghq.atlassian.net/browse/APMAPI-2127) and the server semantic-convention behavior in [DataDog/dd-trace-go#5242](https://github.com/DataDog/dd-trace-go/pull/5242).

## Changes

Allow the non-standard HTTP method used by semantic-convention coverage to reach route tracing middleware.
We can't simply restore a global middleware, since that breaks AppSec.

We use `PROPFIND` because that's the "non-standard HTTP method" we use today.

Validation:

- `./format.sh`
- `git diff --check`

Local image build and focused scenario validation were blocked because the sandbox denied Docker Hub access while fetching `golang:1.26-alpine`.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)


[APMAPI-2127]: https://datadoghq.atlassian.net/browse/APMAPI-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ