### PR TITLE
Fix rails72 FFE flake: bump opentelemetry-sdk so metrics-sdk 0.17 resolves

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2050,9 +2050,6 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         rails72: v2.32.0
-    - weblog: rails72
-      component_version: ">=2.42.0"
-      declaration: flaky (FFL-3244)
   tests/integration_frameworks/llm/anthropic/test_anthropic_llmobs.py::TestAnthropicLlmObsMessages::test_create_error: bug (MLOB-1234)
   tests/integrations/crossed_integrations/test_kafka.py::Test_Kafka:
     - weblog_declaration:

--- a/utils/build/docker/ruby/rails72/Gemfile
+++ b/utils/build/docker/ruby/rails72/Gemfile
@@ -9,7 +9,7 @@ gem 'bootsnap', require: false
 # Tracing related dependencies
 gem 'ruby-kafka', '~> 1.5.0'
 gem 'opentelemetry-api', '~> 1.5.0'
-gem 'opentelemetry-sdk', '~> 1.8.0'
+gem 'opentelemetry-sdk', '~> 1.13.0'
 gem 'opentelemetry-common', '>= 0.23.0'
 gem 'opentelemetry-metrics-sdk', '>= 0.8'
 gem 'opentelemetry-exporter-otlp-metrics', '>= 0.6'

--- a/utils/build/docker/ruby/rails72/Gemfile.lock
+++ b/utils/build/docker/ruby/rails72/Gemfile.lock
@@ -108,12 +108,26 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.36.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.36.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.36.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    googleapis-common-protos-types (1.23.0)
+      google-protobuf (~> 4.26)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.1)
@@ -124,6 +138,7 @@ GEM
     json (2.13.0)
     libdatadog (18.1.0.1.0)
     libdatadog (18.1.0.1.0-aarch64-linux)
+    libdatadog (18.1.0.1.0-x86_64-linux)
     libddwaf (1.24.1.0.2)
       ffi (~> 1.0)
     logger (1.7.0)
@@ -158,13 +173,31 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-aarch64-linux-gnu)
       racc (~> 1.4)
-    openfeature-sdk (0.4.0)
+    nokogiri (1.18.9-x86_64-linux-gnu)
+      racc (~> 1.4)
+    openfeature-sdk (0.6.5)
     opentelemetry-api (1.5.0)
-    opentelemetry-common (0.22.0)
+    opentelemetry-common (0.25.1)
       opentelemetry-api (~> 1.0)
+    opentelemetry-exporter-otlp-metrics (0.11.0)
+      google-protobuf (>= 3.18, < 5.0)
+      googleapis-common-protos-types (~> 1.3)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-metrics-api (~> 0.2)
+      opentelemetry-metrics-sdk (~> 0.5)
+      opentelemetry-sdk (~> 1.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-metrics-api (0.7.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-metrics-sdk (0.17.0)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-metrics-api (~> 0.2)
+      opentelemetry-sdk (~> 1.13.0)
     opentelemetry-registry (0.4.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.8.0)
+    opentelemetry-sdk (1.13.0)
+      logger
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
@@ -256,6 +289,7 @@ GEM
 PLATFORMS
   aarch64-linux
   ruby
+  x86_64-linux-gnu
 
 DEPENDENCIES
   bootsnap
@@ -263,9 +297,13 @@ DEPENDENCIES
   devise (~> 4.9)
   dogstatsd-ruby
   faraday (~> 2.13.0)
-  openfeature-sdk (~> 0.4)
+  faraday-follow_redirects (~> 0.3)
+  openfeature-sdk (~> 0.5)
   opentelemetry-api (~> 1.5.0)
-  opentelemetry-sdk (~> 1.8.0)
+  opentelemetry-common (>= 0.23.0)
+  opentelemetry-exporter-otlp-metrics (>= 0.6)
+  opentelemetry-metrics-sdk (>= 0.8)
+  opentelemetry-sdk (~> 1.13.0)
   pry-byebug
   puma (~> 6.0)
   rails (~> 7.2.2)


### PR DESCRIPTION
## Motivation

The `FEATURE_FLAGGING_AND_EXPERIMENTATION` (FFE) scenario flakes on the rails72
weblog in dd-trace-rb's System Tests workflow: all 17
`tests/ffe/test_flag_eval_metrics.py` tests fail with
`Expected metric for flag '<flag>', found none` because no
`feature_flag.evaluations` metric reaches the agent.

Proven flaky on master commit `9dd0b3b09` (not any PR): job
`test / End-to-end #8 / rails72 8` **passed** in run
[33543431453](https://github.com/DataDog/dd-trace-rb/actions/runs/33543431453)
(2026-09-01 18:30) and **failed** in run
[33590531134](https://github.com/DataDog/dd-trace-rb/actions/runs/33590531134)
(2026-09-02 04:27). The same failure recurred on a DI PR in run
[33663638000](https://github.com/DataDog/dd-trace-rb/actions/runs/33663638000),
which does not touch any OpenFeature code — confirming it is unrelated to the
PR under test.

### Root cause

The rails72 weblog `Gemfile` pinned `opentelemetry-sdk ~> 1.8.0` but left
`opentelemetry-metrics-sdk (>= 0.8)` and `opentelemetry-exporter-otlp-metrics
(>= 0.6)` unlocked, and the committed `Gemfile.lock` locked **neither** metrics
gem. Every Docker build therefore resolved them fresh to the latest release.

`opentelemetry-exporter-otlp-metrics` 0.11.0 (released 2026-09-01 22:56 UTC —
between the passing and failing runs) calls `NumberDataPoint#flags` in its
encoder. The `opentelemetry-sdk ~> 1.8.0` pin forbids
`opentelemetry-metrics-sdk` 0.16+/0.17 (they require
`opentelemetry-sdk ~> 1.13.0`), so bundler capped metrics-sdk at 0.15.0, whose
`NumberDataPoint` has no `flags` attribute. The exporter raised
`NoMethodError: undefined method 'flags'` during encode; OpenTelemetry's
global `error_handler` swallowed it, so the metric never reached the agent.

The failing-run weblog `stderr.log` contains 59 occurrences of that exact
error at `opentelemetry-exporter-otlp-metrics-0.11.0/.../metrics_exporter.rb:351`;
the passing-run weblog `stderr.log` contains none.

A stopgap `declaration: flaky (FFL-3244)` for rails72 at `component_version
>=2.42.0` was added to `manifests/ruby.yml` by PR #7630 (merged 2026-09-02
11:51 UTC), which masked the symptom by skipping the test. That marker is
removed here because this PR fixes the root cause.

## Changes

- `utils/build/docker/ruby/rails72/Gemfile`: bump `opentelemetry-sdk` from
  `~> 1.8.0` to `~> 1.13.0` so `opentelemetry-metrics-sdk` 0.17.0 (whose
  `NumberDataPoint` has `flags`) resolves alongside exporter 0.11.0.
- `utils/build/docker/ruby/rails72/Gemfile.lock`: regenerate so both metrics
  gems are locked (`opentelemetry-metrics-sdk` 0.17.0,
  `opentelemetry-exporter-otlp-metrics` 0.11.0,
  `opentelemetry-metrics-api` 0.7.0) and the Docker build no longer drifts to
  latest. Adds the `x86_64-linux-gnu` platform (the Docker build platform,
  previously absent from the lockfile). Also reconciles stale lockfile entries
  that diverged from the Gemfile: `opentelemetry-common` 0.22.0 -> 0.25.1
  (Gemfile requires `>= 0.23.0`) and `openfeature-sdk` 0.4.0 -> 0.6.5 (Gemfile
  requires `~> 0.5`).
- `manifests/ruby.yml`: remove the stopgap `flaky (FFL-3244)` entry for
  `tests/ffe/test_flag_eval_metrics.py` on rails72 (added by #7630). With the
  root cause fixed, the test must run again to validate the fix and catch
  future regressions.

This is a weblog Gemfile/lockfile change plus a manifest skip removal, not a
base-image change, so no `build-*` label applies.

## Workflow

1. Created as draft.
2. CI: the FFE scenario on the rails72 weblog should now pass — the
   `feature_flag.evaluations` metric exports successfully with the
   `flags`-compatible metrics-sdk 0.17.0, and `test_flag_eval_metrics.py` now
   runs (no longer skipped).

### Local verification

Reproduced with a standalone script on Ruby 3.4:
- broken combo (sdk 1.8.0 + metrics-sdk 0.15.0 + exporter 0.11.0) reproduces
  the exact `NoMethodError: undefined method 'flags'` at
  `metrics_exporter.rb:351`;
- fixed combo (sdk 1.13.0 + metrics-sdk 0.17.0 + exporter 0.11.0) exports
  cleanly.

### CI verification (initial run, before manifest change)

The first CI run (commit a1d89a7) confirmed the rails72 weblog image builds
with the fixed gem combo and the FFE scenario runs with **0** `flags` encode
errors in the weblog stderr (vs. 59 in the failing dd-trace-rb run).
`test_flag_eval_metrics.py` was skipped in that run because the `flaky
(FFL-3244)` marker was still present; the follow-up commit (6cf3f19) removes
that marker so the test runs and validates the fix end-to-end.

## Reviewer checklist

* [x] Nothing outside a weblog `Gemfile`/`Gemfile.lock` and `manifests/ruby.yml` is modified.
* [ ] A docker base image is modified? N/A — this is a weblog, not a base image.
* [ ] A scenario is added, removed or renamed? No.