### PR TITLE
[debugger] Test mismatched tracer and Agent envs

### DIFF
--- a/.github/workflows/run-end-to-end.yml
+++ b/.github/workflows/run-end-to-end.yml
@@ -475,6 +475,9 @@ jobs:
     - name: Run DEBUGGER_INPRODUCT_ENABLEMENT scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"DEBUGGER_INPRODUCT_ENABLEMENT"')
       run: ./run.sh DEBUGGER_INPRODUCT_ENABLEMENT
+    - name: Run DEBUGGER_REMOTE_CONFIG_ENV_MISMATCH scenario
+      if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"DEBUGGER_REMOTE_CONFIG_ENV_MISMATCH"')
+      run: ./run.sh DEBUGGER_REMOTE_CONFIG_ENV_MISMATCH
     - name: Run DEBUGGER_TELEMETRY scenario
       if: steps.build.outcome == 'success' && !cancelled() && contains(inputs.scenarios, '"DEBUGGER_TELEMETRY"')
       run: ./run.sh DEBUGGER_TELEMETRY

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -4,6 +4,7 @@
 
 import tests.debugger.utils as debugger
 from utils import context, features, interfaces, logger, scenarios, slow
+from utils.dd_constants import RemoteConfigApplyState
 import json
 import time
 
@@ -61,6 +62,30 @@ class Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation(debugger.BaseDe
         assert self.di_explicit_enabled, "Expected probes to be emitting after enabling dynamic instrumentation"
         assert self.di_empty_config, "Expected probes to continue emitting with empty config"
         assert self.di_explicit_disabled, "Expected probes to stop emitting after explicit disable"
+
+    def setup_apm_tracing_and_live_debugging_with_mismatched_env(self):
+        self.initialize_weblog_remote_config()
+
+        probe = json.loads(self._probe_template)
+        probe["id"] = debugger.generate_probe_id("log")
+        self.set_probes([probe])
+
+        # The backend associates the service with the Agent's environment, not the tracer's empty environment.
+        self.send_rc_apm_tracing_and_probes(dynamic_instrumentation_enabled=True, env="prod")
+        self.send_weblog_request("/debugger/log")
+        self.di_mismatched_env_emitting = self.wait_for_all_probes(statuses=["EMITTING"], timeout=TIMEOUT)
+        self.di_mismatched_env_snapshot = self.wait_for_all_snapshots(timeout=TIMEOUT)
+
+    @scenarios.debugger_remote_config_env_mismatch
+    def test_apm_tracing_and_live_debugging_with_mismatched_env(self):
+        self.assert_rc_state_not_error()
+        self.assert_all_weblog_responses_ok()
+
+        config_states = [state for result in self.rc_states for state in result.configs.values()]
+        assert {state["product"] for state in config_states} == {"APM_TRACING", "LIVE_DEBUGGING"}
+        assert all(state["apply_state"] == RemoteConfigApplyState.ACKNOWLEDGED for state in config_states)
+        assert self.di_mismatched_env_emitting, "Expected the probe to emit after APM_TRACING enabled it"
+        assert self.di_mismatched_env_snapshot, "Expected LIVE_DEBUGGING to emit a snapshot"
 
 
 @features.debugger_inproduct_enablement

--- a/tests/test_the_test/test_docker_scenario.py
+++ b/tests/test_the_test/test_docker_scenario.py
@@ -5,7 +5,7 @@ import pytest
 
 from utils import interfaces, scenarios
 from utils._context._scenarios.endtoend import DdTraceEndToEndScenario, DockerScenario
-from utils._context.containers import TestedContainer as _TestedContainer
+from utils._context.containers import AgentContainer, TestedContainer as _TestedContainer
 
 
 class FakeContainer(_TestedContainer):
@@ -50,6 +50,12 @@ def test_main():
     scenario.pytest_sessionstart(None)
 
     assert events == ["start D", "start C", "start B", "start A"]
+
+
+@scenarios.test_the_test
+def test_agent_container_preserves_explicit_env() -> None:
+    assert AgentContainer(use_proxy=False).environment["DD_ENV"] == "system-tests"
+    assert AgentContainer(use_proxy=False, environment={"DD_ENV": "prod"}).environment["DD_ENV"] == "prod"
 
 
 @scenarios.test_the_test

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -1115,6 +1115,22 @@ class _Scenarios:
         scenario_groups=[scenario_groups.debugger],
     )
 
+    debugger_remote_config_env_mismatch = DdTraceEndToEndScenario(
+        "DEBUGGER_REMOTE_CONFIG_ENV_MISMATCH",
+        rc_api_enabled=True,
+        rc_backend_enabled=True,
+        weblog_env={
+            "DD_ENV": "",
+            "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "0",
+            "DD_REMOTE_CONFIG_ENABLED": "true",
+            "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS": "0.1",
+        },
+        agent_env={"DD_ENV": "prod"},
+        library_interface_timeout=5,
+        doc="Test backend Remote Config when the Agent and tracer have distinct environments.",
+        scenario_groups=[scenario_groups.debugger],
+    )
+
     debugger_telemetry = DdTraceEndToEndScenario(
         "DEBUGGER_TELEMETRY",
         rc_api_enabled=True,

--- a/utils/_context/containers.py
+++ b/utils/_context/containers.py
@@ -791,9 +791,9 @@ class AgentContainer(TestedContainer):
         environment: dict[str, str | None] | None = None,
     ) -> None:
         environment = environment or {}
+        environment.setdefault("DD_ENV", "system-tests")
         environment.update(
             {
-                "DD_ENV": "system-tests",
                 "DD_HOSTNAME": "test",
                 "DD_SITE": self.dd_site,
                 "DD_APM_RECEIVER_PORT": str(self.apm_receiver_port),


### PR DESCRIPTION
## Motivation

Verify that Remote Config continues to support APM Tracing and Live Debugging when the tracer reports an empty environment while the Datadog Agent uses `prod`.

## Changes

- allow explicit Agent `DD_ENV` values to override the system-tests default
- configure the debugger telemetry scenario with distinct tracer and Agent environments
- verify combined `APM_TRACING` and `LIVE_DEBUGGING` configurations are acknowledged and produce a debugger snapshot
- cover Agent environment override behavior in test-the-test

## Testing

- `./run.sh TEST_THE_TEST tests/test_the_test/test_docker_scenario.py`
- `./run.sh TEST_THE_TEST tests/test_the_test/test_minimal_number_of_scenarios.py`
- debugger scenario collection checks for both affected scenarios
- targeted Ruff and diff checks

`./format.sh` passed mypy, Ruff, YAML, and parser checks, then encountered the existing shellcheck issue where `utils/build/docker/internal_server/app.sh` is a directory.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on your PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
