### PR TITLE
ci(nodejs): update parametric client runtime

### DIFF
--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:18.10-slim
+FROM node:18.20.8-bookworm-slim
 
 COPY --from=oven/bun:1.3.13 /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get -y install bash curl git jq \
-  || sleep 60 && apt-get update && apt-get -y install bash curl git jq
+RUN apt-get update && apt-get -y install bash curl git jq
 
 RUN node --version && npm --version && bun --version && curl --version
 

--- a/utils/build/docker/nodejs/parametric/Dockerfile
+++ b/utils/build/docker/nodejs/parametric/Dockerfile
@@ -2,7 +2,8 @@ FROM node:18.20.8-bookworm-slim
 
 COPY --from=oven/bun:1.3.13 /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get -y install bash curl git jq
+RUN apt-get update && apt-get -y install bash curl git jq \
+  || sleep 60 && apt-get update && apt-get -y install bash curl git jq
 
 RUN node --version && npm --version && bun --version && curl --version
 


### PR DESCRIPTION
Node parametric builds use Node 18.10, whose Debian Bullseye package revisions are no longer available. The client image fails before pytest, and the retry repeats the permanent 404s.

This moves the client to Node 18.20.8 Bookworm. It preserves Node 18 coverage for the v5 release line while using active package repositories.