### PR TITLE
Send APM_TRACING configs as sdk_config when the library advertises SDK_CONFIGURATION

### DIFF
--- a/tests/parametric/capabilities.yml
+++ b/tests/parametric/capabilities.yml
@@ -66,24 +66,33 @@ capabilities:
 
   nodejs:
     base:
+      - ASM_ACTIVATION
+      - ASM_AUTO_USER_INSTRUM_MODE
+
+    # Superseded by SDK_CONFIGURATION in 7.0.0: one capability now covers every remotely
+    # configurable setting, so the per-setting APM_TRACING bits are no longer advertised.
+    # SDK_CONFIGURATION itself is not listed as expected yet, because 7.0.0-pre does not
+    # advertise it either until the library side lands; a pre-release is allowed to report
+    # capabilities beyond the expected set, which covers both sides of that transition.
+    '<7.0.0-0':
       - APM_TRACING_CUSTOM_TAGS
       - APM_TRACING_ENABLED
       - APM_TRACING_HTTP_HEADER_TAGS
       - APM_TRACING_LOGS_INJECTION
       - APM_TRACING_SAMPLE_RATE
       - APM_TRACING_SAMPLE_RULES
-      - ASM_ACTIVATION
-      - ASM_AUTO_USER_INSTRUM_MODE
 
     '>=5.72.0':
       - FFE_FLAG_CONFIGURATION_RULES
 
     '>=5.83.0':
-      - APM_TRACING_ENABLE_CODE_ORIGIN
-      - APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION
       - APM_TRACING_MULTICONFIG
 
-    '>=5.84.0':
+    '>=5.83.0 <7.0.0-0':
+      - APM_TRACING_ENABLE_CODE_ORIGIN
+      - APM_TRACING_ENABLE_DYNAMIC_INSTRUMENTATION
+
+    '>=5.84.0 <7.0.0-0':
       - APM_TRACING_ENABLE_LIVE_DEBUGGING
 
   python:

--- a/tests/parametric/test_dynamic_configuration.py
+++ b/tests/parametric/test_dynamic_configuration.py
@@ -12,6 +12,7 @@ import yaml
 from utils import (
     context,
     features,
+    remote_config,
     rfc,
     scenarios,
 )
@@ -173,6 +174,39 @@ def _default_config(service: str, env: str) -> dict[str, Any]:
     }
 
 
+def uses_sdk_configuration(test_agent: TestAgentAPI) -> bool:
+    """Whether the library reads its APM_TRACING settings from the env-var-keyed `sdk_config`
+    field rather than the legacy `lib_config` object.
+
+    Resolve this *before* anything that clears the recorded requests: reading the capabilities
+    waits for the next remote config request, and one recorded in the middle of an update would
+    be taken for the acknowledgement of that update.
+
+    `wait_for_rc_capabilities` raises when it sees no capability at all, which is what a library
+    that does not poll remote config (tracing disabled by DD_TRACE_ENABLED, for instance) looks
+    like; the shared helper turns that into the `lib_config` default.
+    """
+    return remote_config.resolve_sdk_configuration_support(lambda: test_agent.wait_for_rc_capabilities(_RC_WAIT_LOOPS))
+
+
+def assert_rc_capability(test_agent: TestAgentAPI, capability: Capabilities, wait_loops: int = 100) -> None:
+    """Assert that the tracer advertises the capability to remotely configure one setting.
+
+    A tracer that has moved to the unified SDK_CONFIGURATION contract advertises that single bit
+    for every remotely configurable setting instead of the per-setting ones, so it stands in for
+    any of them. The SDK_CONFIGURATION bit on its own does not, since libdatadog gives that bit a
+    different meaning; only a tracer that has really dropped the per-setting bits qualifies.
+    """
+    seen_capabilities = test_agent.wait_for_rc_capabilities(wait_loops)
+    if capability in seen_capabilities:
+        return
+
+    assert remote_config.resolve_sdk_configuration_contract(seen_capabilities), (
+        f"RemoteConfig capability missing: neither {capability.name} nor the SDK_CONFIGURATION "
+        f"contract that replaces it; seen: {seen_capabilities}"
+    )
+
+
 def _set_rc(
     test_agent: TestAgentAPI,
     config: dict[str, Any],
@@ -183,7 +217,8 @@ def _set_rc(
     # payloads and recreate the stale-ACK race, especially when tests reuse config_id.
     resolved_id: str = str(config_id) if config_id is not None else str(uuid.uuid4())
     config["id"] = resolved_id
-    test_agent.set_remote_config(path=f"datadog/2/APM_TRACING/{resolved_id}/config", payload=config)
+    payload = remote_config.to_sdk_config_payload(config) if uses_sdk_configuration(test_agent) else config
+    test_agent.set_remote_config(path=f"datadog/2/APM_TRACING/{resolved_id}/config", payload=payload)
 
     return resolved_id
 
@@ -207,6 +242,10 @@ def set_and_wait_rc(
     config. config_id filtering matches only the ACK we just triggered.
     """
     rc_config: dict[str, Any] = _create_rc_config(config_overrides)
+    # Resolve the payload shape before clearing, not in _set_rc below: it waits for the next RC
+    # request, and one recorded between the clear and the update would be the stale ACK the clear
+    # is there to discard, which wait_for_rc_apply_state would then take for the new one.
+    uses_sdk_configuration(test_agent)
     if config_id is not None:
         # Reuse case: discard stale ACKs from prior updates at the same path
         test_agent.clear()
@@ -309,7 +348,7 @@ class TestDynamicConfigTracingEnabled:
     def test_capability_tracing_enabled(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the tracing enabled capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_ENABLED})
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_ENABLED)
 
     @parametrize(
         "library_env",
@@ -733,25 +772,25 @@ class TestDynamicConfigV2:
     def test_capability_tracing_sampling_rate(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the trace sampling rate capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_SAMPLE_RATE})
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_SAMPLE_RATE)
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_capability_tracing_logs_injection(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the logs injection capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_LOGS_INJECTION})
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_LOGS_INJECTION)
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_capability_tracing_http_header_tags(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the http header tags capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_HTTP_HEADER_TAGS})
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_HTTP_HEADER_TAGS)
 
     @parametrize("library_env", [{**DEFAULT_ENVVARS}])
     def test_capability_tracing_custom_tags(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the custom tags capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_CUSTOM_TAGS})
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_CUSTOM_TAGS)
 
 
 @scenarios.parametric
@@ -762,7 +801,7 @@ class TestDynamicConfigSamplingRules:
     def test_capability_tracing_sample_rules(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
         """Ensure the RC request contains the trace sampling rules capability."""
         assert test_library.is_alive(), "library container is not alive"
-        test_agent.assert_rc_capabilities({Capabilities.APM_TRACING_SAMPLE_RULES}, wait_loops=_RC_WAIT_LOOPS)
+        assert_rc_capability(test_agent, Capabilities.APM_TRACING_SAMPLE_RULES, wait_loops=_RC_WAIT_LOOPS)
 
     @parametrize(
         "library_env",

--- a/tests/test_library_conf.py
+++ b/tests/test_library_conf.py
@@ -389,6 +389,8 @@ class Test_HeaderTags_DynamicConfig:
             "lib_config": header_tags,
         }
         rc_id = hash(json.dumps(config))
+        if rc.library_supports_sdk_configuration():
+            config = rc.to_sdk_config_payload(config)
         return f"datadog/2/APM_TRACING/{rc_id}/config", config
 
 

--- a/tests/test_the_test/test_remote_config.py
+++ b/tests/test_the_test/test_remote_config.py
@@ -1,4 +1,8 @@
+import base64
+import json
+
 from utils import remote_config as rc, scenarios
+from utils.dd_constants import Capabilities
 
 
 @scenarios.test_the_test
@@ -42,3 +46,221 @@ def test_debugger_command_one_probe():
     obeserved = rc.build_debugger_command(probes, 1)
 
     assert obeserved == expected
+
+
+@scenarios.test_the_test
+def test_to_sdk_config_payload():
+    """The lib_config object is replaced by an env-var-keyed sdk_config, everything else is kept"""
+    observed = rc.to_sdk_config_payload(
+        {
+            "schema_version": "v1.0.0",
+            "action": "enable",
+            "service_target": {"service": "weblog", "env": "system-tests"},
+            "lib_config": {
+                "library_language": "all",
+                "library_version": "latest",
+                "tracing_enabled": True,
+                "dynamic_instrumentation_enabled": False,
+                "tracing_sampling_rate": 0.5,
+                "code_origin_enabled": None,
+            },
+        }
+    )
+
+    assert observed == {
+        "schema_version": "v1.0.0",
+        "action": "enable",
+        "service_target": {"service": "weblog", "env": "system-tests"},
+        "sdk_config": {
+            "service_name": "weblog",
+            "env": "system-tests",
+            "config": {
+                "DD_TRACE_ENABLED": "true",
+                "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "false",
+                "DD_TRACE_SAMPLE_RATE": "0.5",
+            },
+        },
+    }
+
+
+@scenarios.test_the_test
+def test_to_sdk_config_payload_complex_values():
+    """Settings that are objects in lib_config are serialized to their environment variable form"""
+    observed = rc.to_sdk_config_payload(
+        {
+            "service_target": {"service": "*", "env": "*"},
+            "lib_config": {
+                "tracing_header_tags": [
+                    {"header": "X-Test-Header", "tag_name": "test_header_rc"},
+                    {"header": "Content-Length", "tag_name": ""},
+                ],
+                "tracing_tags": ["rc_key1:val1", "rc_key2:val2"],
+                "tracing_service_mapping": [{"from_key": "inbound", "to_name": "outbound"}],
+                "tracing_sampling_rules": [
+                    {
+                        "sample_rate": 0.8,
+                        "service": "test_service",
+                        "resource": "*",
+                        "tags": [{"key": "tag-a", "value_glob": "tag-a-val*"}],
+                        "provenance": "customer",
+                    }
+                ],
+            },
+        }
+    )
+
+    assert observed["sdk_config"]["config"] == {
+        "DD_TRACE_HEADER_TAGS": "X-Test-Header:test_header_rc,Content-Length",
+        "DD_TAGS": "rc_key1:val1,rc_key2:val2",
+        "DD_SERVICE_MAPPING": "inbound:outbound",
+        # the list of tag clauses becomes the map the environment variable expects
+        "DD_TRACE_SAMPLING_RULES": (
+            '[{"sample_rate": 0.8, "service": "test_service", "resource": "*", '
+            '"tags": {"tag-a": "tag-a-val*"}, "provenance": "customer"}]'
+        ),
+    }
+
+
+@scenarios.test_the_test
+def test_to_sdk_config_payload_drops_remote_only_settings():
+    """Settings without an environment variable counterpart can't be expressed as sdk_config"""
+    observed = rc.to_sdk_config_payload(
+        {
+            "service_target": {"service": "weblog", "env": "system-tests"},
+            "lib_config": {
+                "dynamic_sampling_enabled": "true",
+                "live_debugging_enabled": True,
+                "not_a_known_setting": True,
+                "exception_replay_enabled": True,
+            },
+        }
+    )
+
+    assert observed["sdk_config"]["config"] == {"DD_EXCEPTION_REPLAY_ENABLED": "true"}
+
+
+@scenarios.test_the_test
+def test_to_sdk_config_payload_empty_lib_config():
+    """An empty config resets every remotely set value, and stays empty once translated"""
+    observed = rc.to_sdk_config_payload({"action": "enable", "lib_config": {"tracing_sampling_rate": None}})
+
+    assert observed == {"action": "enable", "sdk_config": {"config": {}}}
+
+
+@scenarios.test_the_test
+def test_apm_tracing_command_settings_are_all_mapped():
+    """Every setting the APM_TRACING builders can emit must have a known sdk_config translation"""
+    _, apm_config = rc.build_combined_apm_tracing_and_debugger_command(
+        1,
+        [],
+        dynamic_instrumentation_enabled=True,
+        exception_replay_enabled=True,
+        live_debugging_enabled=True,
+        code_origin_enabled=True,
+        dynamic_sampling_enabled=True,
+    )
+    unknown = set(apm_config["lib_config"]) - set(rc.APM_TRACING_ENV_VAR_NAMES) - rc._LIB_CONFIG_METADATA_KEYS  # noqa: SLF001
+
+    assert not unknown, f"APM_TRACING_ENV_VAR_NAMES is missing an entry for {unknown}"
+
+
+@scenarios.test_the_test
+def test_build_apm_tracing_command_use_sdk_config():
+    """The command carries the sdk_config shape, while prev_payloads keeps the legacy one"""
+    prev_payloads: list[dict] = []
+    command = rc.build_apm_tracing_command(1, prev_payloads, dynamic_instrumentation_enabled=True, use_sdk_config=True)
+
+    sent = json.loads(base64.b64decode(command["target_files"][0]["raw"]))
+    assert "lib_config" not in sent
+    assert sent["sdk_config"]["config"]["DD_DYNAMIC_INSTRUMENTATION_ENABLED"] == "true"
+
+    # the next command inherits its defaults from prev_payloads, which stays in the legacy shape
+    assert prev_payloads[-1]["lib_config"]["dynamic_instrumentation_enabled"] is True
+
+
+@scenarios.test_the_test
+def test_build_apm_tracing_command_legacy_by_default():
+    """Libraries that do not advertise SDK_CONFIGURATION keep receiving lib_config"""
+    command = rc.build_apm_tracing_command(1, [], dynamic_instrumentation_enabled=True)
+
+    sent = json.loads(base64.b64decode(command["target_files"][0]["raw"]))
+    assert "sdk_config" not in sent
+    assert sent["lib_config"]["dynamic_instrumentation_enabled"] is True
+
+
+@scenarios.test_the_test
+def test_resolve_sdk_configuration_contract():
+    """The SDK_CONFIGURATION bit alone does not mean the library reads sdk_config.
+
+    Bit 49 is SDK_CONFIGURATION in the remote config source of truth, but libdatadog gives the
+    same bit to ASM_RAW_RESPONSE_BODY, so the per-setting capabilities have to be gone too.
+    """
+    # dd-trace-js with the SDK_CONFIGURATION support: the per-setting capabilities are dropped
+    assert rc.resolve_sdk_configuration_contract(
+        {
+            Capabilities.ASM_ACTIVATION,
+            Capabilities.APM_TRACING_MULTICONFIG,
+            Capabilities.SDK_CONFIGURATION,
+        }
+    )
+
+    # dd-trace-php: bit 49 is ASM_RAW_RESPONSE_BODY there, and lib_config is still what it reads
+    assert (
+        rc.resolve_sdk_configuration_contract(
+            {
+                Capabilities.APM_TRACING_CUSTOM_TAGS,
+                Capabilities.APM_TRACING_ENABLED,
+                Capabilities.APM_TRACING_HTTP_HEADER_TAGS,
+                Capabilities.APM_TRACING_LOGS_INJECTION,
+                Capabilities.APM_TRACING_SAMPLE_RATE,
+                Capabilities.APM_TRACING_SAMPLE_RULES,
+                Capabilities.APM_TRACING_MULTICONFIG,
+                Capabilities.SDK_CONFIGURATION,
+            }
+        )
+        is False
+    )
+
+    # dd-trace-java: no SDK_CONFIGURATION at all
+    assert (
+        rc.resolve_sdk_configuration_contract({Capabilities.APM_TRACING_SAMPLE_RATE, Capabilities.APM_TRACING_ENABLED})
+        is False
+    )
+
+    # Only ASM capabilities registered so far: nothing to conclude, ask again later
+    assert rc.resolve_sdk_configuration_contract({Capabilities.ASM_ACTIVATION}) is None
+    assert rc.resolve_sdk_configuration_contract(set()) is None
+
+    # A libdatadog library mid-startup: bit 49 is registered with the other AppSec capabilities,
+    # before any APM_TRACING one. The absence of the per-setting bits is not evidence of the
+    # unified contract yet, so this must stay inconclusive rather than be cached as sdk_config.
+    assert (
+        rc.resolve_sdk_configuration_contract(
+            {
+                Capabilities.ASM_ACTIVATION,
+                Capabilities.ASM_AUTO_USER_INSTRUM_MODE,
+                Capabilities.SDK_CONFIGURATION,
+            }
+        )
+        is None
+    )
+
+    # APM_TRACING registered but no SDK_CONFIGURATION: conclusively lib_config
+    assert (
+        rc.resolve_sdk_configuration_contract(
+            {Capabilities.APM_TRACING_MULTICONFIG, Capabilities.APM_TRACING_ENABLE_CODE_ORIGIN}
+        )
+        is False
+    )
+
+
+@scenarios.test_the_test
+def test_apm_tracing_capabilities_exclude_sdk_configuration():
+    """SDK_CONFIGURATION must not count as evidence that APM_TRACING capabilities registered.
+
+    It is the bit whose meaning is ambiguous, so using it as its own evidence would defeat
+    `resolve_sdk_configuration_contract`.
+    """
+    assert Capabilities.SDK_CONFIGURATION not in rc.APM_TRACING_CAPABILITIES
+    assert rc.LEGACY_APM_TRACING_CAPABILITIES <= rc.APM_TRACING_CAPABILITIES
+    assert Capabilities.APM_TRACING_MULTICONFIG in rc.APM_TRACING_CAPABILITIES

--- a/utils/_remote_config.py
+++ b/utils/_remote_config.py
@@ -13,11 +13,11 @@ import threading
 import time
 import uuid
 from typing import Any, Literal
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 
 from utils._context.core import context
 
-from utils.dd_constants import RemoteConfigApplyState as ApplyState
+from utils.dd_constants import Capabilities, RemoteConfigApplyState as ApplyState
 from utils.interfaces import library
 from utils._logger import logger
 from utils.proxy.mocked_response import (
@@ -507,6 +507,236 @@ def send_symdb_command(version: int = 1) -> RemoteConfigStateResults:
     return send_state(raw_payload, target=target)
 
 
+####################################################################################
+# SDK_CONFIGURATION payloads
+#
+# Libraries advertising the SDK_CONFIGURATION capability no longer read the legacy
+# `lib_config` object of an APM_TRACING config. They read a `sdk_config` field
+# instead, which carries the very same settings keyed by their canonical environment
+# variable name, with values in their environment variable (string) form:
+#
+#   {
+#     "schema_version": "v1.0.0",
+#     "action": "enable",
+#     "service_target": {"service": "weblog", "env": "system-tests"},
+#     "sdk_config": {
+#       "service_name": "weblog",
+#       "env": "system-tests",
+#       "config": {"DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true"}
+#     }
+#   }
+#
+# `config` is a flat map, matching `jsonconf.SDKConfig` in dd-go
+# (`remote-config/pkg/products/apmtracing/jsonconf/domain.go`). It used to be a list of
+# `{key, value}` pairs; libraries still read that shape for configs stored before dd-go#14029,
+# but the backend no longer produces it, so neither do we.
+#
+# `service_target` is unchanged: it still drives config matching and priority.
+####################################################################################
+
+# `lib_config` fields that describe the config itself instead of a library setting.
+_LIB_CONFIG_METADATA_KEYS = frozenset({"env", "library_language", "library_version", "service_name"})
+
+# Canonical environment variable name of each `lib_config` setting. `dynamic_sampling_enabled` and
+# `live_debugging_enabled` map to `None`: both are real settings with their own capability bit, but
+# they only ever existed as remote configs and have no environment variable counterpart, so there
+# is nothing to send for them under SDK_CONFIGURATION. They stay listed rather than being removed,
+# so that a setting missing from this table still reports as an unknown one.
+APM_TRACING_ENV_VAR_NAMES: dict[str, str | None] = {
+    "code_origin_enabled": "DD_CODE_ORIGIN_FOR_SPANS_ENABLED",
+    "data_streams_enabled": "DD_DATA_STREAMS_ENABLED",
+    "dynamic_instrumentation_enabled": "DD_DYNAMIC_INSTRUMENTATION_ENABLED",
+    "dynamic_sampling_enabled": None,
+    "exception_replay_enabled": "DD_EXCEPTION_REPLAY_ENABLED",
+    "live_debugging_enabled": None,
+    "log_injection_enabled": "DD_LOGS_INJECTION",
+    "runtime_metrics_enabled": "DD_RUNTIME_METRICS_ENABLED",
+    "tracing_debug": "DD_TRACE_DEBUG",
+    "tracing_enabled": "DD_TRACE_ENABLED",
+    "tracing_header_tags": "DD_TRACE_HEADER_TAGS",
+    "tracing_sampling_rate": "DD_TRACE_SAMPLE_RATE",
+    "tracing_sampling_rules": "DD_TRACE_SAMPLING_RULES",
+    "tracing_service_mapping": "DD_SERVICE_MAPPING",
+    "tracing_tags": "DD_TAGS",
+}
+
+
+def _serialize_header_tags(value: Any) -> str:  # noqa: ANN401
+    """Turn [{"header": "X-Test", "tag_name": "test"}] into `X-Test:test`."""
+    return ",".join(f"{tag['header']}:{tag['tag_name']}" if tag.get("tag_name") else tag["header"] for tag in value)
+
+
+def _serialize_service_mapping(value: Any) -> str:  # noqa: ANN401
+    """Turn [{"from_key": "a", "to_name": "b"}] into `a:b`."""
+    return ",".join(f"{entry['from_key']}:{entry['to_name']}" for entry in value)
+
+
+def _serialize_sampling_rules(value: Any) -> str:  # noqa: ANN401
+    """Remote config rules use a list of tag clauses, DD_TRACE_SAMPLING_RULES uses a map."""
+    rules = []
+    for rule in value:
+        rule = dict(rule)  # noqa: PLW2901
+        if isinstance(rule.get("tags"), list):
+            rule["tags"] = {tag["key"]: tag["value_glob"] for tag in rule["tags"]}
+        rules.append(rule)
+
+    return json.dumps(rules)
+
+
+_SDK_CONFIG_SERIALIZERS: dict[str, Callable[[Any], str]] = {
+    "tracing_header_tags": _serialize_header_tags,
+    "tracing_sampling_rules": _serialize_sampling_rules,
+    "tracing_service_mapping": _serialize_service_mapping,
+    "tracing_tags": lambda value: ",".join(value),
+}
+
+
+def _serialize_sdk_config_value(key: str, value: Any) -> str:  # noqa: ANN401
+    serializer = _SDK_CONFIG_SERIALIZERS.get(key)
+    if serializer is not None:
+        return serializer(value)
+
+    # `isinstance(True, int)` is True, so booleans must be handled before numbers.
+    if isinstance(value, bool):
+        return "true" if value else "false"
+
+    return str(value)
+
+
+def to_sdk_config_payload(config: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite an APM_TRACING config from the legacy `lib_config` shape to the `sdk_config` one.
+
+    Settings set to `None` are omitted: under SDK_CONFIGURATION, a setting missing from the
+    payload is what tells the library to fall back to its local value, which is exactly what a
+    `null` meant in `lib_config`.
+    """
+    service_target = config.get("service_target") or {}
+    settings: dict[str, str] = {}
+
+    for key, value in (config.get("lib_config") or {}).items():
+        if key in _LIB_CONFIG_METADATA_KEYS or value is None:
+            continue
+
+        if key not in APM_TRACING_ENV_VAR_NAMES:
+            logger.warning(f"No environment variable known for lib_config.{key}, not sent as SDK_CONFIGURATION")
+            continue
+
+        env_var_name = APM_TRACING_ENV_VAR_NAMES[key]
+        if env_var_name is None:
+            logger.debug(f"lib_config.{key} has no environment variable counterpart, not sent as SDK_CONFIGURATION")
+            continue
+
+        settings[env_var_name] = _serialize_sdk_config_value(key, value)
+
+    sdk_config: dict[str, Any] = {}
+    if service_target.get("service") is not None:
+        sdk_config["service_name"] = service_target["service"]
+    if service_target.get("env") is not None:
+        sdk_config["env"] = service_target["env"]
+    sdk_config["config"] = settings
+
+    result = {key: value for key, value in config.items() if key != "lib_config"}
+    result["sdk_config"] = sdk_config
+    return result
+
+
+# Every capability of the APM_TRACING family. SDK_CONFIGURATION is deliberately not one of them:
+# it is the bit whose meaning is ambiguous (see `resolve_sdk_configuration_contract`), so it cannot
+# serve as evidence that the library has registered its APM_TRACING remote config.
+APM_TRACING_CAPABILITIES = frozenset(
+    capability for capability in Capabilities if capability.name.startswith("APM_TRACING_")
+)
+
+# The per-setting APM_TRACING capabilities that SDK_CONFIGURATION replaces. A library on the new
+# contract advertises the single SDK_CONFIGURATION bit instead of all of these.
+LEGACY_APM_TRACING_CAPABILITIES = frozenset(
+    {
+        Capabilities.APM_TRACING_CUSTOM_TAGS,
+        Capabilities.APM_TRACING_ENABLED,
+        Capabilities.APM_TRACING_HTTP_HEADER_TAGS,
+        Capabilities.APM_TRACING_LOGS_INJECTION,
+        Capabilities.APM_TRACING_SAMPLE_RATE,
+        Capabilities.APM_TRACING_SAMPLE_RULES,
+    }
+)
+
+
+def resolve_sdk_configuration_contract(capabilities: set[Capabilities]) -> bool | None:
+    """Decide which APM_TRACING payload shape a set of advertised capabilities asks for.
+
+    Returns True for `sdk_config`, False for `lib_config`, and None when the capabilities seen so
+    far cannot tell, so the caller should look again later.
+
+    The SDK_CONFIGURATION bit alone is not enough to decide. Bit 49 is SDK_CONFIGURATION in the
+    remote config source of truth (dd-source `remote-config/shared/libs/rc/capabilities.go`), but
+    libdatadog hands the same bit to `ASM_RAW_RESPONSE_BODY`, so a libdatadog-based library such as
+    dd-trace-php advertises it while still reading `lib_config`.
+
+    Dropping the per-setting capabilities is the whole point of the unified bit, so their absence
+    is what distinguishes the two. Absence only counts once the library has actually registered its
+    APM_TRACING remote config, though: capabilities are added as products start, and AppSec ones
+    come first, so an early poll from a libdatadog library shows bit 49 with no APM_TRACING bit yet
+    and would otherwise be mistaken for the unified contract.
+    """
+    if not capabilities & APM_TRACING_CAPABILITIES:
+        return None
+
+    if capabilities & LEGACY_APM_TRACING_CAPABILITIES:
+        return False
+
+    return Capabilities.SDK_CONFIGURATION in capabilities
+
+
+# Memoized once the capabilities are conclusive, both to skip re-scanning the whole /v0.7/config
+# history on every payload and because a library that has not registered its APM_TRACING
+# capabilities yet reports a partial set, which must not be cached.
+_sdk_configuration_support: dict[str, bool] = {}
+
+
+def resolve_sdk_configuration_support(get_capabilities: Callable[[], set[Capabilities]]) -> bool:
+    """Whether the library reads its APM_TRACING settings from `sdk_config` instead of `lib_config`.
+
+    `get_capabilities` returns the capabilities the library currently advertises. How to obtain
+    them, and how long to wait for them, differs between the end-to-end interface and the
+    parametric test agent, so that part stays with the caller; everything after it is shared.
+
+    Falls back to `lib_config` whenever the answer is not yet knowable, which is the safe
+    direction: a library on the unified contract ignores `lib_config` and its test fails visibly,
+    whereas the reverse would silently apply nothing.
+    """
+    if "value" in _sdk_configuration_support:
+        return _sdk_configuration_support["value"]
+
+    try:
+        capabilities = get_capabilities()
+    except Exception as e:  # callers include setup methods, which must never fail
+        logger.error(f"Could not read the RC capabilities ({e}), assuming no SDK_CONFIGURATION support")
+        return False
+
+    supported = resolve_sdk_configuration_contract(capabilities)
+    if supported is None:
+        logger.info("No APM_TRACING capability advertised yet, sending lib_config for now")
+        return False
+
+    logger.info(f"Library {'supports' if supported else 'does not support'} the SDK_CONFIGURATION capability")
+    _sdk_configuration_support["value"] = supported
+    return supported
+
+
+def library_supports_sdk_configuration() -> bool:
+    """End-to-end flavour of `resolve_sdk_configuration_support`."""
+    if "value" in _sdk_configuration_support:
+        return _sdk_configuration_support["value"]
+
+    # Capabilities are only observable once the library has polled /v0.7/config at least once.
+    # This returns straight away when such a request has already been seen.
+    if not library.wait_for(lambda data: data["path"] == "/v0.7/config", timeout=30):
+        logger.warning("No remote config request seen, assuming the library does not support SDK_CONFIGURATION")
+        return False
+
+    return resolve_sdk_configuration_support(library.get_rc_capabilities)
+
+
 def build_apm_tracing_command(
     version: int,
     prev_payloads: list[dict[str, Any]],
@@ -518,6 +748,7 @@ def build_apm_tracing_command(
     dynamic_sampling_enabled: bool | None = None,
     service_name: str | None = "weblog",
     env: str | None = "system-tests",
+    use_sdk_config: bool = False,
 ):
     lib_config: dict[str, str | bool] = {
         "library_language": "all",
@@ -544,10 +775,13 @@ def build_apm_tracing_command(
     }
 
     path_payloads = {}
-    for _config in prev_payloads:
-        path_payloads[f"datadog/2/APM_TRACING/{uuid.uuid4()}/config"] = _config
+    for _config in [*prev_payloads, config]:
+        path_payloads[f"datadog/2/APM_TRACING/{uuid.uuid4()}/config"] = (
+            to_sdk_config_payload(_config) if use_sdk_config else _config
+        )
 
-    path_payloads[f"datadog/2/APM_TRACING/{uuid.uuid4()}/config"] = config
+    # `prev_payloads` tracks the legacy shape: it is the input of the next command, and gets
+    # translated on its way out just like this one.
     prev_payloads.append(config)
     return _build_base_command(path_payloads, version)
 
@@ -577,6 +811,7 @@ def send_apm_tracing_command(
         dynamic_sampling_enabled=dynamic_sampling_enabled,
         service_name=service_name,
         env=env,
+        use_sdk_config=library_supports_sdk_configuration(),
     )
 
     # Use backend target for scenarios with rc_backend_enabled, tracer target otherwise
@@ -596,6 +831,7 @@ def build_combined_apm_tracing_and_debugger_command(
     dynamic_sampling_enabled: bool | None = None,
     service_name: str | None = "weblog",
     env: str | None = "system-tests",
+    use_sdk_config: bool = False,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Build a single RC command containing both APM_TRACING and LIVE_DEBUGGING configs.
 
@@ -605,7 +841,9 @@ def build_combined_apm_tracing_and_debugger_command(
 
     Returns:
         A tuple of (rc_command, apm_config). The caller should update prev_payloads with
-        the returned apm_config if tracking state across multiple calls.
+        the returned apm_config if tracking state across multiple calls. `apm_config` is always
+        in the legacy `lib_config` shape, whatever shape was sent, as that is what the next
+        call inherits its defaults from.
 
     """
     path_payloads: dict[str, Any] = {}
@@ -649,7 +887,9 @@ def build_combined_apm_tracing_and_debugger_command(
     }
 
     # Only send the latest APM_TRACING config, not all previous ones
-    path_payloads[f"datadog/2/APM_TRACING/{uuid.uuid4()}/config"] = apm_config
+    path_payloads[f"datadog/2/APM_TRACING/{uuid.uuid4()}/config"] = (
+        to_sdk_config_payload(apm_config) if use_sdk_config else apm_config
+    )
 
     # Add LIVE_DEBUGGING configs (probes)
     if probes:
@@ -690,6 +930,7 @@ def send_combined_apm_tracing_and_debugger_command(
         dynamic_sampling_enabled=dynamic_sampling_enabled,
         service_name=service_name,
         env=env,
+        use_sdk_config=library_supports_sdk_configuration(),
     )
 
     # Update prev_payloads with just the new config (don't accumulate)


### PR DESCRIPTION
### Motivation

[dd-trace-js#9392](https://github.com/DataDog/dd-trace-js/pull/9392) is the first library to move to the unified **Config at Runtime** contract, and it fails 7 system-tests jobs:

- `DEBUGGER_INPRODUCT_ENABLEMENT` × 5 weblogs — `Test_Debugger_InProduct_Enablement_Dynamic_Instrumentation::test_inproduct_enablement_di`
- `PARAMETRIC` × 2 — 10 behaviour tests + 7 capability tests in `test_dynamic_configuration.py`

That PR swaps the whole APM_TRACING contract:

|  | before | after |
| --- | --- | --- |
| capabilities | `APM_TRACING_SAMPLE_RATE`, `_LOGS_INJECTION`, `_HTTP_HEADER_TAGS`, `_CUSTOM_TAGS`, `_ENABLED`, `_SAMPLE_RULES`, `_ENABLE_DYNAMIC_INSTRUMENTATION`, `_ENABLE_CODE_ORIGIN`, `_ENABLE_LIVE_DEBUGGING` | `SDK_CONFIGURATION` (bit 49) |
| payload | `lib_config: {dynamic_instrumentation_enabled: true}` | `sdk_config: {service_name, env, config: [{key: "DD_DYNAMIC_INSTRUMENTATION_ENABLED", value: "true"}]}` |

The `lib_config` branch is **removed**, not kept as a fallback — `RCClientManager.addConfig` only reads `conf.sdk_config?.config`. system-tests only ever emits `lib_config`, so every APM_TRACING config becomes a no-op: DI is never enabled, probes never reach `EMITTING`, and the test fails.

### What does this PR do?

The RC helpers now read the capability bit the library advertises on `/v0.7/config` and, when `SDK_CONFIGURATION` is set, send the same settings in the new shape. `service_target` is untouched — it still drives matching and priority.

- **`utils/_remote_config.py`** — `to_sdk_config_payload()` rewrites an APM_TRACING config from `lib_config` to `sdk_config`: each setting keyed by its canonical `DD_*` name, serialized to its environment variable form (booleans, sample rate, `tracing_header_tags` → `"h:tag,…"`, `tracing_tags` → `"k:v,…"`, `tracing_service_mapping` → `"a:b,…"`, `tracing_sampling_rules` → JSON with the `[{key, value_glob}]` tag clauses folded into a map). `library_supports_sdk_configuration()` reads the bit.
- **The two APM_TRACING builders** take `use_sdk_config`; the `send_*` wrappers detect it. `lib_config` stays the internal representation and `prev_payloads` keeps it, so the "empty config keeps the previous value" inheritance the debugger helpers rely on is unchanged.
- **`tests/parametric/test_dynamic_configuration.py`** — translation happens in `_set_rc`, the single choke point that owns `test_agent`. `assert_rc_capability()` accepts the legacy per-setting bit **or** `SDK_CONFIGURATION`, since one bit now covers them all.
- **`tests/parametric/capabilities.yml`** — nodejs's per-setting bits scoped to `<7.0.0-0`.
- **`tests/test_library_conf.py`** — `Test_HeaderTags_DynamicConfig` routed through the same translation (`missing_feature` for nodejs today, but it builds its own APM_TRACING payload).
- **`tests/test_the_test/test_remote_config.py`** — 7 unit tests covering the translation, the value serializers, and that the mapping stays exhaustive over what the builders can emit.

**Nothing changes for any library that does not advertise the bit** — today that is every library, including nodejs on `main`.

### Notes for reviewers

- **`capabilities.yml`**: `SDK_CONFIGURATION` is deliberately *not* listed as expected yet. dd-trace-js `main` is `7.0.0-pre` and does not advertise it until #9392 lands; a pre-release is allowed to report capabilities beyond the expected set, so the `<7.0.0-0` bound alone covers both sides of the transition without a chicken-and-egg break. A follow-up should add `'>=7.0.0-0': [SDK_CONFIGURATION]` once #9392 merges. The bound assumes the removal ships in 7.0.0; if a 7.0.0 is cut before #9392 lands, the bound needs moving.
- **`dynamic_sampling_enabled` and `live_debugging_enabled`** are remote-config-only settings with no environment variable, so they cannot be expressed as `sdk_config` and are dropped for libraries on the new contract. Both are already ignored by dd-trace-js, so nothing regresses; the mapping records them explicitly as `None` rather than guessing a name.
- **`provenance` on sampling rules** is carried through in the `DD_TRACE_SAMPLING_RULES` JSON. dd-trace-js's `SamplingRule` reads it, so `_dd.p.dm` `-11`/`-12` should still be produced through the env-var path — worth confirming on the #9392 run, as it is a library-side behaviour, not a payload one.

### Testing
- `./run.sh TEST_THE_TEST` — 445 passed
- `./format.sh` — clean
- Replayed the 4-step RC sequence of `test_inproduct_enablement_di` through the js reader's allowlist/merge logic: unset → `{}`, enable → `DD_DYNAMIC_INSTRUMENTATION_ENABLED=true`, empty → inherits `true`, disable → `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
