### PR TITLE
test(ffe): validate Python agentless EVP fallback

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1444,8 +1444,8 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_From_Start: v4.0.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: flaky (FFL-1622)
   tests/ffe/test_exposure_egress.py: v4.2.0-dev
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: v4.15.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: v4.15.0-dev
   tests/ffe/test_exposures_datadog_agent.py: v4.2.0-dev
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3413)

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -10,15 +10,11 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
-EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
-
-
 @dataclass(frozen=True)
 class ExposureEgress:
     interface: ProxyBasedInterfaceValidator
     excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
     expected_api_key: str | None = None
-    expected_api_key_fingerprint: str | None = None
 
 
 def exposure_egress() -> ExposureEgress:
@@ -44,7 +40,6 @@ def exposure_egress() -> ExposureEgress:
         interfaces.datadog_direct,
         (interfaces.datadog_sidecar,),
         EXPECTED_API_KEY,
-        EXPECTED_API_KEY_FINGERPRINT,
     )
 
 
@@ -96,8 +91,6 @@ class ExposureEgressContract:
 
         headers = {name.lower(): value for name, value in request["request"]["headers"]}
         assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
-        if egress.expected_api_key_fingerprint is not None:
-            assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -10,6 +10,7 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
+FLAG_EVALUATIONS_PATH = "/api/v2/flagevaluation"
 
 
 @dataclass(frozen=True)
@@ -45,11 +46,42 @@ def exposure_egress() -> ExposureEgress:
     )
 
 
+def flag_evaluation_events_from_data(data: dict, flag_key: str) -> list[dict]:
+    """Return matching flag-evaluation events from one captured request."""
+    if data.get("path") != FLAG_EVALUATIONS_PATH:
+        return []
+
+    content = data.get("request", {}).get("content")
+    if not isinstance(content, dict):
+        return []
+
+    events = content.get("flagEvaluations")
+    if not isinstance(events, list):
+        return []
+
+    return [
+        event
+        for event in events
+        if isinstance(event, dict) and isinstance(event.get("flag"), dict) and event["flag"].get("key") == flag_key
+    ]
+
+
+def assert_direct_delivery_request(request: dict, egress: ExposureEgress) -> None:
+    """Assert authentication and routing for a sidecar or direct intake request."""
+    assert egress.expected_api_key is not None
+    assert request["host"] == "event-platform-intake.mock-intake.invalid"
+    assert request["response"]["status_code"] == 202
+
+    headers = {name.lower(): value for name, value in request["request"]["headers"]}
+    assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+
+
 class ExposureEgressContract:
     """One exposure contract inherited by each supported topology adapter."""
 
     flag_key = "empty-targeting-key-flag"
     targeting_key = "exposure-egress-user"
+    validate_flag_evaluation = False
 
     def setup_exposure_egress(self) -> None:
         if not isinstance(context.scenario, FeatureFlaggingAgentlessEndToEndScenario):
@@ -87,17 +119,42 @@ class ExposureEgressContract:
         if egress.expected_api_key is None:
             return
 
-        request = matching_requests[0]
-        assert request["host"] == "event-platform-intake.mock-intake.invalid"
-        assert request["response"]["status_code"] == 202
-
-        headers = {name.lower(): value for name, value in request["request"]["headers"]}
-        assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+        assert_direct_delivery_request(matching_requests[0], egress)
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(
                 exposure_events_from_data(data, {self.flag_key}, self.targeting_key)
                 for data in excluded_interface.get_data()
+            )
+
+        if not self.validate_flag_evaluation:
+            return
+
+        def matches_flag_evaluation(data: dict) -> bool:
+            return bool(flag_evaluation_events_from_data(data, self.flag_key))
+
+        assert egress.interface.wait_for(matches_flag_evaluation, timeout=30), (
+            f"Timed out waiting for flag-evaluation event for {self.flag_key!r}"
+        )
+        flag_evaluation_requests = [data for data in egress.interface.get_data() if matches_flag_evaluation(data)]
+        flag_evaluation_events = [
+            event
+            for request in flag_evaluation_requests
+            for event in flag_evaluation_events_from_data(request, self.flag_key)
+        ]
+        assert sum(event.get("evaluation_count", 0) for event in flag_evaluation_events) == len(self.responses)
+
+        for event in flag_evaluation_events:
+            assert event["flag"]["key"] == self.flag_key
+            assert event["variant"]["key"] == "on"
+            assert event["allocation"]["key"] == "default-allocation"
+
+        for request in flag_evaluation_requests:
+            assert_direct_delivery_request(request, egress)
+
+        for excluded_interface in egress.excluded_interfaces:
+            assert not any(
+                flag_evaluation_events_from_data(data, self.flag_key) for data in excluded_interface.get_data()
             )
 
 
@@ -108,12 +165,14 @@ class Test_FFE_Exposure_Egress_Datadog_Agent(ExposureEgressContract):
 
 
 @scenarios.feature_flagging_and_experimentation_agentless_direct
+@features.feature_flags_evp_flagevaluation
 @features.feature_flags_exposures
 class Test_FFE_Exposure_Egress_Agentless_Direct(ExposureEgressContract):
-    pass
+    validate_flag_evaluation = True
 
 
 @scenarios.feature_flagging_and_experimentation_agentless_serverless
+@features.feature_flags_evp_flagevaluation
 @features.feature_flags_exposures
 class Test_FFE_Exposure_Egress_Agentless_Sidecar(ExposureEgressContract):
-    pass
+    validate_flag_evaluation = True

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -10,6 +10,8 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
+
+
 @dataclass(frozen=True)
 class ExposureEgress:
     interface: ProxyBasedInterfaceValidator

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -10,6 +10,7 @@ from utils.interfaces._core import ProxyBasedInterfaceValidator
 from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 RC_PATH = "datadog/2/FFE_FLAGS"
+EXPECTED_API_KEY_FINGERPRINT = "rijn_Fc1Sxm6lPHiKU1IdWeNqpcVZiiW3C2LXJLqQp670sFU"
 
 
 @dataclass(frozen=True)
@@ -17,6 +18,7 @@ class ExposureEgress:
     interface: ProxyBasedInterfaceValidator
     excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
     expected_api_key: str | None = None
+    expected_api_key_fingerprint: str | None = None
 
 
 def exposure_egress() -> ExposureEgress:
@@ -42,6 +44,7 @@ def exposure_egress() -> ExposureEgress:
         interfaces.datadog_direct,
         (interfaces.datadog_sidecar,),
         EXPECTED_API_KEY,
+        EXPECTED_API_KEY_FINGERPRINT,
     )
 
 
@@ -93,6 +96,8 @@ class ExposureEgressContract:
 
         headers = {name.lower(): value for name, value in request["request"]["headers"]}
         assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+        if egress.expected_api_key_fingerprint is not None:
+            assert headers["dd-api-key-fingerprint"] == egress.expected_api_key_fingerprint
 
         for excluded_interface in egress.excluded_interfaces:
             assert not any(

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -850,13 +850,13 @@ class _Scenarios:
 
     feature_flagging_and_experimentation_agentless_direct = FeatureFlaggingAgentlessEndToEndScenario(
         "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT",
-        doc="Validate direct exposure delivery with agentless UFC and no local receiver.",
+        doc="Validate direct exposure and flag-evaluation delivery with agentless UFC and no local receiver.",
         exposure_egress="direct",
     )
 
     feature_flagging_and_experimentation_agentless_serverless = FeatureFlaggingAgentlessEndToEndScenario(
         "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS",
-        doc="Validate exposure delivery with agentless UFC and serverless-init.",
+        doc="Validate exposure and flag-evaluation delivery with agentless UFC and serverless-init.",
         exposure_egress="sidecar",
     )
 

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -173,6 +173,10 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
             # Do not advertise the proxy as a local Agent endpoint.
             for env_name in ("DD_AGENT_HOST", "DD_DOGSTATSD_HOST", "DD_TRACE_AGENT_PORT", "DD_TRACE_AGENT_URL"):
                 self.weblog_infra.library_container.environment.pop(env_name, None)
+            self.weblog_infra.library_container.volumes["./utils/build/docker/agent/ca-certificates.crt"] = {
+                "bind": "/etc/ssl/certs/ca-certificates.crt",
+                "mode": "ro",
+            }
 
     def configure(self, config: pytest.Config) -> None:
         try:


### PR DESCRIPTION
## Motivation

Python needs system-test coverage proving that agentless exposure and flag-evaluation EVP payloads reach the configured direct or serverless intake route.

Linear: [FFL-1489](https://linear.app/datadoghq/issue/FFL-1489)

## Changes

- Activate the Python agentless direct and serverless scenarios at `v4.15.0-dev`.
- Validate exposure and `/api/v2/flagevaluation` payloads from the same evaluation sequence.
- Assert destination host, response status, API-key authentication, evaluation counts, and absence from the excluded intake route.
- Mount the test CA bundle for direct HTTPS intake capture.

## Decisions

- The direct and serverless adapters inherit one shared egress contract.
- The existing Agent-backed exposure scenario keeps its current scope.
- Manifest activation stays future-facing until the SDK version containing the fallback is available.

## Validation

- `./format.sh`: passed, including mypy, Ruff, YAML validation, shellcheck, and Node linters.
- `TEST_LIBRARY=python ./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT -F tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct`: 1 passed, 3018 deselected against a freshly built Python 3.11 branch artifact.


[FFL-1489]: https://datadoghq.atlassian.net/browse/FFL-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ