### PR TITLE
Add script to build agent image from a local datadog-agent branch

### DIFF
--- a/docs/execute/binaries.md
+++ b/docs/execute/binaries.md
@@ -7,6 +7,38 @@ But we often want to run system tests against unmerged changes. The general appr
 
 * Add a file `agent-image` in `binaries/`. The content must be a valid docker image name containing the datadog agent, like `datadog/agent` or `datadog/agent-dev:master-py3`.
 
+### Building an agent image from a local datadog-agent branch
+
+If your datadog-agent changes are limited to `pkg/trace` or `cmd/trace-agent`, you don't need
+to wait for a datadog-agent CI image build (or run the slow, Linux-devcontainer-only
+`dda inv agent.hacky-dev-image-build`) to test them. `utils/scripts/build-local-agent-image.sh`
+compiles just the trace-agent binary from your local checkout/worktree and overlays it onto a
+published agent base image:
+
+```bash
+./utils/scripts/build-local-agent-image.sh /path/to/datadog-agent datadog/agent-dev:my-branch
+echo datadog/agent-dev:my-branch > binaries/agent-image
+./build.sh golang
+TEST_LIBRARY=golang ./run.sh DEFAULT
+```
+
+Run `./utils/scripts/build-local-agent-image.sh --help` for all options (base image, output
+image tag/path via flags or env vars, etc). The script builds the trace-agent with `CGO_ENABLED=1`
+(required by the zstd dependency, so it can't cross-compile from macOS with `CGO_ENABLED=0`)
+inside a `golang` container matching your Docker host's architecture and your agent checkout's
+`.go-version`, and sets version ldflags so the resulting binary reports the same agent version as
+the base image (otherwise system-tests' agent-version gating sees a generic `6.0.0`).
+
+To confirm the custom binary is actually running once a scenario has executed:
+* `logs_<scenario>/docker/agent/stdout.log` -- TRACE-level log lines show `/src/...` source
+  paths, since the binary was compiled inside the script's `/src` mount.
+* `logs_<scenario>/docker/agent/image.json` -- shows the image tag that was used.
+
+**Limitation**: only the trace-agent binary is replaced, so this only covers changes inside
+`pkg/trace`/`cmd/trace-agent`. For changes elsewhere in datadog-agent, build a full agent image
+instead, either with `dda inv agent.hacky-dev-image-build` from a Linux devcontainer, or by using
+the CI-built `datadog/agent-dev:<branch>` image from your datadog-agent PR.
+
 ## C++ library
 
 * Tracer:

--- a/utils/scripts/build-local-agent-image.sh
+++ b/utils/scripts/build-local-agent-image.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2021 Datadog, Inc.
+
+##########################################################################################
+# Build a datadog-agent Docker image whose trace-agent binary is compiled from a LOCAL
+# datadog-agent checkout/worktree, overlaid on a published agent base image.
+#
+# This is a fast shortcut for iterating on pkg/trace or cmd/trace-agent without waiting
+# for a datadog-agent CI image build, and without needing `dda inv agent.hacky-dev-image-build`
+# (which builds host-native binaries + rtloader and requires a Linux devcontainer on macOS).
+#
+# Only the trace-agent binary is replaced -- this is enough for most APM/tracing
+# system-tests scenarios. If your changes touch code outside pkg/trace or cmd/trace-agent,
+# use `dda inv agent.hacky-dev-image-build` (from a Linux devcontainer) or a CI-built
+# datadog-agent image instead.
+#
+# See docs/execute/binaries.md for how to wire the resulting image into system-tests.
+##########################################################################################
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: build-local-agent-image.sh [OPTIONS] [AGENT_SRC] [IMAGE]
+
+Build a datadog-agent image with a trace-agent binary compiled from a local
+datadog-agent checkout, overlaid on a published base image.
+
+Arguments (may also be given as options):
+  AGENT_SRC             Path to a local datadog-agent checkout/worktree.
+                         Env: AGENT_SRC
+  IMAGE                 Tag for the resulting image, e.g. datadog/agent-dev:my-branch
+                         Env: IMAGE
+
+Options:
+  -s, --agent-src PATH   Same as the AGENT_SRC positional argument.
+  -i, --image TAG        Same as the IMAGE positional argument.
+  -b, --base-image REF   Base agent image to overlay onto. Default: datadog/agent-dev:master-py3
+                         Env: BASE_IMAGE
+  -h, --help             Show this help and exit.
+
+Environment variables:
+  BASE_IMAGE      Base agent image (default: datadog/agent-dev:master-py3)
+  PLATFORM        Docker platform to build for (default: linux/<docker server arch>)
+  AGENT_VERSION   Override the version baked into the binary (default: derived from
+                  BASE_IMAGE's own trace-agent)
+  GOMODCACHE      Host Go module cache to mount (default: $GOPATH/pkg/mod or
+                  $HOME/go/pkg/mod)
+
+Examples:
+  ./utils/scripts/build-local-agent-image.sh ~/dev/datadog-agent datadog/agent-dev:my-branch
+  ./utils/scripts/build-local-agent-image.sh --agent-src ~/dev/datadog-agent \
+      --image datadog/agent-dev:my-branch
+
+After building, wire the image into system-tests:
+  echo datadog/agent-dev:my-branch > binaries/agent-image
+  ./build.sh <library>
+  TEST_LIBRARY=<library> ./run.sh DEFAULT
+EOF
+}
+
+AGENT_SRC="${AGENT_SRC:-}"
+IMAGE="${IMAGE:-}"
+BASE_IMAGE="${BASE_IMAGE:-datadog/agent-dev:master-py3}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -s | --agent-src)
+            AGENT_SRC="$2"
+            shift 2
+            ;;
+        -i | --image)
+            IMAGE="$2"
+            shift 2
+            ;;
+        -b | --base-image)
+            BASE_IMAGE="$2"
+            shift 2
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$AGENT_SRC" ]]; then
+                AGENT_SRC="$1"
+            elif [[ -z "$IMAGE" ]]; then
+                IMAGE="$1"
+            else
+                echo "Unexpected extra argument: $1" >&2
+                usage >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$AGENT_SRC" ]]; then
+    echo "error: missing datadog-agent source path." >&2
+    echo "Pass it as the first argument, --agent-src, or the AGENT_SRC env var." >&2
+    exit 1
+fi
+
+if [[ -z "$IMAGE" ]]; then
+    echo "error: missing output image tag." >&2
+    echo "Pass it as the second argument, --image, or the IMAGE env var." >&2
+    exit 1
+fi
+
+if [[ ! -d "$AGENT_SRC" ]]; then
+    echo "error: datadog-agent source path '$AGENT_SRC' does not exist or is not a directory." >&2
+    exit 1
+fi
+
+if [[ ! -f "$AGENT_SRC/.go-version" ]]; then
+    echo "error: '$AGENT_SRC/.go-version' not found -- is this a datadog-agent checkout?" >&2
+    exit 1
+fi
+
+# Docker platform of the resulting image; must match the arch your docker VM/host runs.
+PLATFORM="${PLATFORM:-linux/$(docker version --format '{{.Server.Arch}}')}"
+GOARCH="${PLATFORM##*/}"
+
+WORK="$HOME/.cache/system-tests-agent-build"
+OUT="$WORK/out"
+mkdir -p "$OUT" "$WORK/gocache"
+
+GO_VERSION="$(cat "$AGENT_SRC/.go-version")"
+TRACE_AGENT_TAGS="docker containerd datadog.no_waf kubelet otlp netcgo podman"
+GOMODCACHE="${GOMODCACHE:-${GOPATH:-$HOME/go}/pkg/mod}"
+
+# Match the base image's own version so system-tests' agent-version gating behaves the
+# same way it would with the published image (an unset version would otherwise report
+# a generic 6.0.0).
+AGENT_VERSION="${AGENT_VERSION:-$(docker run --rm --entrypoint /opt/datadog-agent/embedded/bin/trace-agent "$BASE_IMAGE" version |
+    sed -E 's/^trace-agent ([^ ]+).*/\1/')}"
+COMMIT="$(git -C "$AGENT_SRC" rev-parse --short HEAD)"
+FULL_COMMIT="$(git -C "$AGENT_SRC" rev-parse HEAD)"
+VERSION_PKG=github.com/DataDog/datadog-agent/pkg/version
+
+echo ">> building trace-agent ($AGENT_VERSION, $COMMIT) for $PLATFORM from $AGENT_SRC"
+docker run --rm --platform "$PLATFORM" \
+    -v "$AGENT_SRC:/src" \
+    -v "$GOMODCACHE:/go/pkg/mod" \
+    -v "$OUT:/out" \
+    -v "$WORK/gocache:/gocache" \
+    -w /src -e CGO_ENABLED=1 -e GOCACHE=/gocache -e "GOARCH=$GOARCH" \
+    "golang:$GO_VERSION" \
+    go build -tags "$TRACE_AGENT_TAGS" \
+        -ldflags "-X $VERSION_PKG.AgentVersion=$AGENT_VERSION -X $VERSION_PKG.Commit=$COMMIT -X $VERSION_PKG.FullCommit=$FULL_COMMIT" \
+        -o /out/trace-agent ./cmd/trace-agent
+
+# The Dockerfile must live inside the (small) build context directory: using `-f` to
+# point at a Dockerfile outside the context (e.g. in /tmp) fails on macOS with xattr
+# permission errors.
+cat >"$OUT/Dockerfile" <<EOF
+FROM $BASE_IMAGE
+COPY trace-agent /opt/datadog-agent/embedded/bin/trace-agent
+EOF
+
+echo ">> building image $IMAGE on $BASE_IMAGE"
+docker build --platform "$PLATFORM" -t "$IMAGE" "$OUT"
+
+echo ">> verifying built image"
+docker run --rm --entrypoint /opt/datadog-agent/embedded/bin/trace-agent "$IMAGE" version
+
+echo ">> done: $IMAGE"
+echo ">> to use it with system-tests, run:"
+echo "     echo $IMAGE > binaries/agent-image"

--- a/utils/scripts/build-local-agent-image.sh
+++ b/utils/scripts/build-local-agent-image.sh
@@ -86,6 +86,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --)
             shift
+            while [[ $# -gt 0 ]]; do
+                if [[ -z "$AGENT_SRC" ]]; then
+                    AGENT_SRC="$1"
+                elif [[ -z "$IMAGE" ]]; then
+                    IMAGE="$1"
+                else
+                    echo "Unexpected extra argument: $1" >&2
+                    usage >&2
+                    exit 1
+                fi
+                shift
+            done
             break
             ;;
         -*)
@@ -125,18 +137,28 @@ if [[ ! -d "$AGENT_SRC" ]]; then
     exit 1
 fi
 
+# Docker's bind-mount syntax requires an absolute host path.
+AGENT_SRC="$(cd "$AGENT_SRC" && pwd)"
+
 if [[ ! -f "$AGENT_SRC/.go-version" ]]; then
     echo "error: '$AGENT_SRC/.go-version' not found -- is this a datadog-agent checkout?" >&2
     exit 1
 fi
 
 # Docker platform of the resulting image; must match the arch your docker VM/host runs.
+# Platform is os/arch[/variant] (e.g. linux/arm/v7) -- only the arch component maps to GOARCH.
 PLATFORM="${PLATFORM:-linux/$(docker version --format '{{.Server.Arch}}')}"
-GOARCH="${PLATFORM##*/}"
+IFS='/' read -r _PLATFORM_OS GOARCH PLATFORM_VARIANT <<<"$PLATFORM"
+GOARM=""
+if [[ "$GOARCH" == "arm" && -n "$PLATFORM_VARIANT" ]]; then
+    GOARM="${PLATFORM_VARIANT#v}"
+fi
 
 WORK="$HOME/.cache/system-tests-agent-build"
-OUT="$WORK/out"
-mkdir -p "$OUT" "$WORK/gocache"
+GOCACHE_DIR="$WORK/gocache"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/system-tests-agent-build.XXXXXX")"
+trap 'rm -rf "$OUT"' EXIT
+mkdir -p "$GOCACHE_DIR"
 
 GO_VERSION="$(cat "$AGENT_SRC/.go-version")"
 TRACE_AGENT_TAGS="docker containerd datadog.no_waf kubelet otlp netcgo podman"
@@ -152,12 +174,19 @@ FULL_COMMIT="$(git -C "$AGENT_SRC" rev-parse HEAD)"
 VERSION_PKG=github.com/DataDog/datadog-agent/pkg/version
 
 echo ">> building trace-agent ($AGENT_VERSION, $COMMIT) for $PLATFORM from $AGENT_SRC"
+GOARCH_ENV=("-e" "GOARCH=$GOARCH")
+if [[ -n "$GOARM" ]]; then
+    GOARCH_ENV+=("-e" "GOARM=$GOARM")
+fi
+# Run as the caller's UID/GID so the build doesn't leave root-owned files behind in the
+# host-mounted GOMODCACHE/gocache/out directories.
 docker run --rm --platform "$PLATFORM" \
+    --user "$(id -u):$(id -g)" -e HOME=/tmp \
     -v "$AGENT_SRC:/src" \
     -v "$GOMODCACHE:/go/pkg/mod" \
     -v "$OUT:/out" \
-    -v "$WORK/gocache:/gocache" \
-    -w /src -e CGO_ENABLED=1 -e GOCACHE=/gocache -e "GOARCH=$GOARCH" \
+    -v "$GOCACHE_DIR:/gocache" \
+    -w /src -e CGO_ENABLED=1 -e GOCACHE=/gocache "${GOARCH_ENV[@]}" \
     "golang:$GO_VERSION" \
     go build -tags "$TRACE_AGENT_TAGS" \
         -ldflags "-X $VERSION_PKG.AgentVersion=$AGENT_VERSION -X $VERSION_PKG.Commit=$COMMIT -X $VERSION_PKG.FullCommit=$FULL_COMMIT" \

--- a/utils/scripts/libraries_and_scenarios_rules.yml
+++ b/utils/scripts/libraries_and_scenarios_rules.yml
@@ -254,6 +254,9 @@ patterns:
         scenario_groups: null
     utils/scripts/ai/*:
         scenario_groups: null
+    utils/scripts/build-local-agent-image.sh:
+        scenario_groups: null
+        libraries: null
     utils/scripts/check_version.sh:
         scenario_groups: null
     utils/scripts/compute_libraries_and_scenarios.py:


### PR DESCRIPTION
## Motivation

Testing datadog-agent trace-agent changes against system-tests today means waiting on a
datadog-agent CI image build, or running `dda inv agent.hacky-dev-image-build` -- which builds
host-native binaries + rtloader and requires a Linux devcontainer, so it doesn't work directly
on macOS and is slow either way.

Most APM/tracing system-tests scenarios only exercise the **trace-agent**, so this PR adds a
much faster path: compile just `cmd/trace-agent` from a local datadog-agent checkout/worktree
inside a Linux `golang` container, and overlay that one binary onto a published agent base
image. system-tests already supports pointing at a custom agent image via `binaries/agent-image`
(see `utils/_context/containers.py`), so the resulting image drops straight into an existing
system-tests workflow.

## What's added

- `utils/scripts/build-local-agent-image.sh`
  - Takes the datadog-agent source path and output image tag as positional args, `--agent-src`
    / `--image` flags, or env vars (`AGENT_SRC` / `IMAGE`) -- no personal paths or tags baked in.
  - Detects the Docker server arch (`docker version --format '{{.Server.Arch}}'`) and builds for
    it, so it works on both arm64 Macs (colima/Docker Desktop) and amd64 Linux.
  - Reads the Go version from the agent checkout's `.go-version` and uses the matching
    `golang:<version>` image.
  - Builds with the trace-agent's build tags (`docker containerd datadog.no_waf kubelet otlp
    netcgo podman`) and `CGO_ENABLED=1` (the zstd dependency needs cgo; a pure
    `CGO_ENABLED=0` cross-compile from macOS fails).
  - Mounts the host Go module cache and a persistent `GOCACHE` so repeat builds are fast
    (~45s warm).
  - Sets version ldflags (`pkg/version.{AgentVersion,Commit,FullCommit}`) so the built binary
    reports the same agent version as the base image -- otherwise it reports the generic
    `6.0.0`, which skews system-tests' agent-version gating.
  - Overlays the binary via a generated Dockerfile inside a small build context dir (a
    Dockerfile referenced with `-f` from outside the context, e.g. `/tmp`, fails on macOS with
    xattr permission errors).
  - Verifies the result by running `trace-agent version` in the built image.
  - Prints the exact `echo ... > binaries/agent-image` line to wire the image into
    system-tests.

- `docs/execute/binaries.md`: new subsection under `## Agent` covering when to use this (changes
  limited to `pkg/trace`/`cmd/trace-agent`), the exact commands, how to confirm the custom binary
  is running (`logs_<scenario>/docker/agent/stdout.log` TRACE lines show `/src/...` paths;
  `logs_<scenario>/docker/agent/image.json` shows the image tag), and the limitation that only
  the trace-agent binary is replaced -- for anything else, use
  `dda inv agent.hacky-dev-image-build` from a Linux devcontainer or a CI-built
  `datadog/agent-dev:<branch>` image.

## Validation

- End-to-end: the resulting image was used to run the `DEFAULT` scenario for `golang`, which
  passed green, and the agent container logs confirmed the custom binary was in use (TRACE log
  lines showed `/src/...` source paths from the container's build mount).
- This PR's script itself was re-run against a real local datadog-agent worktree with a throwaway tag, and produced:
  ```
  trace-agent 7.84.0-devel - Commit: 7e639d07d86 - Serialization version:  - Go version: go1.26.6
  ```
  confirming the devel version and commit were baked in correctly. The throwaway image was
  removed afterward, and no files under `binaries/` were committed.
- `shellcheck utils/scripts/build-local-agent-image.sh` passes with no findings.