### PR TITLE
Adding an option to the gitlab workflow to set the number of parametric workers

### DIFF
--- a/tests/test_the_test/test_gitlab_pipeline_structure.py
+++ b/tests/test_the_test/test_gitlab_pipeline_structure.py
@@ -32,6 +32,31 @@ def test_gitlab_component_allow_failure_input_is_wired() -> None:
 
 
 @scenarios.test_the_test
+def test_gitlab_parametric_workers_input_is_wired(tmp_path: Path) -> None:
+    spec, _ = yaml.safe_load_all(Path("utils/ci/gitlab/main.yml").read_text())
+    assert spec["spec"]["inputs"]["parametric_workers"]["default"] == "auto"
+
+    params = {
+        "endtoend_defs": {"parallel_weblogs": [], "parallel_jobs": []},
+        "miscs": {"binaries_artifact": ""},
+        "parametric": {"enable": True, "job_count": 2, "job_matrix": [1, 2], "workers": "4"},
+    }
+    (tmp_path / "params_nodejs.json").write_text(json.dumps(params))
+    out = tmp_path / "out"
+    build(["nodejs"], tmp_path, out, stage="e2e", ci_image="img", chunks=1)
+
+    chunk = yaml.safe_load((out / "generated-pipeline-chunk-0.yml").read_text())
+    parametric_jobs = [
+        job
+        for name, job in chunk.items()
+        if isinstance(job, dict) and name.startswith("system_tests_run_nodejs_PARAMETRIC")
+    ]
+    assert parametric_jobs
+    for job in parametric_jobs:
+        assert job["variables"]["PYTEST_XDIST_AUTO_NUM_WORKERS"] == "4"
+
+
+@scenarios.test_the_test
 def test_generated_chunk_jobs_have_required_keys(tmp_path: Path):
     (tmp_path / "params_python.json").write_text(json.dumps(MINIMAL_PARAMS))
     out = tmp_path / "out"

--- a/utils/ci/gitlab/main.yml
+++ b/utils/ci/gitlab/main.yml
@@ -34,6 +34,9 @@ spec:
       description: "Number of parallel jobs for the PARAMETRIC scenario"
       type: number
       default: 3
+    parametric_workers:
+      description: "Number of pytest-xdist workers to use within each PARAMETRIC job"
+      default: "auto"
     push_to_test_optimization:
       description: "Push test results to Datadog Test Optimization"
       type: boolean
@@ -127,6 +130,7 @@ system_tests_build_pipeline:
       excluded_scenarios=$(echo "$[[ inputs.excluded_scenarios ]],$EXCLUDED_SCENARIOS" | tr ',' '\n' | sed '/^$/d' | sort -u | tr '\n' ',' | sed 's/,$//')
       force_execute=$(echo "$[[ inputs.force_execute ]],$FORCE_EXECUTE" | tr ',' '\n' | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')
       parametric_job_count="${SYSTEM_TESTS_PARAMETRIC_JOB_COUNT:-$[[ inputs.parametric_job_count ]]}"
+      parametric_workers="${SYSTEM_TESTS_PARAMETRIC_WORKERS:-$[[ inputs.parametric_workers ]]}"
       push_to_test_optimization="${SYSTEM_TESTS_PUSH_TO_TEST_OPTIMIZATION:-$[[ inputs.push_to_test_optimization ]]}"
       docker_auth="${SYSTEM_TESTS_DOCKER_AUTH:-$[[ inputs.docker_auth ]]}"
       skip_empty_scenario="${SYSTEM_TESTS_SKIP_EMPTY_SCENARIO:-$[[ inputs.skip_empty_scenarios ]]}"
@@ -137,13 +141,14 @@ system_tests_build_pipeline:
       echo "excluded_scenarios:     $excluded_scenarios"
       echo "force_execute:          $force_execute"
       echo "parametric_job_count:   $parametric_job_count"
+      echo "parametric_workers:     $parametric_workers"
       echo "push_to_test_opt:       $push_to_test_optimization"
       echo "skip_empty_scenario:    $skip_empty_scenario"
       printf 'SYSTEM_TESTS_FORCE_EXECUTE=%s\nSYSTEM_TESTS_SKIP_EMPTY_SCENARIO=%s\n' "$force_execute" "$skip_empty_scenario" > build_params.env
       binaries_artifacts="${BINARIES_ARTIFACTS:-$[[ inputs.binaries_artifacts ]]}"
       binaries_artifact_path="${BINARIES_ARTIFACT_PATH:-$[[ inputs.binaries_artifact_path ]]}"
       for library in $libraries; do
-        python3 utils/scripts/compute-workflow-parameters.py $library --format json --groups "$scenario_groups" --excluded-scenarios "$excluded_scenarios" --scenarios "$scenarios" --weblogs "$weblogs" --explicit-binaries-artifact "$binaries_artifacts" --parametric-job-count $parametric_job_count --output params_${library}.json
+        python3 utils/scripts/compute-workflow-parameters.py $library --format json --groups "$scenario_groups" --excluded-scenarios "$excluded_scenarios" --scenarios "$scenarios" --weblogs "$weblogs" --explicit-binaries-artifact "$binaries_artifacts" --parametric-job-count $parametric_job_count --parametric-workers "$parametric_workers" --output params_${library}.json
       done
       chunks=1
       if [ "$SYSTEM_TESTS_SPLIT_PIPELINE" = "true" ]; then chunks=3; fi

--- a/utils/ci/gitlab/system-tests.yml.j2
+++ b/utils/ci/gitlab/system-tests.yml.j2
@@ -187,6 +187,10 @@ system_tests_run_{{library}}_PARAMETRIC_{{job_index}}:
   id_tokens:
     DD_STS_OIDC_TOKEN:
       aud: dd-sts
+{% if parametric.workers != "auto" %}
+  variables:
+    PYTEST_XDIST_AUTO_NUM_WORKERS: "{{parametric.workers}}"
+{% endif %}
   {% if binaries_artifacts_list %}
   needs:
     {% for artifact_job in binaries_artifacts_list %}

--- a/utils/scripts/compute-workflow-parameters.py
+++ b/utils/scripts/compute-workflow-parameters.py
@@ -39,6 +39,7 @@ class CiData:
         excluded_scenarios: str,
         weblogs: str,
         parametric_job_count: int,
+        parametric_workers: str,
         desired_execution_time: int,
         explicit_binaries_artifact: str,
         system_tests_dev_mode: bool,
@@ -94,6 +95,7 @@ class CiData:
         self.data["parametric"] = {
             "job_count": parametric_job_count,
             "job_matrix": list(range(1, parametric_job_count + 1)),
+            "workers": parametric_workers,
             "enable": len(scenario_map.get("parametric", [])) > 0
             and "otel" not in library
             and library
@@ -280,6 +282,9 @@ if __name__ == "__main__":
 
     # workflow specific parameters
     parser.add_argument("--parametric-job-count", type=int, help="How may jobs must run parametric scenario", default=1)
+    parser.add_argument(
+        "--parametric-workers", type=str, help="How many pytest-xdist workers to use per parametric job", default="auto"
+    )
 
     # Misc
     parser.add_argument(
@@ -310,6 +315,7 @@ if __name__ == "__main__":
         excluded_scenarios=args.excluded_scenarios,
         weblogs=args.weblogs,
         parametric_job_count=args.parametric_job_count,
+        parametric_workers=args.parametric_workers,
         desired_execution_time=args.desired_execution_time,
         explicit_binaries_artifact=args.explicit_binaries_artifact,
         system_tests_dev_mode=args.system_tests_dev_mode == "true",


### PR DESCRIPTION
…ic workers

## Motivation

<!-- What inspired you to submit this pull request? -->

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
