### PR TITLE
Fix debian 11 deps (+ ruby deps)

### DIFF
--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-bundle-deploy/Dockerfile
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-bundle-deploy/Dockerfile
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-conflict/Dockerfile
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-conflict/Dockerfile
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-explicit/Dockerfile
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-explicit/Dockerfile
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-explicit/Dockerfile.lib_init_validator
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-explicit/Dockerfile.lib_init_validator
@@ -14,7 +14,11 @@ COPY --from=dd-lib-ruby-init /datadog-init /datadog-lib/
 ENV RUBYOPT=" -r/datadog-lib/auto_inject"
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-gemsrb/Dockerfile
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-gemsrb/Dockerfile
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-gemsrb/Dockerfile.lib_init_validator
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails-gemsrb/Dockerfile.lib_init_validator
@@ -14,7 +14,11 @@ COPY --from=dd-lib-ruby-init /datadog-init /datadog-lib/
 ENV RUBYOPT=" -r/datadog-lib/auto_inject"
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails/Dockerfile
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails/Dockerfile
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails/Dockerfile.lib_init_validator
+++ b/lib-injection/build/docker/ruby/dd-lib-ruby-init-test-rails/Dockerfile.lib_init_validator
@@ -14,7 +14,11 @@ COPY --from=dd-lib-ruby-init /datadog-init /datadog-lib/
 ENV RUBYOPT=" -r/datadog-lib/auto_inject"
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \

--- a/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
+++ b/utils/build/virtual_machine/provisions/auto-inject/auto-inject_init_vm_config.yml
@@ -98,6 +98,10 @@
         echo "deb http://archive.debian.org/debian bullseye-backports main contrib non-free" | sudo tee /etc/apt/sources.list.d/bullseye-backports.list >/dev/null || true
         sudo sed -i 's|cdn-aws.deb.debian.org|archive.debian.org|g' /etc/apt/sources.list || true
         sudo find /etc/apt/sources.list.d -name '*.list' -exec sudo sed -i 's|cdn-aws.deb.debian.org|archive.debian.org|g' {} + || true
+        # Debian 11 LTS ended 2026-08-31; drop security.debian.org (404s) and keep archive only
+        sudo sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list || true
+        sudo find /etc/apt/sources.list.d -name '*.list' -exec sudo sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' {} + || true
+        echo 'Acquire::Check-Valid-Until "false";' | sudo tee /etc/apt/apt.conf.d/99no-check-valid-until >/dev/null || true
       fi
     fi
     sudo apt-get -y update

--- a/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/Dockerfile.template
+++ b/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-container/Dockerfile.template
@@ -3,7 +3,11 @@ FROM public.ecr.aws/docker/library/ruby:3.1.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
- Debian 11 LTS ended on 2026-08-31. `security.debian.org` still lists bullseye packages but the `.deb` files 404, which breaks AWS SSI provisioning on `Debian_11_*` (`apt-get install git wget`).
- Drop `security.debian.org` / `bullseye-security` sources on Debian 11 and keep `archive.debian.org` only. Disable `Acquire::Check-Valid-Until` so expired archive Release files do not fail `apt-get update`.
- Ruby K8s SSI weblogs: ruby:3.1.3 is Debian 11. After LTS ended on 2026-08-31, debian-security 404s during apt-get install and the image build fails. Same fix as the AWS SSI VMs: point apt at archive.debian.org, drop security repos, and disable Check-Valid-Until.

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
