### PR TITLE
fix(aws-ssi): reject incomplete Python AMI caches

### DIFF
--- a/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
+++ b/utils/build/virtual_machine/weblogs/python/provision_test-app-python.yml
@@ -5,6 +5,16 @@ lang_variant:
     install: 
       - os_type: linux
         os_distro: deb
+        os_branch: ubuntu22_arm64
+        remote-command: |
+          set -e
+          sudo apt-get update
+          sudo apt install -y python-is-python3
+          sudo apt install -y python3-pip
+          sudo apt install -y python3-django || true
+
+      - os_type: linux
+        os_distro: deb
         remote-command: |
           # Ubuntu 23.04 (Lunar) is EOL since January 2024, use archive repositories
           if grep -q "lunar" /etc/os-release 2>/dev/null; then


### PR DESCRIPTION
## Motivation

The Ubuntu 22 ARM64 `test-app-python` jobs are failing across unrelated dd-trace-py branches because a cached AMI is missing both `python` and `pip3`. This currently blocks DataDog/dd-trace-py#20012.

The shared Debian setup can continue after a required package installation fails. Its final best-effort Django command then returns success, allowing an incomplete AMI to be cached and reused.

## Changes

- Add a fail-fast Python installation specifically for Ubuntu 22 ARM64.
- Keep the generic Debian installation and all other VM cache keys unchanged.
- Change the Ubuntu 22 ARM64 cache key so a clean AMI is built.

## Validation

- Validated the weblog provision against `weblog_provision_schema.yml`.
- Parsed Ubuntu 22 ARM64 and Debian 11 provisions and confirmed only Ubuntu 22 ARM64 selects the fail-fast setup.
- Checked both generated remote commands with `sh -n`.
- The first CI run proved all Ubuntu 22 ARM64 Python jobs pass; this narrower revision avoids rebuilding unrelated Debian AMIs.