### PR TITLE
test(cpp_nginx): enable AppSec startup product telemetry

### DIFF
--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -505,6 +505,6 @@ manifest:
   tests/test_telemetry.py::Test_TelemetryEnhancedConfigReporting::test_telemetry_enhanced_config_reporting_precedence: missing_feature  # Created by easy win activation script
   tests/test_telemetry.py::Test_TelemetrySCAEnvVar: missing_feature
   tests/test_telemetry.py::Test_TelemetryV2: missing_feature
-  tests/test_telemetry.py::Test_TelemetryV2::test_app_started_product_info: missing_feature (Product started missing in app-started payload)
+  tests/test_telemetry.py::Test_TelemetryV2::test_app_started_product_info: '>1.22.0'
   tests/test_telemetry.py::Test_TelemetryV2::test_telemetry_v2_required_headers: missing_feature
   tests/test_v1_payloads.py: missing_feature


### PR DESCRIPTION
## Summary

- enable `Test_TelemetryV2::test_app_started_product_info` for nginx-datadog versions after 1.22.0
- cover the AppSec `enabled` and module `version` product data added by DataDog/nginx-datadog#426
- rely on the corrected app-started product serialization from DataDog/dd-trace-cpp#366

## Validation

- combined cpp_nginx image built with both implementation branches
- default scenario passed and emitted `products.appsec = {"enabled": true, "version": "1.22.0"}`
- disabled-products scenario passed and emitted `products.appsec = {"enabled": false, "version": "1.22.0"}`
- manifest validator, yamllint, and YAML language-server diagnostics passed
- full `./format.sh` reached shellcheck, which failed on the pre-existing directory `utils/build/docker/internal_server/app.sh`