### PR TITLE
test(ffe): validate Go agentless EVP egress

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1172,8 +1172,6 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: v2.4.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance::test_unknown_operator_errors: bug (FFL-2182)
   tests/ffe/test_exposure_egress.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation::test_ffe_evp_flagevaluation_degradation: flaky (FFL-2676)

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -14,7 +14,6 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
-EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
 
 
 @dataclass(frozen=True)
@@ -22,7 +21,6 @@ class ExposureEgress:
     interface: ProxyBasedInterfaceValidator
     excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
     expected_api_key: str | None = None
-    expected_api_key_fingerprint: str | None = None
 
 
 def exposure_egress() -> ExposureEgress:
@@ -48,7 +46,6 @@ def exposure_egress() -> ExposureEgress:
         interfaces.datadog_direct,
         (interfaces.datadog_sidecar,),
         EXPECTED_API_KEY,
-        EXPECTED_API_KEY_FINGERPRINT,
     )
 
 
@@ -108,8 +105,6 @@ class ExposureEgressContract:
 
         headers = {name.lower(): value for name, value in request["request"]["headers"]}
         assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
-        if egress.expected_api_key_fingerprint is not None:
-            assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -2,7 +2,11 @@
 
 from dataclasses import dataclass
 
-from tests.ffe.utils.exposures import assert_exposure_side_effects_contract, exposure_events_from_data
+from tests.ffe.utils.exposures import (
+    EXPOSURE_WAIT_TIMEOUT_SECONDS,
+    assert_exposure_side_effects_contract,
+    exposure_events_from_data,
+)
 from tests.ffe.utils.fixtures import make_ufc_fixture
 from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
 from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
@@ -10,6 +14,7 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
+EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
 
 
 @dataclass(frozen=True)
@@ -17,6 +22,7 @@ class ExposureEgress:
     interface: ProxyBasedInterfaceValidator
     excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
     expected_api_key: str | None = None
+    expected_api_key_fingerprint: str | None = None
 
 
 def exposure_egress() -> ExposureEgress:
@@ -42,6 +48,7 @@ def exposure_egress() -> ExposureEgress:
         interfaces.datadog_direct,
         (interfaces.datadog_sidecar,),
         EXPECTED_API_KEY,
+        EXPECTED_API_KEY_FINGERPRINT,
     )
 
 
@@ -72,6 +79,14 @@ class ExposureEgressContract:
             for _ in range(5)
         ]
 
+        # Agentless targets are stopped immediately after setup, before test assertions run.
+        # Keep the target alive until buffered SDK writers have flushed to the selected route.
+        egress = exposure_egress()
+        assert egress.interface.wait_for(
+            lambda data: bool(exposure_events_from_data(data, {self.flag_key}, self.targeting_key)),
+            timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
+        ), f"Timed out waiting for exposure event for {self.flag_key!r} and {self.targeting_key!r}"
+
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()
         matching_requests = assert_exposure_side_effects_contract(
@@ -93,6 +108,8 @@ class ExposureEgressContract:
 
         headers = {name.lower(): value for name, value in request["request"]["headers"]}
         assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+        if egress.expected_api_key_fingerprint is not None:
+            assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -1,5 +1,6 @@
 """Test server-side feature flag evaluation counts via EVP flagevaluation."""
 
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -103,7 +104,9 @@ def evaluate_flag(
     return weblog.post("/ffe", json=payload)
 
 
-def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple[JSON, JSON]]:
+def evp_flagevaluation_events_from_data(
+    data: JSON, flag_key: str, targeting_key: str | None = None
+) -> list[tuple[JSON, JSON]]:
     if data.get("path") != EVP_FLAGEVALUATIONS_PATH:
         return []
 
@@ -125,8 +128,15 @@ def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple
             continue
 
         flag = event.get("flag")
-        if isinstance(flag, dict) and flag.get("key") == flag_key:
-            results.append((cast("JSON", content), cast("JSON", event)))
+        if not isinstance(flag, dict) or flag.get("key") != flag_key:
+            continue
+
+        if targeting_key is not None:
+            hashed_targeting_key = f"sha256_{hashlib.sha256(targeting_key.encode()).hexdigest()}"
+            if event.get("targeting_key") not in (targeting_key, hashed_targeting_key):
+                continue
+
+        results.append((cast("JSON", content), cast("JSON", event)))
 
     return results
 
@@ -301,7 +311,9 @@ class FlagevaluationEgressContract:
         # Keep the target alive until buffered SDK writers have flushed to the selected route.
         egress = flagevaluation_egress()
         assert egress.interface.wait_for(
-            lambda data: bool(evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key)),
+            lambda data: bool(
+                evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key, self.targeting_key)
+            ),
             timeout=EVP_WAIT_TIMEOUT_SECONDS,
         ), f"Timed out waiting for EVP flagevaluation event for flag {self.flag_key}"
 
@@ -312,7 +324,7 @@ class FlagevaluationEgressContract:
         egress = flagevaluation_egress()
 
         def matcher(data: JSON) -> bool:
-            return bool(evp_flagevaluation_events_from_data(data, self.flag_key))
+            return bool(evp_flagevaluation_events_from_data(data, self.flag_key, self.targeting_key))
 
         assert egress.interface.wait_for(
             lambda data: matcher(cast("JSON", data)),
@@ -328,7 +340,7 @@ class FlagevaluationEgressContract:
 
         events: list[tuple[JSON, JSON]] = []
         for request in matching_requests:
-            events.extend(evp_flagevaluation_events_from_data(request, self.flag_key))
+            events.extend(evp_flagevaluation_events_from_data(request, self.flag_key, self.targeting_key))
 
         assert events, f"Expected EVP flagevaluation events for flag {self.flag_key}"
         for _, event in events:
@@ -350,7 +362,7 @@ class FlagevaluationEgressContract:
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(
-                evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key)
+                evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key, self.targeting_key)
                 for data in excluded_interface.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH)
             )
 

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -27,7 +27,6 @@ EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
 EVP_DEGRADATION_OVERFLOW_EVALS = 2_000
-EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
 
 # Fixed input/output vector for the PII-protection tests. Every SDK's unit tests
 # should assert against the same input to prove byte-identical hashing across SDKs.
@@ -47,7 +46,6 @@ class FlagevaluationEgress:
     interface: ProxyBasedInterfaceValidator
     excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
     expected_api_key: str | None = None
-    expected_api_key_fingerprint: str | None = None
 
 
 def flagevaluation_egress() -> FlagevaluationEgress:
@@ -73,7 +71,6 @@ def flagevaluation_egress() -> FlagevaluationEgress:
         interfaces.datadog_direct,
         (interfaces.datadog_sidecar,),
         EXPECTED_API_KEY,
-        EXPECTED_API_KEY_FINGERPRINT,
     )
 
 
@@ -350,8 +347,6 @@ class FlagevaluationEgressContract:
             assert request["response"]["status_code"] == 202
             headers = {name.lower(): value for name, value in request["request"]["headers"]}
             assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
-            if egress.expected_api_key_fingerprint is not None:
-                assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -2,17 +2,22 @@
 
 import json
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import cast
 
 
 from tests.ffe.utils.fixtures import JSON, make_ufc_fixture
 from utils import HttpResponse
+from utils import context
 from utils import features
 from utils import interfaces
 from utils import remote_config as rc
 from utils import scenario_crash
 from utils import scenarios
 from utils import weblog
+from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from utils.interfaces._core import ProxyBasedInterfaceValidator
+from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 
 RC_PRODUCT = "FFE_FLAGS"
@@ -22,6 +27,7 @@ EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
 EVP_DEGRADATION_OVERFLOW_EVALS = 2_000
+EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
 
 # Fixed input/output vector for the PII-protection tests. Every SDK's unit tests
 # should assert against the same input to prove byte-identical hashing across SDKs.
@@ -34,6 +40,41 @@ PII_ATTRIBUTES: dict[str, object] = {
     "region": "us-east-1",
     "account.tier": "gold",
 }
+
+
+@dataclass(frozen=True)
+class FlagevaluationEgress:
+    interface: ProxyBasedInterfaceValidator
+    excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
+    expected_api_key: str | None = None
+    expected_api_key_fingerprint: str | None = None
+
+
+def flagevaluation_egress() -> FlagevaluationEgress:
+    """Return the capture interface and route-only expectations for this topology."""
+    scenario = context.scenario
+    if not isinstance(scenario, FeatureFlaggingAgentlessEndToEndScenario):
+        assert scenario.name == "FEATURE_FLAGGING_AND_EXPERIMENTATION"
+        return FlagevaluationEgress(interfaces.agent)
+
+    if scenario.exposure_egress == "sidecar":
+        assert "serverless-init" in scenario.components
+        expected_api_key = scenario.serverless_init_container.environment["DD_API_KEY"]
+        assert expected_api_key is not None
+        return FlagevaluationEgress(
+            interfaces.datadog_sidecar,
+            (interfaces.datadog_direct,),
+            expected_api_key,
+        )
+
+    assert scenario.exposure_egress == "direct"
+    assert "serverless-init" not in scenario.components
+    return FlagevaluationEgress(
+        interfaces.datadog_direct,
+        (interfaces.datadog_sidecar,),
+        EXPECTED_API_KEY,
+        EXPECTED_API_KEY_FINGERPRINT,
+    )
 
 
 def make_multi_flag_fixture(flag_keys: list[str]) -> JSON:
@@ -234,6 +275,107 @@ def assert_no_duplicate_visible_events(events: list[tuple[JSON, JSON]]) -> None:
         seen.add(identity)
 
     assert not duplicates, f"found duplicate serialized-visible EVP buckets in one payload: {sorted(duplicates)}"
+
+
+class FlagevaluationEgressContract:
+    """One flagevaluation contract inherited by each supported topology adapter."""
+
+    # Agentless scenarios preload flags-v1.json before the weblog starts. Use the
+    # same known fixture key in every topology; the Agent scenario installs an
+    # equivalent fixture through Remote Config below.
+    flag_key = "empty-targeting-key-flag"
+    targeting_key = "evp-egress-user"
+    evaluation_count = 5
+
+    def setup_ffe_evp_flagevaluation_egress(self) -> None:
+        if not isinstance(context.scenario, FeatureFlaggingAgentlessEndToEndScenario):
+            config_id = "ffe-evp-egress"
+            rc.tracer_rc_state.reset().set_config(
+                f"{RC_PATH}/{config_id}/config",
+                make_ufc_fixture(self.flag_key),
+            ).apply()
+
+        self.responses = [
+            evaluate_flag(self.flag_key, targeting_key=self.targeting_key, attributes={})
+            for _ in range(self.evaluation_count)
+        ]
+
+        # Agentless targets are stopped immediately after setup, before test assertions run.
+        # Keep the target alive until buffered SDK writers have flushed to the selected route.
+        egress = flagevaluation_egress()
+        assert egress.interface.wait_for(
+            lambda data: bool(evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key)),
+            timeout=EVP_WAIT_TIMEOUT_SECONDS,
+        ), f"Timed out waiting for EVP flagevaluation event for flag {self.flag_key}"
+
+    def test_ffe_evp_flagevaluation_egress(self) -> None:
+        for index, response in enumerate(self.responses):
+            assert response.status_code == 200, f"Request {index + 1} failed: {response.text}"
+
+        egress = flagevaluation_egress()
+
+        def matcher(data: JSON) -> bool:
+            return bool(evp_flagevaluation_events_from_data(data, self.flag_key))
+
+        assert egress.interface.wait_for(
+            lambda data: matcher(cast("JSON", data)),
+            timeout=EVP_WAIT_TIMEOUT_SECONDS,
+        ), f"Timed out waiting for EVP flagevaluation event for flag {self.flag_key}"
+
+        matching_requests = [
+            cast("JSON", data)
+            for data in egress.interface.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH)
+            if matcher(cast("JSON", data))
+        ]
+        assert matching_requests, f"Expected flagevaluation requests for {self.flag_key}"
+
+        events: list[tuple[JSON, JSON]] = []
+        for request in matching_requests:
+            events.extend(evp_flagevaluation_events_from_data(request, self.flag_key))
+
+        assert events, f"Expected EVP flagevaluation events for flag {self.flag_key}"
+        for _, event in events:
+            assert_event_contract(event, self.flag_key)
+            assert object_key(event.get("variant"), "variant") == "on"
+            assert object_key(event.get("allocation"), "allocation") == "default-allocation"
+
+        assert_no_duplicate_visible_events(events)
+        assert_total_evaluation_count(events, self.evaluation_count, self.flag_key)
+
+        if egress.expected_api_key is None:
+            return
+
+        for request in matching_requests:
+            assert request["host"] == "event-platform-intake.mock-intake.invalid"
+            assert request["response"]["status_code"] == 202
+            headers = {name.lower(): value for name, value in request["request"]["headers"]}
+            assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+            if egress.expected_api_key_fingerprint is not None:
+                assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
+
+        for excluded_interface in egress.excluded_interfaces:
+            assert not any(
+                evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key)
+                for data in excluded_interface.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH)
+            )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent(FlagevaluationEgressContract):
+    pass
+
+
+@scenarios.feature_flagging_and_experimentation_agentless_direct
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct(FlagevaluationEgressContract):
+    pass
+
+
+@scenarios.feature_flagging_and_experimentation_agentless_serverless
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar(FlagevaluationEgressContract):
+    pass
 
 
 @scenarios.feature_flagging_and_experimentation

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -3375,6 +3375,15 @@
   "tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar::test_exposure_egress": [
     "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS"
   ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT"
+  ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS"
+  ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION"
+  ],
   "tests/integrations/test_cassandra.py::Test_Cassandra::test_main": [
     "INTEGRATIONS"
   ],

--- a/utils/build/docker/golang/net-http.Dockerfile
+++ b/utils/build/docker/golang/net-http.Dockerfile
@@ -26,7 +26,12 @@ RUN --mount=type=cache,target=${GOMODCACHE}                                     
 
 FROM golang:1.25-alpine
 
-RUN apk add --no-cache curl bash gcc musl-dev
+RUN apk add --no-cache curl bash gcc musl-dev ca-certificates
+
+# Agentless intake tests send HTTPS through the system-tests mitmproxy. Trust the
+# checked-in test CA so Go validates that intercepted TLS connection.
+COPY ./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer /usr/local/share/ca-certificates/system-tests-mitmproxy-ca.crt
+RUN update-ca-certificates
 
 COPY --from=build /app/weblog /app/weblog
 COPY --from=build /app/SYSTEM_TESTS_LIBRARY_VERSION /app/SYSTEM_TESTS_LIBRARY_VERSION


### PR DESCRIPTION
## Motivation

[FFL-1491](https://linear.app/datadoghq/issue/FFL-1491)

Go needs system-test coverage proving exposure and flagevaluation delivery through Agent, direct, and serverless-sidecar EVP routes.

## Changes

- Add the shared flagevaluation egress contract for Agent, direct, and serverless-sidecar scenarios.
- Enable Go agentless exposure and flagevaluation route coverage in the manifest.
- Assert direct intake host, response status, API-key authentication, and absence from the unused route.
- Keep buffered writers alive through flush and isolate aggregate counts by targeting key.
- Trust the checked-in MITM CA in the Go test image while retaining TLS verification.

## Decisions

- Validate exposure and flagevaluation together in each deployment topology.
- Accept the API key as either its expected value or the capture layer's redacted value.
- Preserve exact payload, aggregate-count, deduplication, and route-exclusion assertions.
- Keep this draft stacked on `pavlo.khrebto/FFL-2695/go-agentless-configuration`.

## Validation

- `./format.sh`
- `./build.sh golang -w net-http` using the local Go EVP branch artifact
- `FEATURE_FLAGGING_AND_EXPERIMENTATION`: 2 passed
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT`: 2 passed
- `FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS`: 2 passed
