### PR TITLE
Use specific exit status for pytest test failures be able to retry infra failures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,11 @@ JSONReport.pytest_terminal_summary = lambda *args, **kwargs: None  # noqa: ARG00
 _deselected_items: list[pytest.Item] = []
 setup_properties = SetupProperties()
 
+# Exit code returned by pytest when at least one test failed.
+# It is distinct from pytest's default exit codes (0-5) so that CI can tell
+# a test failure apart from other errors.
+TEST_FAIL_EXIT_CODE = 42
+
 PytestOutcome = Literal["passed", "xpassed", "failed", "xfailed", "skipped", "error"]
 
 
@@ -563,6 +568,9 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     if session.config.option.skip_empty_scenario and exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED:
         exitstatus = pytest.ExitCode.OK
         session.exitstatus = pytest.ExitCode.OK
+
+    if exitstatus == pytest.ExitCode.TESTS_FAILED:
+        session.exitstatus = TEST_FAIL_EXIT_CODE
 
     if session.config.option.collectonly:
         return

--- a/conftest.py
+++ b/conftest.py
@@ -41,6 +41,13 @@ setup_properties = SetupProperties()
 # a test failure apart from other errors.
 TEST_FAIL_EXIT_CODE = 42
 
+# Track which test phases (setup / call / teardown) had failures, so that
+# we only use TEST_FAIL_EXIT_CODE when failures occurred exclusively during
+# the test ``call`` phase.  Setup/teardown failures are typically
+# infrastructure issues (Docker, network, ...) and should remain retryable
+# by CI (exit code 1).
+_failed_phases: set[str] = set()
+
 PytestOutcome = Literal["passed", "xpassed", "failed", "xfailed", "skipped", "error"]
 
 
@@ -533,6 +540,11 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> Gener
         _set_outcome_properties(value, item.user_properties)
 
 
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if report.failed:
+        _failed_phases.add(report.when)
+
+
 def _set_outcome_properties(outcome: PytestOutcome, user_properties: list[tuple]) -> None:
     if outcome in ("passed", "xpassed"):
         final_status = "pass"
@@ -570,7 +582,12 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         session.exitstatus = pytest.ExitCode.OK
 
     if exitstatus == pytest.ExitCode.TESTS_FAILED:
-        session.exitstatus = TEST_FAIL_EXIT_CODE
+        # Only use the dedicated test-failure exit code when every failure
+        # happened during the test ``call`` phase.  If any setup or teardown
+        # phase also failed, keep the default exit code (1) so that CI can
+        # retry the job — those failures are usually infrastructure issues.
+        if _failed_phases and _failed_phases <= {"call"}:
+            session.exitstatus = TEST_FAIL_EXIT_CODE
 
     if session.config.option.collectonly:
         return

--- a/tests/test_the_test/test_junit.py
+++ b/tests/test_the_test/test_junit.py
@@ -55,7 +55,10 @@ class Test_Cases:
 @scenarios.test_the_test
 @pytest.mark.parametrize("use_xdist", [True, False])
 def test_main(use_xdist: bool):  # noqa: FBT001
-    run_system_tests(test_path="tests/test_the_test/test_junit.py", use_xdist=use_xdist, expected_return_code=1)
+    test_failure_exit_code = 42
+    run_system_tests(
+        test_path="tests/test_the_test/test_junit.py", use_xdist=use_xdist, expected_return_code=test_failure_exit_code
+    )
 
     observed_file = "logs_mock_the_test/reportJunit.xml"
     expected_file = "tests/test_the_test/reportJunit_expected.xml"

--- a/tests/test_the_test/test_strict.py
+++ b/tests/test_the_test/test_strict.py
@@ -8,7 +8,8 @@ FILENAME = "tests/test_the_test/test_strict.py"
 @scenarios.test_the_test
 class Test_StrictMode:
     def test_strict_missing_features(self):
-        tests = run_system_tests(test_path=FILENAME, xfail_strict=True, expected_return_code=1)
+        test_failure_exit_code = 42
+        tests = run_system_tests(test_path=FILENAME, xfail_strict=True, expected_return_code=test_failure_exit_code)
 
         assert tests[f"{FILENAME}::test_strict_bug"]["outcome"] == "failed"
         assert tests[f"{FILENAME}::test_strict_missing_feature"]["outcome"] == "failed"

--- a/utils/ci/gitlab/system-tests.yml.j2
+++ b/utils/ci/gitlab/system-tests.yml.j2
@@ -55,8 +55,9 @@ default:
       - unknown_failure
       - data_integrity_failure
     exit_codes:
-      - 1-41
-      - 43-255
+{% for code in range(1, 42) %}      - {{ code }}
+{% endfor %}{% for code in range(43, 256) %}      - {{ code }}
+{% endfor %}
 
 stages:
   - {{stage}}

--- a/utils/ci/gitlab/system-tests.yml.j2
+++ b/utils/ci/gitlab/system-tests.yml.j2
@@ -55,7 +55,8 @@ default:
       - unknown_failure
       - data_integrity_failure
     exit_codes:
-      - 255
+      - 1-41
+      - 43-255
 
 stages:
   - {{stage}}


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
