### PR TITLE
test(ffe): enable .NET EVP flagevaluation egress

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -764,7 +764,20 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3416)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3416)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3416)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Basic: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Context_Bounds: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Count: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v3.53.0
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: v3.53.0
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent: v3.53.0
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_High_Cardinality_Aggregation: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Load_Aggregation: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFLSDK-28)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Runtime_Default: missing_feature (FFLSDK-28)
   tests/ffe/test_flag_eval_metrics.py: v3.44.0
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka: v2.0.0-prerelease

--- a/tests/test_the_test/test_mock_ffe_agentless_backend.py
+++ b/tests/test_the_test/test_mock_ffe_agentless_backend.py
@@ -114,7 +114,8 @@ def test_agentless_end_to_end_scenario_starts_backend_before_weblog() -> None:
         scenario._start_mock_backend()  # noqa: SLF001 - focused lifecycle test
 
         environment = scenario.weblog_infra.library_container.environment
-        assert "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE" not in environment
+        assert environment["DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED"] == "true"
+        assert environment["DD_FEATURE_FLAGS_CONFIGURATION_SOURCE"] == "agentless"
         assert "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" not in environment
         base_url = environment["DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL"]
         assert isinstance(base_url, str)

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -130,6 +130,11 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
     ) -> None:
         self.exposure_egress = exposure_egress
         environment: dict[str, str | None] = {
+            # The shared weblogs use this switch to install their OpenFeature provider. The
+            # configuration source selects how the provider receives flags; it does not make the
+            # application adopt the provider on its own.
+            "DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED": "true",
+            "DD_FEATURE_FLAGS_CONFIGURATION_SOURCE": "agentless",
             # Both variables are integer seconds across the SDKs: Java parses them with
             # getInteger, and the shared configuration registry declares them "int" with an
             # allowed pattern of [1-9]\d*. A fractional value only ever worked on Node, which


### PR DESCRIPTION
## Motivation

.NET needs route-level system-test coverage for flag-evaluation EVP delivery through the Datadog Agent, direct intake, and the serverless sidecar.

Linear: [FFL-1492](https://linear.app/datadoghq/issue/FFL-1492)

## Changes

- Explicitly install the shared OpenFeature provider and select the agentless configuration source in agentless FFE scenarios.
- Enable the three .NET flag-evaluation egress cases at `v3.53.0`:
  - Datadog Agent
  - agentless direct intake
  - agentless serverless sidecar
- Keep the remaining .NET flag-evaluation behavior cases marked `missing_feature (FFLSDK-28)`.

## Decisions

- Keep provider activation explicit because selecting a configuration source does not install the provider.
- Activate only the three egress cases validated against the branch-built tracer.
- Stack on #7602 so the shared direct-intake system-CA binding is reviewed once.

## Validation

- `./build.sh dotnet -w poc` -- passed against the branch-built tracer package.
- `./format.sh --check` -- passed.
- `./run.sh TEST_THE_TEST tests/test_the_test/test_manifest.py` -- 32 passed.
- `./run.sh TEST_THE_TEST tests/test_the_test/test_mock_ffe_agentless_backend.py` -- 9 passed.
- `./run.sh TEST_THE_TEST` -- 438 passed, 1 expected xfail.
- Manifest computation at `.NET 3.53.0` confirmed exactly three egress classes enabled and eleven behavior classes disabled.
- Datadog Agent flag-evaluation egress -- 1 passed in 66.95s.
- Agentless direct flag-evaluation egress -- 1 passed in 15.17s; post-restack verification passed in 44.53s.
- Agentless serverless-sidecar flag-evaluation egress -- 1 passed in 15.60s.
- A control run with only the Node-specific CA location timed out after 30s; binding the proxy CA at the system bundle path made direct delivery observable before teardown.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on your PR until CI passes.
3. Keep test-logic review with the RFC owner; ask the R&P team in [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) for framework or non-obvious harness changes.

> [!NOTE]
> FOR SYSTEM-TEST FRAMEWORK OR SCENARIO HELP, USE [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X).

## Reviewer checklist

- [ ] Test logic has RFC-owner review.
- [ ] Any framework or scenario change has R&P review in [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X).
