### PR TITLE
test(python): let a weblog declare its request timeout, 10s for uwsgi-poc

### DIFF
--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -22,6 +22,7 @@ from utils._context.component_version import ComponentVersion, Version
 from utils._context.docker import get_docker_client
 from utils._context._image_mirror import mirror_image
 from utils._context.constants import ContainerPorts
+from utils._context.weblog_metadata import WeblogMetaData
 from utils.docker_fixtures._core import extra_hosts_for_environment
 from utils.proxy.tuf import get_tuf_root_json
 from utils.proxy.ports import ProxyPorts
@@ -1078,6 +1079,11 @@ class WeblogContainer(TestedContainer):
         self._set_aws_auth_environment()
 
         library = self.image.labels["system-tests-library"]
+
+        metadata = next((w for w in WeblogMetaData.load(library) if w.name == self.weblog_variant), None)
+        if metadata is not None and metadata.request_timeout is not None:
+            logger.info(f"Weblog {self.weblog_variant} declares a {metadata.request_timeout}s request timeout")
+            weblog.set_default_timeout(metadata.request_timeout)
 
         header_tags = ""
         if library in ("cpp_nginx", "cpp_httpd", "dotnet", "java", "python"):

--- a/utils/_context/weblog_metadata.py
+++ b/utils/_context/weblog_metadata.py
@@ -19,6 +19,9 @@ class WeblogMetaData:
 
     categories: list[WeblogCategory] = field(default_factory=list)
 
+    request_timeout: int | None = None
+    """ Read timeout in seconds for HTTP requests sent to this weblog. None means use the default. """
+
     def __post_init__(self):
         # cast enums
         self.build_mode = WeblogBuildMode(self.build_mode)

--- a/utils/_weblog.py
+++ b/utils/_weblog.py
@@ -98,7 +98,7 @@ class HttpResponse:
 
 # TODO : this should be build by weblog container
 class _Weblog:
-    def __init__(self, session: requests.Session | None = None):
+    def __init__(self, session: requests.Session | None = None, default_timeout: int = 5):
         if "SYSTEM_TESTS_WEBLOG_PORT" in os.environ:
             self.port = int(os.environ["SYSTEM_TESTS_WEBLOG_PORT"])
         else:
@@ -127,8 +127,16 @@ class _Weblog:
 
         self._default_retries = 1
 
+        # Read timeout in seconds, applied when a request does not pass one explicitly.
+        # Configurable per weblog, see set_default_timeout.
+        self._default_timeout = default_timeout
+
     def set_request_default_retry(self, value: int) -> None:
         self._retries = value
+
+    def set_default_timeout(self, value: int) -> None:
+        """Set the default read timeout, in seconds, for requests that don't pass one."""
+        self._default_timeout = value
 
     def get(
         self,
@@ -137,7 +145,7 @@ class _Weblog:
         headers: dict | None = None,
         cookies: dict | None = None,
         *,
-        timeout: int = 5,
+        timeout: int | None = None,
         allow_redirects: bool = True,
         rid_in_user_agent: bool = True,
     ):
@@ -162,7 +170,7 @@ class _Weblog:
         json: dict | list | None = None,
         files: dict | None = None,
         cookies: dict | None = None,
-        timeout: int = 5,
+        timeout: int | None = None,
     ):
         return self.request(
             "POST",
@@ -183,7 +191,7 @@ class _Weblog:
         data: dict | str | None = None,
         headers: dict | None = None,
         *,
-        timeout: int = 5,
+        timeout: int | None = None,
     ):
         return self.request("TRACE", path, params=params, data=data, headers=headers, timeout=timeout)
 
@@ -203,8 +211,11 @@ class _Weblog:
         port: int | None = None,
         allow_redirects: bool = True,
         rid_in_user_agent: bool = True,
-        timeout: int = 5,
+        timeout: int | None = None,
     ):
+        if timeout is None:
+            timeout = self._default_timeout
+
         rid = "".join(random.choices(string.ascii_uppercase, k=36))
         headers = {**headers} if headers else {}  # get our own copy of headers, as we'll modify them
 
@@ -330,7 +341,7 @@ class _Weblog:
     @contextmanager
     def get_session(self) -> Generator["_Weblog", None, None]:
         with requests.Session() as session:
-            yield _Weblog(session)
+            yield _Weblog(session, default_timeout=self._default_timeout)
 
 
 weblog = _Weblog()

--- a/utils/build/docker/python/weblog_metadata.yml
+++ b/utils/build/docker/python/weblog_metadata.yml
@@ -24,6 +24,7 @@ python3.12:
   excluded_scenarios: [CROSSED_TRACING_LIBRARIES]  # APMAPI-1096
 uwsgi-poc:
   categories: [dd_trace]
+  request_timeout: 10
 uds-flask:
   categories: [dd_trace]
   excluded_scenarios: [IPV6]


### PR DESCRIPTION
APPSEC-69833

`uwsgi-poc` occasionally stalls a few seconds on an early request, exceeding the weblog client's 5s read timeout. The test then gets no response at all and fails on a null status code, though the weblog answered a moment later (seen in CI: 403 after 6517ms, client gave up at 5000ms). The trace was flushed and collected normally, so only the HTTP leg was affected.

Makes the client's default read timeout configurable, declared per weblog in `weblog_metadata.yml`. Only `uwsgi-poc` sets one (10s); every other weblog keeps 5s, and explicit per-call timeouts are unchanged.

This reduces flake exposure, it does not explain the stall — still under investigation.