### PR TITLE
test(nodejs): validate agentless EVP exposure egress

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1832,8 +1832,14 @@ manifest:
     - weblog_declaration:
         "*": incomplete_test_app
         express4: *ref_5_77_0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (dd-trace-js#9527)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (dd-trace-js#9527)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -169,18 +169,19 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         )
 
         if exposure_egress == "direct":
-            # Node.js does not load the system-test proxy CA by default. Other
+            # Node.js does not load the operating-system CA bundle by default. Other
             # runtimes ignore this Node-only variable.
-            proxy_ca_path = "/etc/system-tests/mitmproxy-ca.pem"
-            self.weblog_infra.library_container.volumes["./utils/build/docker/agent/ca-certificates.crt"] = {
-                "bind": proxy_ca_path,
-                "mode": "ro",
-            }
-            self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = proxy_ca_path
+            self.weblog_infra.library_container.environment["NODE_EXTRA_CA_CERTS"] = (
+                "/etc/ssl/certs/ca-certificates.crt"
+            )
             # Direct mode uses the proxy only to capture HTTPS intake requests.
             # Do not advertise the proxy as a local Agent endpoint.
             for env_name in ("DD_AGENT_HOST", "DD_DOGSTATSD_HOST", "DD_TRACE_AGENT_PORT", "DD_TRACE_AGENT_URL"):
                 self.weblog_infra.library_container.environment.pop(env_name, None)
+            self.weblog_infra.library_container.volumes["./utils/build/docker/agent/ca-certificates.crt"] = {
+                "bind": "/etc/ssl/certs/ca-certificates.crt",
+                "mode": "ro",
+            }
 
     def configure(self, config: pytest.Config) -> None:
         try:


### PR DESCRIPTION
## Motivation

Node.js agentless exposure delivery needs route-level system coverage for direct and sidecar deployments.

## Changes

- Activate Node.js Agent, direct, and sidecar exposure egress coverage for `express4` at `v7.0.0-pre`.
- Mount the checked-in system-test CA bundle at `/etc/ssl/certs/ca-certificates.crt`.
- Point `NODE_EXTRA_CA_CERTS` at the mounted system bundle for direct HTTPS capture.

## Decisions

- Preserve TLS verification through the system-test proxy.
- Keep the direct scenario free of Agent endpoint variables.
- Base this draft on the shared Node.js and Java EVP egress harness in #7601.

## Validation

- `./format.sh --check`
- Focused agentless `TEST_THE_TEST`: 9 passed
- Manifest computation: both egress tests remain disabled at `6.99.0` and activate for `express4` at `7.0.0-pre`
- `./build.sh nodejs -w express4` against local `dd-trace-js` fallback head `bd08b048`
- Agent exposure egress: 1 passed in 30.06s
- Direct exposure egress: 1 passed in 18.46s
- Sidecar exposure egress: 1 passed in 19.57s

Tracks [FFL-1488](https://linear.app/datadoghq/issue/FFL-1488).

Questions: `#apm-shared-testing`

🟣 **SYSTEM-TESTS DOCUMENTATION USED:** `docs/edit/manifest.md`, `docs/execute/build.md`, `docs/execute/binaries.md`