### PR TITLE
test: cover OTel deployment environment mapping [golang@brian.marks/otel-deployment-environment-name][dotnet@brian.marks/otel-deployment-environment-name][ruby@brian.marks/otel-deployment-environment-name][php@brian.marks/otel-deployment-environment-name][nodejs@brian.marks/otel-deployment-environment-name][rust@brian.marks/otel-deployment-environment-name]

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -988,6 +988,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.53.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<3.53.0'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<3.53.0'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in .NET)
   tests/parametric/test_otel_logs.py: '>=3.36.0'  # Modified by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection::test_otlp_logs_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1476,6 +1476,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<2.11.0-dev.1'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<2.11.0-dev.1'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in go)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: irrelevant (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)
   tests/parametric/test_otel_logs.py: '>=2.5.0'  # Modified by easy win activation script

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3971,6 +3971,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.35.2
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<1.66.0-SNAPSHOT'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<1.66.0-SNAPSHOT'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: 'missing_feature (Currently DD_TRACE_OTEL_ENABLED=true is required for OTEL_SDK_DISABLED to be parsed. Revisit when the OpenTelemetry integration is enabled by default.)'
   tests/parametric/test_otel_logs.py: '>=1.62.0'
   tests/parametric/test_otel_logs.py::Test_FR06_OTLP_Protocols::test_otlp_protocols: incomplete_test_app (GPRC fails for system-test but works with real collector)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2394,6 +2394,13 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: missing_feature (this setting is not exposed in the Node.js config object)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<7.0.0-pre'
+    - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<7.0.0-pre'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: missing_feature (this setting is not exposed in the Node.js config object)
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR03_Resource_Attributes: *ref_5_72_0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1554,6 +1554,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.1.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<1.25.0'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<1.25.0'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_to_debug_mapping: irrelevant (PHP uses DD_TRACE_DEBUG to set DD_TRACE_LOG_LEVEL=debug, so it does not do this mapping in the reverse direction)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_on:
     - declaration: missing_feature (The always_on sampler mapping is properly implemented in v1.2.0)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2059,6 +2059,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.9.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<4.15.0-rc1'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<4.15.0-rc1'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in Python)
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection: v3.13.0.dev
   tests/parametric/test_otel_logs.py::Test_FR03_Resource_Attributes: v3.13.0.dev

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2470,6 +2470,12 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_otel_enabled_takes_precedence: missing_feature (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<2.42.0-dev'
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<2.42.0-dev'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in ruby)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: missing_feature (does not support enabling opentelemetry via DD_TRACE_OTEL_ENABLED)
   tests/parametric/test_otel_logs.py: '>=2.34.0-dev'

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -232,6 +232,13 @@ manifest:
     - declaration: incomplete_test_app
     - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_attribute_mapping: incomplete_test_app (/trace/config endpoint is not implemented)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<0.5.3-dev'
+    - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
+  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_deployment_environment_mapping_on_span:
+    - declaration: missing_feature (deployment.environment.name mapping is not released)
+      component_version: '<0.5.3-dev'
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_env_vars_set: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_sdk_disabled_set: incomplete_test_app (/trace/config endpoint is not implemented)

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -148,16 +148,16 @@ class Test_Otel_Env_Vars:
         "library_env",
         [
             {
-                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1",
+                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=legacy,service.name=test2,service.version=5,foo=bar1,baz=qux1",
                 "DD_TRACE_OTEL_ENABLED": "true",
             }
         ],
     )
-    def test_otel_attribute_mapping(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+    def test_otel_attribute_mapping(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         with test_library as t:
             if t.lang == "nodejs":
                 assert_nodejs_telemetry_config(
-                    test_agent, {"dd_service": "test2", "dd_env": "test1", "dd_version": "5"}
+                    test_agent, {"dd_service": "test2", "dd_env": "legacy", "dd_version": "5"}
                 )
                 # OTEL_RESOURCE_ATTRIBUTES tags surface on spans, not in the DD_TAGS telemetry value
                 with t.dd_start_span(name="otel_attrs"):
@@ -165,16 +165,132 @@ class Test_Otel_Env_Vars:
                 span = find_only_span(test_agent.wait_for_num_traces(1))
                 assert span["meta"]["foo"] == "bar1"
                 assert span["meta"]["baz"] == "qux1"
+                assert "deployment.environment" not in span["meta"]
+                assert "deployment.environment.name" not in span["meta"]
                 return
             resp = t.config()
 
         assert resp["dd_service"] == "test2"
-        assert resp["dd_env"] == "test1"
+        assert resp["dd_env"] == "legacy"
         assert resp["dd_version"] == "5"
         tags = resp["dd_tags"]
         assert isinstance(tags, (str, list))
         assert "foo:bar1" in tags
         assert "baz:qux1" in tags
+        tags_text = str(tags)
+        assert "deployment.environment:" not in tags_text
+        assert "deployment.environment.name:" not in tags_text
+
+    @pytest.mark.parametrize(
+        ("library_env", "expected_env"),
+        [
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,service.name=test2,service.version=5,foo=bar1,baz=qux1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="stable-only",
+            ),
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,deployment.environment=legacy,service.name=test2,service.version=5,foo=bar1,baz=qux1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="both-stable-first",
+            ),
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=legacy,deployment.environment.name=stable,service.name=test2,service.version=5,foo=bar1,baz=qux1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="both-legacy-first",
+            ),
+            pytest.param(
+                {
+                    "DD_ENV": "datadog",
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,deployment.environment=legacy,service.name=test2,service.version=5,foo=bar1,baz=qux1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "datadog",
+                id="dd-env-precedence",
+            ),
+        ],
+    )
+    def test_otel_deployment_environment_mapping(self, expected_env: str, test_library: APMLibrary) -> None:
+        with test_library as t:
+            resp = t.config()
+
+        assert resp["dd_service"] == "test2"
+        assert resp["dd_env"] == expected_env
+        assert resp["dd_version"] == "5"
+        tags = resp["dd_tags"]
+        assert isinstance(tags, (str, list))
+        assert "foo:bar1" in tags
+        assert "baz:qux1" in tags
+        tags_text = str(tags)
+        assert "deployment.environment:" not in tags_text
+        assert "deployment.environment.name:" not in tags_text
+
+    @pytest.mark.parametrize(
+        ("library_env", "expected_env"),
+        [
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=legacy,foo=bar1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "legacy",
+                id="legacy-only",
+            ),
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,foo=bar1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="stable-only",
+            ),
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,deployment.environment=legacy,foo=bar1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="both-stable-first",
+            ),
+            pytest.param(
+                {
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=legacy,deployment.environment.name=stable,foo=bar1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "stable",
+                id="both-legacy-first",
+            ),
+            pytest.param(
+                {
+                    "DD_ENV": "datadog",
+                    "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment.name=stable,deployment.environment=legacy,foo=bar1",
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                },
+                "datadog",
+                id="dd-env-precedence",
+            ),
+        ],
+    )
+    def test_otel_deployment_environment_mapping_on_span(
+        self, expected_env: str, test_agent: TestAgentAPI, test_library: APMLibrary
+    ) -> None:
+        with test_library as t, t.dd_start_span(name="otel_deployment_environment"):
+            pass
+
+        span = find_only_span(test_agent.wait_for_num_traces(1))
+        assert span["meta"]["env"] == expected_env
+        assert span["meta"]["foo"] == "bar1"
+        assert "deployment.environment" not in span["meta"]
+        assert "deployment.environment.name" not in span["meta"]
 
     @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on", "DD_TRACE_OTEL_ENABLED": "true"}])
     def test_otel_traces_always_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):


### PR DESCRIPTION
## Motivation

Java and Python now map the stable OpenTelemetry resource attribute `deployment.environment.name` to the Datadog environment. The shared suite should enforce the same behavior as the remaining tracers add support.

Reference fixes:

- DataDog/dd-trace-java#12324
- DataDog/dd-trace-py#19901

## Changes

- Keep the existing, ungated legacy `deployment.environment` fallback test.
- Add config and emitted-span cases for each attribute alone, both attribute orders, and `DD_ENV` precedence.
- Check that unrelated resource attributes survive and that environment source attributes are consumed in the new cases.
- Gate each tracer on the first release that contains its implementation.

Coordinated tracer PRs:

- DataDog/dd-trace-go#5285
- DataDog/dd-trace-dotnet#9150
- DataDog/dd-trace-rb#6261
- DataDog/dd-trace-php#4148
- DataDog/dd-trace-js#10050
- DataDog/dd-trace-rs#300

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on your PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or its usage is non-obvious? -> Get a review from repository maintainers.

:rocket: Once your PR is reviewed and the CI green, you can merge it!

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified? I have approval from repository maintainers.
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from repository maintainers.