### PR TITLE
Add test to verify that `_dd.span_links span_id` is zero-padded to 16 hex chars

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -315,6 +315,7 @@ manifest:
   tests/parametric/test_span_links.py: ">=2.2.0"
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_link_propagated_sampling_decisions: missing_feature (auto.drop not supported)
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05: missing_feature (v0.5 not implemented)
+  tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05_span_id_padding: missing_feature (v0.5 not implemented)
   ? tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_child_span_selected_and_root_dropped_by_sss_when_dropping_policy_is_active017
   : missing_feature (span dropping policy not implemented)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_entire_trace_dropped_when_dropping_policy_is_active018: missing_feature (span dropping policy not implemented)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2533,6 +2533,9 @@ manifest:
       component_version: <5.93.0
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_link_propagated_sampling_decisions: missing_feature (links do not influence the sampling decision of spans)
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v04: missing_feature (only supports span links encoding through _dd.span_links tag)
+  tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05_span_id_padding:  # TODO: a lower version might be supported
+    - declaration: missing_feature (does not currently support creating a link from distributed datadog headers)
+      component_version: <5.93.0
   ? tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_child_span_selected_and_root_dropped_by_sss_when_dropping_policy_is_active017
   : missing_feature (Not implemented)
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_entire_trace_dropped_when_dropping_policy_is_active018: missing_feature (Not implemented)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2594,6 +2594,7 @@ manifest:
   tests/parametric/test_span_links.py::Test_Span_Links: v2.0.0
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_link_propagated_sampling_decisions: missing_feature (links do not influence the sampling decision of spans)
   tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05: missing_feature (v0.5 is not supported in Ruby)
+  tests/parametric/test_span_links.py::Test_Span_Links::test_span_started_with_link_v05_span_id_padding: missing_feature (v0.5 is not supported in Ruby)
   ? tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_child_span_selected_and_root_dropped_by_sss_when_dropping_policy_is_active017
   : "missing_feature (\"Issue: sending the complete trace when only the root span is expected\")"
   tests/parametric/test_span_sampling.py::Test_Span_Sampling::test_entire_trace_dropped_when_dropping_policy_is_active018: "missing_feature (\"Issue: sending the complete trace when only the root span is expected\")"

--- a/tests/parametric/test_span_links.py
+++ b/tests/parametric/test_span_links.py
@@ -84,6 +84,33 @@ class Test_Span_Links:
         assert link["attributes"].get("array.1") == "b"
         assert link["attributes"].get("array.2") == "c"
 
+    @pytest.mark.parametrize("library_env", [{"DD_TRACE_API_VERSION": "v0.5"}])
+    def test_span_started_with_link_v05_span_id_padding(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """_dd.span_links span_id must be zero-padded to 16 hex chars, per the RFC.
+
+        Uses a fixed span_id with a zero leading nibble (unlike test_span_started_with_link_v05,
+        which relies on a tracer-generated random id and only has a ~1/16 chance of catching this).
+        """
+        linked_span_id = 0x0123456789ABCDEF  # leading nibble 0 -> unpadded hex would be 15 chars
+
+        with test_library, test_library.dd_start_span("root") as rs:
+            parent_id = test_library.dd_extract_headers(
+                http_headers=[
+                    ("x-datadog-trace-id", "1"),
+                    ("x-datadog-parent-id", str(linked_span_id)),
+                    ("x-datadog-sampling-priority", "2"),
+                ]
+            )
+            rs.add_link(parent_id=parent_id)
+
+        traces = test_agent.wait_for_num_traces(1)
+        trace = find_trace(traces, rs.trace_id)
+        span = find_span(trace, rs.span_id)
+
+        span_links = json.loads(span.get("meta", {}).get("_dd.span_links"))
+        assert len(span_links) == 1
+        assert span_links[0].get("span_id") == f"{linked_span_id:016x}"
+
     def test_span_link_from_distributed_datadog_headers(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         """Properly inject datadog distributed tracing information into span links when trace_api is v0.4.
         Testing the conversion of x-datadog-* headers to tracestate for


### PR DESCRIPTION
## Motivation

Relevant section of the RFC: https://docs.google.com/document/d/1RcTjO8ER5FNweJ0rqVcQEbf6tb1PrlPsQ6coZZww8Xg/edit?tab=t.0#heading=h.pwna8rp9exnf

Current test checks linking to a random span-id, which may or may not need padding. The new test uses a span-id that will definitely require padding.

## Changes

Add test to specifically verify that `_dd.span_links span_id` is zero-padded to 16 hex chars

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
