### PR TITLE
Implement /security/thread_context_sharing endpoints for Java, Python and PHP

### DIFF
--- a/manifests/agent.yml
+++ b/manifests/agent.yml
@@ -7,7 +7,9 @@ manifest:
   tests/appsec/smoke_tests/test_apm_standalone.py:
     - component_version: "<7.77.0-0"
       declaration: irrelevant (APM Standalone option was added in 7.77.0)
-  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing: missing_feature (agent does not yet correlate CWS events with the trace_id/span_id shared by the tracer)
+  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing:
+    - declaration: missing_feature (Trace collection not available in agents pre 7.84)
+      component_version: '<7.84.0-devel'
   tests/debugger/test_debugger_condition_errors.py::Test_Debugger_Invalid_Condition_DSL:
     - component_version: "<7.77.1"
       weblog_declaration:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2942,7 +2942,10 @@ manifest:
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualProfiling::test_profiling:
     - declaration: bug (SCP-962)
       component_version: '>=1.5.0'
-  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing: missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing:
+    - weblog_declaration:
+        "*": missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+        spring-boot: v1.63.0
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -2942,10 +2942,7 @@ manifest:
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualProfiling::test_profiling:
     - declaration: bug (SCP-962)
       component_version: '>=1.5.0'
-  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing:
-    - weblog_declaration:
-        "*": missing_feature (missing /security/thread_context_sharing endpoint on weblog)
-        spring-boot: v1.63.0
+  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing: missing_feature (thread context sharing not enabled for appsec yet)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions:
     - weblog_declaration:
         "*": missing_feature

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1057,7 +1057,11 @@ manifest:
   tests/auto_inject/test_auto_inject_install.py::TestHostAutoInjectInstallScriptProfiling: v1.9.0
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualAppsec: v1.9.0
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualProfiling: v1.9.0
-  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing: missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing:
+    - weblog_declaration:
+        "*": v1.24.0
+        laravel11x: missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+        symfony7x: missing_feature (missing /security/thread_context_sharing endpoint on weblog)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions:
     - weblog_declaration:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1270,7 +1270,10 @@ manifest:
   tests/auto_inject/test_auto_inject_install.py::TestSimpleInstallerAutoInjectManualProfiling::test_profiling:
     - declaration: irrelevant (PROF-11296)
       component_version: <3.0.0
-  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing: missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+  tests/cws/test_thread_context_sharing.py::Test_ThreadContextSharing:
+    - weblog_declaration:
+        "*": missing_feature (missing /security/thread_context_sharing endpoint on weblog)
+        *flask : v4.14.0
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Line_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions.py::Test_Debugger_Method_Capture_Expressions: missing_feature (Not yet implemented)
   tests/debugger/test_debugger_capture_expressions_errors.py::Test_Debugger_Filter_Rejected_Capture_Expression_Error:  # TODO: a lower version might be supported

--- a/utils/_context/_scenarios/thread_context_sharing.py
+++ b/utils/_context/_scenarios/thread_context_sharing.py
@@ -36,6 +36,10 @@ class ThreadContextSharingScenario(EndToEndScenario):
     def configure(self, config: pytest.Config):
         super().configure(config)
 
+        if self.weblog_infra.library_name == "java":
+            # Should be removed once java enables this with appsec
+            self.weblog_container.environment["DD_PROFILING_ENABLED"] = "true"
+
         agent = self.agent_container
 
         agent.environment["DD_RUNTIME_SECURITY_CONFIG_ENABLED"] = "true"

--- a/utils/_context/_scenarios/thread_context_sharing.py
+++ b/utils/_context/_scenarios/thread_context_sharing.py
@@ -36,10 +36,6 @@ class ThreadContextSharingScenario(EndToEndScenario):
     def configure(self, config: pytest.Config):
         super().configure(config)
 
-        if self.weblog_infra.library_name == "java":
-            # Should be removed once java enables this with appsec
-            self.weblog_container.environment["DD_PROFILING_ENABLED"] = "true"
-
         agent = self.agent_container
 
         agent.environment["DD_RUNTIME_SECURITY_CONFIG_ENABLED"] = "true"

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/App.java
@@ -33,6 +33,7 @@ import datadog.trace.api.interceptor.MutableSpan;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration;
 import org.springframework.web.server.ResponseStatusException;
@@ -94,6 +95,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileWriter;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Collections;
@@ -394,6 +396,29 @@ public class App {
                 .forUser(user)
                 .blockIfMatch();
         return "Hello " + user;
+    }
+
+    @GetMapping("/security/thread_context_sharing")
+    ResponseEntity<Map<String, String>> threadContextSharing(@RequestParam String path) throws IOException {
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span == null) {
+            return ResponseEntity.status(500).build();
+        }
+
+        try (FileWriter writer = new FileWriter(path)) {
+            writer.write("system-tests thread context sharing");
+        }
+
+        // The OpenTracing SpanContext only exposes the low-order 64 bits of the trace id;
+        // datadog.trace.api.GlobalTracer surfaces the full 128-bit trace id, as hex, while its
+        // span id is already decimal.
+        final String traceIdHex = datadog.trace.api.GlobalTracer.get().getTraceId();
+        final String spanId = datadog.trace.api.GlobalTracer.get().getSpanId();
+
+        final Map<String, String> body = new HashMap<>();
+        body.put("trace_id", new BigInteger(traceIdHex, 16).toString());
+        body.put("span_id", spanId);
+        return ResponseEntity.ok(body);
     }
 
     @GetMapping("/identify")

--- a/utils/build/docker/php/apache-mod/php.conf
+++ b/utils/build/docker/php/apache-mod/php.conf
@@ -3,6 +3,7 @@
     Include /var/www/html/rewrite-rules.conf
     RewriteCond /var/www/html/%{REQUEST_URI} !-f
     RewriteRule "^/rasp/(.*)" "/rasp/$1.php" [L]
+    RewriteRule "^/security/(.*)" "/security/$1.php" [L]
     RewriteRule "^/api_security.sampling/.*" "/api_security_sampling.php$0" [L]
     RewriteRule "^/([^/]+)/(.*)" "/$1.php/$2" [L]
     ErrorDocument 404 /404.php

--- a/utils/build/docker/php/php-fpm/php-fpm.conf
+++ b/utils/build/docker/php/php-fpm/php-fpm.conf
@@ -18,6 +18,7 @@
         </Location>
         Include /var/www/html/rewrite-rules.conf
         RewriteRule "^/rasp/(.*)" "/rasp/$1.php" [L]
+        RewriteRule "^/security/(.*)" "/security/$1.php" [L]
         RewriteRule "^/debugger$" "/debugger/"
         RewriteCond /var/www/html/%{REQUEST_URI} !-f
         RewriteRule "^/api_security.sampling/.*" "/api_security_sampling.php/$0" [L]

--- a/utils/build/docker/php/weblogs/plain/security/thread_context_sharing.php
+++ b/utils/build/docker/php/weblogs/plain/security/thread_context_sharing.php
@@ -1,0 +1,17 @@
+<?php
+
+$path = $_GET["path"];
+
+$span = \DDTrace\active_span();
+if ($span === null) {
+    http_response_code(500);
+    exit;
+}
+
+file_put_contents($path, "system-tests thread context sharing");
+
+header('Content-Type: application/json');
+echo json_encode([
+    'trace_id' => \DDTrace\trace_id(),
+    'span_id' => (string) $span->id,
+]);

--- a/utils/build/docker/php/weblogs/plain/security/thread_context_sharing.php
+++ b/utils/build/docker/php/weblogs/plain/security/thread_context_sharing.php
@@ -8,6 +8,11 @@ if ($span === null) {
     exit;
 }
 
+// Warm-up: Apache's prefork MPM can hand this request to a worker that has never run
+// PHP before, and the tracer publishes its OTel process context (the OTEL_CTX mapping
+// only when the first request initialises it.
+usleep(1000 * 1000);
+
 file_put_contents($path, "system-tests thread context sharing");
 
 header('Content-Type: application/json');

--- a/utils/build/docker/python/flask/app.py
+++ b/utils/build/docker/python/flask/app.py
@@ -632,6 +632,23 @@ def trace_manual_keep_drop():
     }
 
 
+@app.route("/security/thread_context_sharing")
+def thread_context_sharing():
+    path = flask_request.args["path"]
+
+    span = tracer.current_span()
+    if span is None:
+        return Response(status=500)
+
+    with open(path, "w") as f:
+        f.write("system-tests thread context sharing")
+
+    return {
+        "trace_id": str(span.trace_id),
+        "span_id": str(span.span_id),
+    }
+
+
 @app.route("/make_distant_call")
 def make_distant_call():
     url = flask_request.args["url"]


### PR DESCRIPTION
## Motivation

End to end test for trace correlation between tracers and agent.

## Changes

Added the /security/thread_context_sharing endpoint for Java, Python and PHP
