### PR TITLE
test(dotnet): revert easywins for OtelTracestate sampling, disable IAST in sampling scenario

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1097,14 +1097,7 @@ manifest:
       component_version: <=2.41.0
   tests/parametric/test_otel_span_with_baggage.py::Test_Otel_Span_With_Baggage: missing_feature
   tests/parametric/test_otel_tracer.py::Test_Otel_Tracer: v2.8.0
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling::test_emits_probability_sampling_vectors: missing_feature (APMAPI-2171)
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling::test_force_keep_clears_inherited_th: missing_feature (APMAPI-2171)
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling::test_malformed_th_preserves_rv: missing_feature (APMAPI-2171)
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling::test_precision_boundary_decisions: missing_feature (APMAPI-2171)
-  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling::test_sanitizes_malformed_inbound_ot: missing_feature (APMAPI-2171)
+  tests/parametric/test_otel_tracestate_sampling.py::Test_OtelTracestateSampling: missing_feature (APMAPI-2171)
   tests/parametric/test_otlp_trace_metrics.py: v3.52.0
   tests/parametric/test_otlp_trace_metrics.py::Test_FR02_Mutual_Exclusion::test_fr02_3_otlp_suppresses_native_stats: irrelevant (OTLP trace metrics alongside native (non-OTLP) trace export was removed and will not be supported; OTLP trace metrics now require OTEL_TRACES_EXPORTER=otlp)
   tests/parametric/test_otlp_trace_metrics.py::Test_FR06_Otel_Resource_Attributes::test_fr06_10_hostname: missing_feature (host.name is not yet reported on the OTLP trace metrics resource)
@@ -1345,59 +1338,15 @@ manifest:
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_appsec: missing_feature (OTel HTTP server semantics not implemented over OTLP export)
   tests/test_otel_http_semantics.py::Test_OtelSemantics_Spans_Http_Server::test_http_endpoint_retained_from_resource_renaming: irrelevant (The .NET tracer creates http.endpoint from routed AppSec requests)
   tests/test_otel_tracestate_sampling.py::Test_EmitOtOnProbabilityDecision_Rate0_5: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh::test_force_keep_overrides_inherited_drop_decision:
-    - weblog_declaration:
-        poc: missing_feature (APMAPI-2171)
-        uds: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
+  tests/test_otel_tracestate_sampling.py::Test_ForceKeepClearsTh: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchanged: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_ForwardInboundOtUnchangedWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otel_tracestate_sampling.py::Test_MalformedOtHandling: missing_feature (APMAPI-2171)
-  tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
-  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped:  # TODO: a lower version might be supported
-    - declaration: missing_feature (APMAPI-2171)
-      component_version: <3.52.0
-      weblog: [poc, uds]
-    - declaration: missing_feature (APMAPI-2171)
-      excluded_weblog: [poc, uds]
+  tests/test_otel_tracestate_sampling.py::Test_PreserveDdAndOtherVendors: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_PreserveTracestateMemberOrder: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_SampledWithoutOtNotFabricated: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRv: missing_feature (APMAPI-2171)
+  tests/test_otel_tracestate_sampling.py::Test_ThOnlyDoesNotFabricateRvWhenDropped: missing_feature (APMAPI-2171)
   tests/test_otlp_runtime_metrics.py::Test_OtlpRuntimeMetrics: v3.44.0
   tests/test_profiling.py::Test_Profile:
     - weblog_declaration:

--- a/tests/test_otel_tracestate_sampling.py
+++ b/tests/test_otel_tracestate_sampling.py
@@ -105,7 +105,7 @@ class Test_EmitOtOnProbabilityDecision_Rate0_5(_EmitOtOnProbabilityDecisionBase)
 
 
 # Trace ID and rv/th below match the RFC's own verified worked example (rate 0.1, trace ID 0xfff972474538efff).
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_ForwardInboundOtUnchanged:
     """A2: DD honors an already-decided upstream trace; ot=rv:...;th:... is forwarded unchanged, never re-derived."""
@@ -169,7 +169,7 @@ class Test_ForwardInboundOtUnchanged:
         assert "th" not in ot_only, "th was fabricated for an ot= that carried no sampling decision"
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_ThOnlyDoesNotFabricateRv:
     """A2b: th alone is a valid OTel default-sampling decision (rv is only carried when the decision deviates
@@ -194,7 +194,7 @@ class Test_ThOnlyDoesNotFabricateRv:
         assert "rv" not in ot, "an rv was fabricated for a th-only (OTel default-sampling) decision"
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_ForwardInboundOtUnchangedWhenDropped:
     """A2c: A2's forward-unchanged rule holds for a dropped decision too, not just a kept one."""
@@ -217,7 +217,7 @@ class Test_ForwardInboundOtUnchangedWhenDropped:
         assert ot.get("th") == FORWARD_TH, "inbound th was altered instead of being forwarded unchanged"
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_ThOnlyDoesNotFabricateRvWhenDropped:
     """A2d: A2b's no-fabrication rule holds for a dropped decision too, not just a kept one."""
@@ -240,7 +240,7 @@ class Test_ThOnlyDoesNotFabricateRvWhenDropped:
         assert "rv" not in ot, "an rv was fabricated for a th-only (OTel default-sampling) decision"
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_PreserveDdAndOtherVendors:
     """A3: ot= handling must not disturb dd= or an unrelated vendor tracestate member."""
@@ -273,7 +273,7 @@ class Test_PreserveDdAndOtherVendors:
         assert ot.get("th") == FORWARD_TH
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_PreserveTracestateMemberOrder:
     def setup_preserve_tracestate_member_order(self):
@@ -302,7 +302,7 @@ class Test_PreserveTracestateMemberOrder:
         assert unmodified_members == "foo=bar,ot=rv:6e6d1a75832a2f,something=else"
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_ForceKeepClearsTh:
     """A4: a non-probability (force-keep) decision erases th but still forwards an inherited rv.
@@ -381,7 +381,7 @@ class Test_ForceKeepClearsTh:
         assert span.get_sampling_priority() == SamplingPriority.USER_KEEP
 
 
-@scenarios.default
+@scenarios.sampling
 @features.w3c_headers_injection_and_extraction
 class Test_SampledWithoutOtNotFabricated:
     """A5: an inbound trace already sampled (W3C flag) but with no ot= is honored; th/rv are never fabricated."""

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -148,11 +148,10 @@ class Test_SamplingDecisions:
 
     def setup_sampling_decision(self):
         # Generate enough traces to have a high chance to catch sampling problems
-        for _ in range(30):
-            weblog.get(f"/sample_rate_route/{next(request_id_gen)}")
+        self.requests = [weblog.get(f"/sample_rate_route/{next(request_id_gen)}") for _ in range(30)]
 
     def test_sampling_decision(self):
-        """Verify that traces are sampled following the sample rate. This test is run on every root span in the scenario."""
+        """Verify that traces are sampled following the sample rate"""
 
         def validator(trace: DataDogLibraryTrace, root_span: DataDogLibrarySpan):
             sampling_priority = root_span.get_sampling_priority()
@@ -171,9 +170,6 @@ class Test_SamplingDecisions:
                     # In this case it is most likely the Healthcheck as it is the first request
                     # and AppSec WAF always samples the first request.
                     return
-                if root_span["meta"].get("_dd.p.dm") == "-4":
-                    # Manual sampling decisions (keep, drop) override the configured probabilistic sampling rate.
-                    return
                 raise ValueError(
                     f"Trace id {root_span['trace_id']}, sampling priority {sampling_priority}, "
                     f"sampling decision {sampling_decision} differs from the expected {expected_decision}"
@@ -181,7 +177,11 @@ class Test_SamplingDecisions:
 
         # get_root_spans() yields nothing when no root span was collected, so the validator below
         # would never run without this guard
-        root_spans = list(interfaces.library.get_root_spans())
+        root_spans = [
+            (trace, root_span)
+            for request in self.requests
+            for trace, root_span in interfaces.library.get_root_spans(request=request)
+        ]
         assert root_spans, "Expected at least one root span"
 
         for trace, root_span in root_spans:

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -10,7 +10,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from utils import weblog, interfaces, context, scenarios, features, logger
-from utils.dd_constants import SamplingPriority
+from utils.dd_constants import SamplingMechanism, SamplingPriority
 from utils.dd_types import DataDogLibrarySpan, DataDogLibraryTrace
 
 """Those are the constants used by the sampling algorithm in all the tracers
@@ -152,7 +152,7 @@ class Test_SamplingDecisions:
             weblog.get(f"/sample_rate_route/{next(request_id_gen)}")
 
     def test_sampling_decision(self):
-        """Verify that traces are sampled following the sample rate"""
+        """Verify that traces are sampled following the sample rate. This test is run on every root span in the scenario."""
 
         def validator(trace: DataDogLibraryTrace, root_span: DataDogLibrarySpan):
             sampling_priority = root_span.get_sampling_priority()
@@ -170,6 +170,9 @@ class Test_SamplingDecisions:
                     # to AppSec, it should not impact this test and should be ignored.
                     # In this case it is most likely the Healthcheck as it is the first request
                     # and AppSec WAF always samples the first request.
+                    return
+                if root_span["meta"].get("_dd.p.dm") == "-4":
+                    # Manual sampling decisions (keep, drop) override the configured probabilistic sampling rate.
                     return
                 raise ValueError(
                     f"Trace id {root_span['trace_id']}, sampling priority {sampling_priority}, "

--- a/tests/test_sampling_rates.py
+++ b/tests/test_sampling_rates.py
@@ -10,7 +10,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from utils import weblog, interfaces, context, scenarios, features, logger
-from utils.dd_constants import SamplingMechanism, SamplingPriority
+from utils.dd_constants import SamplingPriority
 from utils.dd_types import DataDogLibrarySpan, DataDogLibraryTrace
 
 """Those are the constants used by the sampling algorithm in all the tracers

--- a/utils/_context/_scenarios/__init__.py
+++ b/utils/_context/_scenarios/__init__.py
@@ -240,6 +240,8 @@ class _Scenarios:
 
     sampling = DdTraceEndToEndScenario(
         "SAMPLING",
+        appsec_enabled=False,
+        iast_enabled=False,
         tracer_sampling_rate=0.5,
         weblog_env={"DD_TRACE_RATE_LIMIT": "10000000", "DD_TRACE_STATS_COMPUTATION_ENABLED": "false"},
         doc="Test sampling mechanism. Not included in default scenario because it's a little bit too flaky",


### PR DESCRIPTION
These were activated by easy win script but some will be marked as bug
Moreover, IAST flags the payload in `make_distant_call` and makes a force keeps which would break the test in python, dotnet, Java and PHP. Action: move the impacted test to the sampling scenario, and restrict the a SamplingTest to its own spans (because the moved test involve manual keep)


## Summary

- disable the .NET parametric and end-to-end OTel tracestate sampling suites
- run every end-to-end OTel tracestate test in SAMPLING instead of DEFAULT
- disable AppSec and IAST in the SAMPLING scenario
- remove only the OTel tracestate activations introduced by the automated easy-win PR

All .NET declarations retain the APMAPI-2171 missing-feature marker.