### PR TITLE
test(golang): validate direct agentless EVP egress

### DIFF
--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1343,20 +1343,20 @@ manifest:
     - declaration: bug (FFL-2182)
       excluded_weblog: [echo, gin, chi, net-http-orchestrion, net-http, uds-echo]
   tests/ffe/test_exposure_egress.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: v2.11.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: v2.12.0-dev
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown:
     - weblog_declaration:
         "*": missing_feature (Shutdown lifecycle hook is implemented only by net-http)
-        net-http: v2.11.0-dev
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+        net-http: v2.12.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: v2.12.0-dev
   tests/ffe/test_exposures_datadog_agent.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3414)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3414)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3414)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3414)
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v2.11.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v2.12.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: v2.12.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: v2.11.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.10.0

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1343,8 +1343,11 @@ manifest:
     - declaration: bug (FFL-2182)
       excluded_weblog: [echo, gin, chi, net-http-orchestrion, net-http, uds-echo]
   tests/ffe/test_exposure_egress.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: v2.11.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown:
+    - weblog_declaration:
+        "*": missing_feature (Shutdown lifecycle hook is implemented only by net-http)
+        net-http: v2.11.0-dev
   tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_exposures_datadog_agent.py: v2.6.0-dev  # Easy win for chi, echo, gin, net-http, net-http-orchestrion, uds-echo and version 2.5.0
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3414)
@@ -1352,7 +1355,7 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3414)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3414)
   tests/ffe/test_flag_eval_evp.py: v2.10.0-dev
-  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: missing_feature (Not yet implemented)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v2.11.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v2.11.0-dev

--- a/tests/test_the_test/test_golang_direct_evp_activation.py
+++ b/tests/test_the_test/test_golang_direct_evp_activation.py
@@ -9,29 +9,26 @@ from utils import features, scenarios
 
 @scenarios.test_the_test
 @features.not_reported
-def test_golang_direct_evp_activation_is_scoped_to_direct_egress() -> None:
+def test_golang_evp_activation_covers_direct_and_sidecar_egress() -> None:
     manifest = yaml.safe_load(Path("manifests/golang.yml").read_text(encoding="utf-8"))["manifest"]
 
-    assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct"] == "v2.11.0-dev"
+    assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct"] == "v2.12.0-dev"
     assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown"] == [
         {
             "weblog_declaration": {
                 "*": "missing_feature (Shutdown lifecycle hook is implemented only by net-http)",
-                "net-http": "v2.11.0-dev",
+                "net-http": "v2.12.0-dev",
             }
         }
     ]
-    assert (
-        manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar"]
-        == "missing_feature (Not yet implemented)"
-    )
+    assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar"] == "v2.12.0-dev"
     assert (
         manifest["tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct"]
-        == "v2.11.0-dev"
+        == "v2.12.0-dev"
     )
     assert (
         manifest["tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar"]
-        == "missing_feature (Not yet implemented)"
+        == "v2.12.0-dev"
     )
 
 

--- a/tests/test_the_test/test_golang_direct_evp_activation.py
+++ b/tests/test_the_test/test_golang_direct_evp_activation.py
@@ -1,0 +1,52 @@
+"""Guard the Go-only activation and lifecycle for direct-EVP validation."""
+
+from pathlib import Path
+
+import yaml
+
+from utils import features, scenarios
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_golang_direct_evp_activation_is_scoped_to_direct_egress() -> None:
+    manifest = yaml.safe_load(Path("manifests/golang.yml").read_text(encoding="utf-8"))["manifest"]
+
+    assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct"] == "v2.11.0-dev"
+    assert manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown"] == [
+        {
+            "weblog_declaration": {
+                "*": "missing_feature (Shutdown lifecycle hook is implemented only by net-http)",
+                "net-http": "v2.11.0-dev",
+            }
+        }
+    ]
+    assert (
+        manifest["tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar"]
+        == "missing_feature (Not yet implemented)"
+    )
+    assert (
+        manifest["tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct"]
+        == "v2.11.0-dev"
+    )
+    assert (
+        manifest["tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar"]
+        == "missing_feature (Not yet implemented)"
+    )
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_golang_direct_evp_shutdown_uses_openfeature_lifecycle_after_server_close() -> None:
+    source = Path("utils/build/docker/golang/app/net-http/main.go").read_text(encoding="utf-8")
+
+    assert "signal.Notify(c, syscall.SIGTERM)" in source
+    assert 'SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED") == "true"' in source
+    assert '"event":     "system_tests.ffe.shutdown.server_closed"' in source
+    assert "srv.Shutdown(httpShutdownCtx)" in source
+    assert "of.ShutdownWithContext(providerShutdownCtx)" in source
+    assert source.count("context.WithTimeout(context.Background(), 10*time.Second)") == 2
+    assert source.index("srv.Shutdown(httpShutdownCtx)") < source.index("system_tests.ffe.shutdown.server_closed")
+    assert source.index("system_tests.ffe.shutdown.server_closed") < source.index(
+        "of.ShutdownWithContext(providerShutdownCtx)"
+    )

--- a/utils/build/docker/golang/app/net-http/main.go
+++ b/utils/build/docker/golang/app/net-http/main.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry/metric"
 	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 	"github.com/DataDog/dd-trace-go/v2/profiler"
+	of "github.com/open-feature/go-sdk/openfeature"
 )
 
 func main() {
@@ -813,10 +814,29 @@ func main() {
 	signal.Notify(c, syscall.SIGTERM)
 	<-c
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := srv.Shutdown(ctx); err != nil {
-		logrus.Fatalf("HTTP shutdown error: %v", err)
+	httpShutdownCtx, httpShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	httpShutdownErr := srv.Shutdown(httpShutdownCtx)
+	httpShutdownCancel()
+	if httpShutdownErr != nil {
+		logrus.Fatalf("HTTP shutdown error: %v", httpShutdownErr)
+	}
+
+	// The direct-EVP shutdown test proves the normal OpenFeature lifecycle: stop
+	// accepting evaluations, record that boundary, then let the provider drain its
+	// buffered events before the process exits. Keep this opt-in so unrelated
+	// scenarios retain the weblog's historical shutdown behavior.
+	if os.Getenv("SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED") == "true" {
+		if err := json.NewEncoder(os.Stdout).Encode(map[string]string{
+			"event":     "system_tests.ffe.shutdown.server_closed",
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+		}); err != nil {
+			logrus.Fatalf("shutdown marker error: %v", err)
+		}
+		providerShutdownCtx, providerShutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer providerShutdownCancel()
+		if err := of.ShutdownWithContext(providerShutdownCtx); err != nil {
+			logrus.Fatalf("OpenFeature shutdown error: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

[FFLSDK-194](https://linear.app/datadoghq/issue/FFLSDK-194/system-testsgo-enable-agentless-evp-fallback-coverage), under [FFLSDK-183](https://linear.app/datadoghq/issue/FFLSDK-183/evp-fallback-across-all-server-sdks), tracks permanent Go coverage for Agentless Feature Flags.

We are shipping CDN-delivered configuration with the goal of making customer deployments simpler. The core telemetry produced by the SDK still needs a reliable path off the process: discover a compatible local Agent or serverless-init relay, and fall back to the direct EVP intake when no compatible relay is available. These behaviors must be exercised across supported languages and frameworks.

The shared transport, capture, and teardown contracts live in [#7299](https://github.com/DataDog/system-tests/pull/7299). This PR contains only the Go activation and the `net-http` lifecycle hook needed to prove shutdown flushing.

## Changes

| Capability | Scenario | Assertion |
|---|---|---|
| Direct exposures | Agentless, no local relay | One exposure reaches `/api/v2/exposures` on direct intake with the API key and Go SDK identity; no local copy exists |
| Direct flag evaluations | Agentless, no local relay | One flag-evaluation batch reaches `/api/v2/flagevaluation` on direct intake with the API key and Go SDK identity; no local copy exists |
| Shutdown flush | Agentless, no local relay, `net-http` | A just-produced exposure is delivered only after public OpenFeature shutdown |
| serverless-init exposures | Agentless with serverless-init 1.10.4 | One exposure traverses EVP proxy v4 with origin identity; no API key is sent by the SDK |
| serverless-init flag evaluations | Agentless with serverless-init 1.10.4 | One flag-evaluation batch traverses EVP proxy v4 with origin identity; no API key is sent by the SDK |

```mermaid
flowchart LR
    SDK[Go OpenFeature provider] --> UFC[Agentless UFC polling]
    SDK --> Select{Compatible local relay?}
    Select -->|No| Direct[Direct EVP intake]
    Select -->|serverless-init advertises v4 + identity headers| Sidecar[serverless-init EVP proxy v4]
    Sidecar --> Intake[Datadog EVP intake]
    Direct --> Intake
```

- Enable Go direct-Agentless exposure, flag-evaluation, and `net-http` shutdown contracts from `v2.12.0-dev`.
- Enable Go serverless-init exposure and flag-evaluation contracts from `v2.12.0-dev`.
- Add an opt-in `net-http` shutdown hook that stops HTTP traffic, records the shutdown boundary, and invokes public OpenFeature shutdown.
- Guard the Go manifest activation, shutdown ordering, and independent timeout budgets with test-the-test coverage.

## Decisions

- Keep this as a sibling activation PR targeting #7299; it is not stacked on another language enablement.
- Pin serverless-init 1.10.4 through #7299 because its embedded Agent advertises EVP v4 and both required `DD-EVP-ORIGIN` identity headers.
- Scope shutdown coverage to `net-http`, because the lifecycle hook is not shared by the other Go weblogs.
- Give HTTP shutdown and OpenFeature provider shutdown separate 10-second contexts, so provider flushing always receives its full budget.
- Use normal OpenFeature shutdown without an explicit test-only writer flush.
- Keep OTLP out of scope: these contracts validate exposure and flag-evaluation EVP egress.

## Validation

Current foundation: `793233f0f70bf49a37c0a3d2c8804fde1937a7df`.
Current candidate: `ba1ab49ba712e1500b1b9a55e2c4bce80e8147ba`; signed merge, GitHub verified.
The merge preserves the same three-file Go-only activation/lifecycle delta.

- `PYTHONPATH=$PWD IN_NIX_SHELL=1 PATH=<existing-python-3.12-venv>/bin:$PATH ./format.sh --check` — passed.
- `PYTHONPATH=$PWD <existing-python-3.12-venv>/bin/python -m pytest -S TEST_THE_TEST tests/test_the_test/test_golang_direct_evp_activation.py tests/test_the_test/test_mock_ffe_agentless_backend.py tests/test_the_test/test_ffe_evp_contract.py -q --disable-warnings` — **64 passed**.
- Fresh CI is running; no new local E2E build under current shared-workspace disk pressure.

Historical E2E evidence, not a rerun on this merge: at system-tests `a30dcda239b98005b05a991a37d0c790235c2abc`, [net-http CI](https://github.com/DataDog/system-tests/actions/runs/34675398026/job/103505421000) executed **3/3 direct** and **2/2 serverless** tests with `golang@2.12.0-dev`, without skips. Earlier local proof used SDK `88f2f3287a84292d8fab12f87d5fc80425cff415`.

These tests exercise mock-intake routing, credentials, identity, delivery, and shutdown; they are not staging or production-intake proof.
