### PR TITLE
Fix parametric Node image build after Debian 11 apt 404s

### DIFF
--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -2,8 +2,13 @@ FROM node:18.10-slim
 
 COPY --from=oven/bun:1.3.13 /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get -y install bash curl git jq \
-  || sleep 60 && apt-get update && apt-get -y install bash curl git jq
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
+# node:18.10-slim is Bullseye
+RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
+  apt-get update && apt-get -y install bash curl git jq
 
 RUN node --version && npm --version && bun --version && curl --version
 


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
Debian 11 LTS ended 2026-08-31. node:18.10-slim (Bullseye) still runs apt-get against live debian-security, so the PARAMETRIC image build 404s (seen on dd-trace-js CI, not a tracer regression).

Same archive-only workaround we used for the AWS SSI / Ruby Bullseye images: point apt at archive.debian.org, drop security repos, and disable Check-Valid-Until.

Other parametric images and e2e weblogs are not on this path (no Bullseye + apt-get).

## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
