### PR TITLE
[python] enable passing OTLP ot.th/ot.rv tracestate sampling scenarios

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1898,8 +1898,8 @@ manifest:
         uwsgi-poc: v4.3.1  # Modified by easy win activation script
   tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP: v4.8.0
   tests/otel/test_tracing_otlp.py::Test_Otel_Tracing_OTLP::test_128bit_trace_id_consistent_across_spans: v4.12.0rc1
-  tests/otel/test_tracing_otlp.py::Test_Otlp_Carries_Ot: missing_feature (APMAPI-2172)
-  tests/otel/test_tracing_otlp.py::Test_Otlp_Forwards_Inherited_Ot: missing_feature (APMAPI-2172)
+  tests/otel/test_tracing_otlp.py::Test_Otlp_Carries_Ot: v4.15.0-dev
+  tests/otel/test_tracing_otlp.py::Test_Otlp_Forwards_Inherited_Ot: v4.15.0-dev
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Enables the Python entries that pass against dd-trace-py's OTLP implementation (https://github.com/DataDog/dd-trace-py/pull/19794), verified locally against a python@4.15.0-dev build across every impacted scenario

## Changes

<!-- A brief description of the change being made with this pull request. -->
Flips `tests/otel/test_tracing_otlp.py` entries from `missing_feature` to `v4.15.0-dev` in `manifests/python.yml`:

- `Test_Otlp_Carries_Ot`
- `Test_Otlp_Forwards_Inherited_Ot`

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
