### PR TITLE
test(ffe): validate Node and Java EVP egress

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1158,6 +1158,8 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3414)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3414)
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: missing_feature (Not yet implemented)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: v2.11.0-dev

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3351,8 +3351,14 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.56.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.66.0-SNAPSHOT
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.66.0-SNAPSHOT
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": irrelevant
@@ -3362,7 +3368,29 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3415)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3415)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3415)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Basic: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Context_Bounds: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Count: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.66.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.66.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.66.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_High_Cardinality_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Load_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Runtime_Default: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:
         "*": irrelevant

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1843,7 +1843,29 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3412)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3412)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3412)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Basic: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Context_Bounds: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Count: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_High_Cardinality_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Load_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Runtime_Default: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/tests/ffe/test_exposure_egress.py
+++ b/tests/ffe/test_exposure_egress.py
@@ -2,7 +2,11 @@
 
 from dataclasses import dataclass
 
-from tests.ffe.utils.exposures import assert_exposure_side_effects_contract, exposure_events_from_data
+from tests.ffe.utils.exposures import (
+    EXPOSURE_WAIT_TIMEOUT_SECONDS,
+    assert_exposure_side_effects_contract,
+    exposure_events_from_data,
+)
 from tests.ffe.utils.fixtures import make_ufc_fixture
 from utils import context, features, interfaces, remote_config as rc, scenarios, weblog
 from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
@@ -71,6 +75,12 @@ class ExposureEgressContract:
             )
             for _ in range(5)
         ]
+
+        egress = exposure_egress()
+        assert egress.interface.wait_for(
+            lambda data: bool(exposure_events_from_data(data, {self.flag_key}, self.targeting_key)),
+            timeout=EXPOSURE_WAIT_TIMEOUT_SECONDS,
+        ), f"Timed out waiting for exposure event for {self.flag_key!r} and {self.targeting_key!r}"
 
     def test_exposure_egress(self) -> None:
         egress = exposure_egress()

--- a/tests/ffe/test_flag_eval_evp.py
+++ b/tests/ffe/test_flag_eval_evp.py
@@ -1,18 +1,24 @@
 """Test server-side feature flag evaluation counts via EVP flagevaluation."""
 
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import cast
 
 
 from tests.ffe.utils.fixtures import JSON, make_ufc_fixture
 from utils import HttpResponse
+from utils import context
 from utils import features
 from utils import interfaces
 from utils import remote_config as rc
 from utils import scenario_crash
 from utils import scenarios
 from utils import weblog
+from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from utils.interfaces._core import ProxyBasedInterfaceValidator
+from utils.mocked_backend.ffe import EXPECTED_API_KEY
 
 
 RC_PRODUCT = "FFE_FLAGS"
@@ -22,7 +28,6 @@ EVP_WAIT_TIMEOUT_SECONDS = 30
 EVP_LOAD_WAIT_TIMEOUT_SECONDS = 60
 EVP_FULL_TIER_PER_FLAG_CAP = 10_000
 EVP_DEGRADATION_OVERFLOW_EVALS = 2_000
-
 # Fixed input/output vector for the PII-protection tests. Every SDK's unit tests
 # should assert against the same input to prove byte-identical hashing across SDKs.
 PII_TARGETING_KEY = "jane.doe@datadoghq.com"
@@ -34,6 +39,39 @@ PII_ATTRIBUTES: dict[str, object] = {
     "region": "us-east-1",
     "account.tier": "gold",
 }
+
+
+@dataclass(frozen=True)
+class FlagevaluationEgress:
+    interface: ProxyBasedInterfaceValidator
+    excluded_interfaces: tuple[ProxyBasedInterfaceValidator, ...] = ()
+    expected_api_key: str | None = None
+
+
+def flagevaluation_egress() -> FlagevaluationEgress:
+    """Return the capture interface and route-only expectations for this topology."""
+    scenario = context.scenario
+    if not isinstance(scenario, FeatureFlaggingAgentlessEndToEndScenario):
+        assert scenario.name == "FEATURE_FLAGGING_AND_EXPERIMENTATION"
+        return FlagevaluationEgress(interfaces.agent)
+
+    if scenario.exposure_egress == "sidecar":
+        assert "serverless-init" in scenario.components
+        expected_api_key = scenario.serverless_init_container.environment["DD_API_KEY"]
+        assert expected_api_key is not None
+        return FlagevaluationEgress(
+            interfaces.datadog_sidecar,
+            (interfaces.datadog_direct,),
+            expected_api_key,
+        )
+
+    assert scenario.exposure_egress == "direct"
+    assert "serverless-init" not in scenario.components
+    return FlagevaluationEgress(
+        interfaces.datadog_direct,
+        (interfaces.datadog_sidecar,),
+        EXPECTED_API_KEY,
+    )
 
 
 def make_multi_flag_fixture(flag_keys: list[str]) -> JSON:
@@ -65,7 +103,9 @@ def evaluate_flag(
     return weblog.post("/ffe", json=payload)
 
 
-def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple[JSON, JSON]]:
+def evp_flagevaluation_events_from_data(
+    data: JSON, flag_key: str, targeting_key: str | None = None
+) -> list[tuple[JSON, JSON]]:
     if data.get("path") != EVP_FLAGEVALUATIONS_PATH:
         return []
 
@@ -87,8 +127,15 @@ def evp_flagevaluation_events_from_data(data: JSON, flag_key: str) -> list[tuple
             continue
 
         flag = event.get("flag")
-        if isinstance(flag, dict) and flag.get("key") == flag_key:
-            results.append((cast("JSON", content), cast("JSON", event)))
+        if not isinstance(flag, dict) or flag.get("key") != flag_key:
+            continue
+
+        if targeting_key is not None:
+            hashed_targeting_key = f"sha256_{hashlib.sha256(targeting_key.encode()).hexdigest()}"
+            if event.get("targeting_key") not in (targeting_key, hashed_targeting_key):
+                continue
+
+        results.append((cast("JSON", content), cast("JSON", event)))
 
     return results
 
@@ -234,6 +281,97 @@ def assert_no_duplicate_visible_events(events: list[tuple[JSON, JSON]]) -> None:
         seen.add(identity)
 
     assert not duplicates, f"found duplicate serialized-visible EVP buckets in one payload: {sorted(duplicates)}"
+
+
+class FlagevaluationEgressContract:
+    """One flagevaluation contract inherited by each supported topology adapter."""
+
+    # Agentless scenarios preload flags-v1.json before the weblog starts. Use the
+    # same known fixture key in every topology; the Agent scenario installs an
+    # equivalent fixture through Remote Config below.
+    flag_key = "empty-targeting-key-flag"
+    targeting_key = "evp-egress-user"
+    evaluation_count = 5
+
+    def setup_ffe_evp_flagevaluation_egress(self) -> None:
+        if not isinstance(context.scenario, FeatureFlaggingAgentlessEndToEndScenario):
+            config_id = "ffe-evp-egress"
+            rc.tracer_rc_state.reset().set_config(
+                f"{RC_PATH}/{config_id}/config",
+                make_ufc_fixture(self.flag_key),
+            ).apply()
+
+        self.responses = [
+            evaluate_flag(self.flag_key, targeting_key=self.targeting_key, attributes={})
+            for _ in range(self.evaluation_count)
+        ]
+
+    def test_ffe_evp_flagevaluation_egress(self) -> None:
+        for index, response in enumerate(self.responses):
+            assert response.status_code == 200, f"Request {index + 1} failed: {response.text}"
+
+        egress = flagevaluation_egress()
+
+        def matcher(data: JSON) -> bool:
+            return bool(evp_flagevaluation_events_from_data(data, self.flag_key, self.targeting_key))
+
+        assert egress.interface.wait_for(
+            lambda data: matcher(cast("JSON", data)),
+            timeout=EVP_WAIT_TIMEOUT_SECONDS,
+        ), f"Timed out waiting for EVP flagevaluation event for flag {self.flag_key}"
+
+        matching_requests = [
+            cast("JSON", data)
+            for data in egress.interface.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH)
+            if matcher(cast("JSON", data))
+        ]
+        assert matching_requests, f"Expected flagevaluation requests for {self.flag_key}"
+
+        events: list[tuple[JSON, JSON]] = []
+        for request in matching_requests:
+            events.extend(evp_flagevaluation_events_from_data(request, self.flag_key, self.targeting_key))
+
+        assert events, f"Expected EVP flagevaluation events for flag {self.flag_key}"
+        for _, event in events:
+            assert_event_contract(event, self.flag_key)
+            assert object_key(event.get("variant"), "variant") == "on"
+            assert object_key(event.get("allocation"), "allocation") == "default-allocation"
+
+        assert_no_duplicate_visible_events(events)
+        assert_total_evaluation_count(events, self.evaluation_count, self.flag_key)
+
+        if egress.expected_api_key is None:
+            return
+
+        for request in matching_requests:
+            assert request["host"] == "event-platform-intake.mock-intake.invalid"
+            assert request["response"]["status_code"] == 202
+            headers = {name.lower(): value for name, value in request["request"]["headers"]}
+            assert headers["dd-api-key"] in {egress.expected_api_key, "--redacted--"}
+
+        for excluded_interface in egress.excluded_interfaces:
+            assert not any(
+                evp_flagevaluation_events_from_data(cast("JSON", data), self.flag_key, self.targeting_key)
+                for data in excluded_interface.get_data(path_filters=EVP_FLAGEVALUATIONS_PATH)
+            )
+
+
+@scenarios.feature_flagging_and_experimentation
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent(FlagevaluationEgressContract):
+    pass
+
+
+@scenarios.feature_flagging_and_experimentation_agentless_direct
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct(FlagevaluationEgressContract):
+    pass
+
+
+@scenarios.feature_flagging_and_experimentation_agentless_serverless
+@features.feature_flags_evp_flagevaluation
+class Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar(FlagevaluationEgressContract):
+    pass
 
 
 @scenarios.feature_flagging_and_experimentation

--- a/tests/test_the_test/scenarios.json
+++ b/tests/test_the_test/scenarios.json
@@ -3390,6 +3390,15 @@
   "tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar::test_exposure_egress": [
     "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS"
   ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT"
+  ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS"
+  ],
+  "tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent::test_ffe_evp_flagevaluation_egress": [
+    "FEATURE_FLAGGING_AND_EXPERIMENTATION"
+  ],
   "tests/integrations/test_cassandra.py::Test_Cassandra::test_main": [
     "INTEGRATIONS"
   ],

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -169,6 +169,14 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         )
 
         if exposure_egress == "direct":
+            # Node.js does not load the system-test proxy CA by default. Other
+            # runtimes ignore this Node-only variable.
+            proxy_ca_path = "/etc/system-tests/mitmproxy-ca.pem"
+            self.weblog_infra.library_container.volumes["./utils/build/docker/agent/ca-certificates.crt"] = {
+                "bind": proxy_ca_path,
+                "mode": "ro",
+            }
+            self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = proxy_ca_path
             # Direct mode uses the proxy only to capture HTTPS intake requests.
             # Do not advertise the proxy as a local Agent endpoint.
             for env_name in ("DD_AGENT_HOST", "DD_DOGSTATSD_HOST", "DD_TRACE_AGENT_PORT", "DD_TRACE_AGENT_URL"):

--- a/utils/build/docker/java/spring-boot.Dockerfile
+++ b/utils/build/docker/java/spring-boot.Dockerfile
@@ -19,6 +19,15 @@ RUN /binaries/install_drop_in.sh
 FROM eclipse-temurin:11-jre
 
 WORKDIR /app
+
+# Agentless intake tests send HTTPS through the system-tests mitmproxy. Trust the
+# checked-in test CA so Java validates that intercepted TLS connection.
+COPY ./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer /tmp/system-tests-mitmproxy-ca.cer
+RUN keytool -importcert -noprompt -cacerts -storepass changeit \
+    -alias system-tests-mitmproxy \
+    -file /tmp/system-tests-mitmproxy-ca.cer \
+    && rm /tmp/system-tests-mitmproxy-ca.cer
+
 COPY --from=build /binaries/SYSTEM_TESTS_LIBRARY_VERSION SYSTEM_TESTS_LIBRARY_VERSION
 
 COPY --from=build /app/target/myproject-0.0.1-SNAPSHOT.jar /app/app.jar


### PR DESCRIPTION
## Motivation

Server-side flag-evaluation and exposure events need route-level coverage for Agent, agentless direct, and agentless sidecar delivery.

## Changes

- Add shared flag-evaluation egress tests for the three delivery topologies.
- Assert aggregate evaluation count, payload fields, selected route, direct `DD-API-KEY` authentication, and zero events on unused routes.
- Activate the flag-evaluation contract for Node.js `express4` and Java `spring-boot`.
- Activate Java exposure egress coverage for agentless direct and sidecar delivery.
- Mark the two Go agentless flag-evaluation routes as pending implementation.
- Configure the Node.js and Java test images to trust the checked-in system-test proxy CA.
- Wait for asynchronous exposure capture before teardown and accept raw or SHA-256-prefixed targeting keys in the shared payload matcher.

## Decisions

- Preserve TLS verification through the system-test proxy.
- Accept multiple flushes while asserting the exact aggregate event count.
- Exercise Node.js with DataDog/dd-trace-js#8902 and DataDog/dd-trace-js#9988.
- Exercise Java with DataDog/dd-trace-java#12299.

## Validation

- `./format.sh`
- Focused `TEST_THE_TEST` manifest, scenario-registration, and agentless-topology suite: 43 passed.
- Node.js Agent, direct, and sidecar combined exposure and flag-evaluation runs: 2 passed per topology.
- Java Agent, direct, and sidecar combined exposure and flag-evaluation runs: 2 passed per topology.

Tracks [FFL-1488](https://linear.app/datadoghq/issue/FFL-1488) and [FFL-1490](https://linear.app/datadoghq/issue/FFL-1490).