### PR TITLE
Retry SSI jobs on scenario timeouts and on the pulumi "short write" error

### DIFF
--- a/.gitlab/ssi_gitlab-ci.yml
+++ b/.gitlab/ssi_gitlab-ci.yml
@@ -191,8 +191,10 @@ ssi_tests:
         - api_failure
       #System-tests exit code 1 if there are tests failures
       #System-tests exit code 3 if there is a issue starting the scenario
+      #Timeout 124 (run.sh is wrapped in `timeout 3000`)
       exit_codes:
         - 3
+        - 124
     artifacts:
         when: always
         paths:

--- a/utils/virtual_machine/aws_infra_exceptions.json
+++ b/utils/virtual_machine/aws_infra_exceptions.json
@@ -41,5 +41,6 @@
     "openssl_ssl_connect_connection_reset_by_peer": "OpenSSL SSL_connect: Connection reset by peer in connection to keys.datadoghq.com:443",
     "Failed_get_info_Microsoft.AspNetCore'":"Failed to retrieve information about 'Microsoft.AspNetCore'",
     "error_download_failed_with_curl_install_script":"Error: Download failed with curl",
-    "error_response_from_docker_daemon":"dial tcp: lookup auth.docker.io: no such host"
+    "error_response_from_docker_daemon":"dial tcp: lookup auth.docker.io: no such host",
+    "pulumi_command_short_write":"error: short write: running"
 }

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -147,7 +147,7 @@ class AWSPulumiProvider(VmProvider):
             return json.load(f)
 
     def _handle_provision_error(self, exception: pulumi.automation.errors.CommandError):
-        """Tear down and abort the scenario with exit code 3, whether or not the error is a known one."""
+        """If the exception is known, we will raise the exception, if not,we will store it in the vm object."""
 
         exception_message = str(exception)
         for known_message in self.aws_infra_exceptions.values():
@@ -167,10 +167,6 @@ class AWSPulumiProvider(VmProvider):
             repr(exception),
             ["operation:up", "result:fail", f"stack:{self.stack_name}"],
         )
-        # A provisioning failure is not a test result, the tests never ran. Exit 3 ("the scenario
-        # could not start") so the CI job is retried via retry:exit_codes, instead of surfacing as
-        # an assert in every test, which fails the job for good and blocks the release pipeline.
-        pytest.exit(f"Unknown infraestructure exception:: {exception_message[:500]}", returncode=3)
 
     def _download_vm_logs_after_provision_failure(self) -> None:
         """Pull /var/log from the VM while it is still up (provision may have failed mid-way)."""

--- a/utils/virtual_machine/aws_provider.py
+++ b/utils/virtual_machine/aws_provider.py
@@ -147,7 +147,7 @@ class AWSPulumiProvider(VmProvider):
             return json.load(f)
 
     def _handle_provision_error(self, exception: pulumi.automation.errors.CommandError):
-        """If the exception is known, we will raise the exception, if not,we will store it in the vm object."""
+        """Tear down and abort the scenario with exit code 3, whether or not the error is a known one."""
 
         exception_message = str(exception)
         for known_message in self.aws_infra_exceptions.values():
@@ -167,6 +167,10 @@ class AWSPulumiProvider(VmProvider):
             repr(exception),
             ["operation:up", "result:fail", f"stack:{self.stack_name}"],
         )
+        # A provisioning failure is not a test result, the tests never ran. Exit 3 ("the scenario
+        # could not start") so the CI job is retried via retry:exit_codes, instead of surfacing as
+        # an assert in every test, which fails the job for good and blocks the release pipeline.
+        pytest.exit(f"Unknown infraestructure exception:: {exception_message[:500]}", returncode=3)
 
     def _download_vm_logs_after_provision_failure(self) -> None:
         """Pull /var/log from the VM while it is still up (provision may have failed mid-way)."""


### PR DESCRIPTION
## Motivation

Two transient provisioning/CI failures fail an SSI job for good today, and a single one of them blocks the whole release pipeline.

**1. Scenario hangs → exit 124.** `run.sh` is wrapped in `timeout 3000`, so a hung scenario exits 124. That code was not in `retry:exit_codes`, so the job just died.

**2. `error: short write: running ...`.** This is what actually blocked the pipeline in the release thread:

```
command:remote:Command -Amazon_Linux_2_arm64-vm_logs  **creating failed**
error: short write: running "#Wait for the app service redirect some logs..."
13 created, 2 errored
```

That's pulumi-command losing the SSH transport while streaming a remote command's output — not the remote script failing. Two things worth knowing:

- the `curl` inside that script returned `HTTP/1.1 200 OK`, so the app was up and the VM was fully provisioned;
- `vm_logs` is the **last** provisioning step (`virtual_machine_provider.py`) and it's purely diagnostic — it copies `/var/log` out for the artifacts.

So a dropped SSH write while copying logs failed the stack → failed provisioning → every test asserted on `provision_install_error` → job failed → release blocked.

## Changes

- add `124` to `retry:exit_codes` in `.gitlab/ssi_gitlab-ci.yml`
- add `"pulumi_command_short_write": "error: short write: running"` to `aws_infra_exceptions.json`

The second one routes the error through the **existing** known-infra-error path: destroy the stack, send a `result:retry` event, `pytest.exit(returncode=3)` → the job is retried. No new retry mechanism.

## Note on the previous version of this PR

The first version also made **unknown** provisioning failures exit 3 so they'd be retried. Reverted per review — unknown failures keep failing the job, as before. Only errors we've explicitly identified get retried.

## Why not make `vm_logs` non-fatal instead

Pulumi has no per-resource "tolerate failure" option, so that would mean moving the log extraction out of the Pulumi graph entirely. Bigger change than this is worth; happy to do it separately if you'd prefer.

🤖 Written with [Claude Code](https://claude.com/claude-code)
