### PR TITLE
Mark regressed OTLP trace metrics tests as bug

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2131,7 +2131,17 @@ manifest:
   tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling: missing_feature (APMAPI-2171)
   tests/parametric/test_otlp_trace_metrics.py: v4.14.0-dev
   tests/parametric/test_otlp_trace_metrics.py::Test_FR01_Enablement_Configuration::test_fr01_6_disabled_when_apm_tracing_disabled: missing_feature (OTLP trace metrics are still emitted when DD_APM_TRACING_ENABLED=false)
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Resource_Attributes::test_fr06_15_default_service_on_data_point: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Span_Attributes::test_fr06_2_span_kind: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Span_Attributes::test_fr06_8_status_code_error: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_10_dd_tags_tracer_tags_resource_attributes: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_11_otel_resource_attributes_env_tracer_tags: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_AdditionalTags::test_fr08_12_stats_additional_tags: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_Datadog_Attributes::test_fr08_13_is_trace_root: bug
   tests/parametric/test_otlp_trace_metrics.py::Test_FR08_Datadog_Attributes::test_fr08_14_peer_tags: missing_feature (Blocked on test-agent support for advertising a peer_tags allowlist in /info)
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_Datadog_Attributes::test_fr08_15_service_source: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR08_Datadog_Attributes::test_fr08_8_process_tags: bug
+  tests/parametric/test_otlp_trace_metrics.py::Test_FR09_Red_Metric_Derivation::test_fr09_2_error_count: bug
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_DDTrace_Baggage: v2.16.0
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_FFE_Start: v4.0.0
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Otel_Baggage: v2.16.0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bbefdbd2-5963-49ac-bdf2-ec18eb6545ef","source":"chat","resourceId":"07eee352-dac5-4db5-9d2b-673378e8ae06","workflowId":"b83b4e8c-fdd8-46a5-b025-e76304ae5988","codeChangeId":"b83b4e8c-fdd8-46a5-b025-e76304ae5988","sourceType":"assistant"} -->
## Motivation

Ten parametric tests under `tests/parametric/test_otlp_trace_metrics.py` were previously passing (xpassed), and their `missing_feature` markers were legitimately removed in commit cb44c9dfc. A subsequent dd-trace-py regression broke these tests. Marking them as `bug` keeps the manifest accurate and CI green while the tracer regression is tracked and fixed by the owner (tickets to be added later).

## Changes

- In `manifests/python.yml`, added `bug` declarations (bare `bug`, no ticket number) for 10 regressed parametric tests alongside the existing test-level overrides for `tests/parametric/test_otlp_trace_metrics.py`, keeping the block in alphabetical order:
  - `Test_FR06_Otel_Resource_Attributes::test_fr06_15_default_service_on_data_point`
  - `Test_FR06_Otel_Span_Attributes::test_fr06_2_span_kind`
  - `Test_FR06_Otel_Span_Attributes::test_fr06_8_status_code_error`
  - `Test_FR08_AdditionalTags::test_fr08_10_dd_tags_tracer_tags_resource_attributes`
  - `Test_FR08_AdditionalTags::test_fr08_11_otel_resource_attributes_env_tracer_tags`
  - `Test_FR08_AdditionalTags::test_fr08_12_stats_additional_tags`
  - `Test_FR08_Datadog_Attributes::test_fr08_13_is_trace_root`
  - `Test_FR08_Datadog_Attributes::test_fr08_15_service_source`
  - `Test_FR08_Datadog_Attributes::test_fr08_8_process_tags`
  - `Test_FR09_Red_Metric_Derivation::test_fr09_2_error_count`

## Testing

- Verified `manifests/python.yml` remains valid YAML.
- Change is confined to `manifests/` (test declarations only); no framework or test logic modified.

## Reviewer checklist

* [x] Anything but `tests/` or `manifests/` is modified ? Only `manifests/` is modified.
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from R&P team

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/07eee352-dac5-4db5-9d2b-673378e8ae06)

Comment @datadog to request changes