### PR TITLE
test(llmobs): subset-match metadata in assert_llmobs_span_event

### DIFF
--- a/tests/integration_frameworks/llm/utils.py
+++ b/tests/integration_frameworks/llm/utils.py
@@ -51,6 +51,11 @@ def assert_llmobs_span_event(
     error: bool = False,
     has_output: bool = True,
 ) -> None:
+    """Assert an LLMObs span event matches the expected shape.
+
+    Everything is compared by exact equality except ``metadata`` and ``tags``, which are shallow
+    subsets: the keys you declare must match exactly, extra keys the tracer emits are tolerated.
+    """
     # assert span kind, tags, and error separately
     actual_span_kind = actual_span_event["meta"].pop("span.kind", None) or actual_span_event["meta"].pop("span")["kind"]
     actual_tags: list[str] = actual_span_event.pop("tags")
@@ -97,7 +102,12 @@ def assert_llmobs_span_event(
         expected_meta["output"]["value"] = output_value
 
     if metadata is not None:
-        expected_meta["metadata"] = metadata
+        # Assert expected metadata values are there, not entirely equality (subset is fine)
+        actual_metadata: dict = actual_span_event["meta"].get("metadata", {})
+        assert metadata.items() <= actual_metadata.items(), (
+            f"Expected metadata {metadata} to be a subset of {actual_metadata}"
+        )
+        expected_meta["metadata"] = mock.ANY  # already asserted above
 
     if model_name is not None:
         expected_meta["model_name"] = model_name

--- a/tests/integration_frameworks/llm/utils.py
+++ b/tests/integration_frameworks/llm/utils.py
@@ -102,12 +102,14 @@ def assert_llmobs_span_event(
         expected_meta["output"]["value"] = output_value
 
     if metadata is not None:
-        # Assert expected metadata values are there, not entirely equality (subset is fine)
-        actual_metadata: dict = actual_span_event["meta"].get("metadata", {})
-        assert metadata.items() <= actual_metadata.items(), (
-            f"Expected metadata {metadata} to be a subset of {actual_metadata}"
-        )
-        expected_meta["metadata"] = mock.ANY  # already asserted above
+        # Assert expected metadata values are there, not entirely equality (subset is fine).
+        # metadata=mock.ANY is a wildcard for the whole dict, so there is no subset to check.
+        if isinstance(metadata, dict):
+            actual_metadata: dict = actual_span_event["meta"].get("metadata", {})
+            assert metadata.items() <= actual_metadata.items(), (
+                f"Expected metadata {metadata} to be a subset of {actual_metadata}"
+            )
+        expected_meta["metadata"] = mock.ANY
 
     if model_name is not None:
         expected_meta["model_name"] = model_name


### PR DESCRIPTION
## Motivation

`assert_llmobs_span_event` compares the whole span event by equality, so `metadata` must match exactly. When a tracer starts emitting a new provider field it lands on every span of that kind, failing every test for that integration at once — for a purely additive change.

That's blocking [DataDog/dd-trace-py#19752](https://github.com/DataDog/dd-trace-py/pull/19752) (adds `finish_reason`/`stop_reason`): 4 jobs + the `system-tests finished` gate are red only because the actual metadata gained one key. The alternative is editing ~23 metadata dicts, and repeating that for every tracer and future addition.

## Changes

Assert `metadata` as a shallow subset — declared keys must still match exactly, unlisted extras are tolerated — and leave `mock.ANY` in its place so the whole-event equality still passes.

Same semantics as `tags` in `_assert_tags_span_event_tags`, and as dd-trace-py's own `assert_llmobs_span_data`.

Nothing else is relaxed: the rest of the event stays exact equality, and the `metadata=None` branch is untouched (all 33 call sites pass `metadata=`, so it's unused today).

**Tradeoff:** a test can no longer assert a declared key is the *only* metadata present. Notably `metadata={}` (4 google_genai tests) now means "metadata present, any value" rather than "exactly `{}`". Happy to add an opt-in `metadata_exact=True` if you'd rather keep that available.

## Testing

Exercised the real helper against: exact match, the `finish_reason`/`stop_reason` extras, wrong declared value, missing declared key, differing nested dict, empty metadata, `mock.ANY` as a declared value, `ignore_values=["meta.metadata"]`, non-mutation of the caller's event, and `metadata=None` still rejecting stray metadata. Wrong values and missing keys still fail. `mypy` + `ruff` clean.

Real signal is dd-trace-py#19752 going green against this branch; not repinned yet since this should land first.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude session: `acefbd3c-6218-49bb-88c2-c77f319c0b78`
Resume: `claude --resume acefbd3c-6218-49bb-88c2-c77f319c0b78`
