### PR TITLE
test(nodejs): validate agentless EVP exposure egress

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1832,8 +1832,6 @@ manifest:
     - weblog_declaration:
         "*": incomplete_test_app
         express4: *ref_5_77_0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (dd-trace-js#9527)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (dd-trace-js#9527)
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -169,6 +169,11 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         )
 
         if exposure_egress == "direct":
+            if self.weblog_infra.library_name == "nodejs":
+                # Node.js does not load the operating-system CA bundle by default.
+                self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = (
+                    "/etc/ssl/certs/ca-certificates.crt"
+                )
             # Direct mode uses the proxy only to capture HTTPS intake requests.
             # Do not advertise the proxy as a local Agent endpoint.
             for env_name in ("DD_AGENT_HOST", "DD_DOGSTATSD_HOST", "DD_TRACE_AGENT_PORT", "DD_TRACE_AGENT_URL"):

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -169,11 +169,11 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         )
 
         if exposure_egress == "direct":
-            if self.weblog_infra.library_name == "nodejs":
-                # Node.js does not load the operating-system CA bundle by default.
-                self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = (
-                    "/etc/ssl/certs/ca-certificates.crt"
-                )
+            # Node.js does not load the operating-system CA bundle by default. Other
+            # runtimes ignore this Node-only variable.
+            self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = (
+                "/etc/ssl/certs/ca-certificates.crt"
+            )
             # Direct mode uses the proxy only to capture HTTPS intake requests.
             # Do not advertise the proxy as a local Agent endpoint.
             for env_name in ("DD_AGENT_HOST", "DD_DOGSTATSD_HOST", "DD_TRACE_AGENT_PORT", "DD_TRACE_AGENT_URL"):


### PR DESCRIPTION
## Motivation

Node.js agentless exposure delivery needs route-level coverage for direct and sidecar deployments.

## Changes

- Activate Node.js direct and sidecar exposure egress coverage.
- Configure `NODE_EXTRA_CA_CERTS` for the mounted checked-in system-test proxy CA.
- Reuse the shared agentless scenario infrastructure from the Python system-test branch.

## Decisions

- Preserve TLS verification through the system-test proxy.
- Assert direct EVP authentication with `DD-API-KEY`.
- Keep the draft stacked on `leo.romanovsky/ffe-agentless-evp-fallback-python-tests` for the shared direct-scenario infrastructure.

## Validation

- Focused `TEST_THE_TEST` agentless-backend suite: 9 passed.
- Node.js Agent, direct, and sidecar focused runs: the exposure test passed in each topology.

Tracks [FFL-1488](https://linear.app/datadoghq/issue/FFL-1488).


[FFL-1488]: https://datadoghq.atlassian.net/browse/FFL-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ