### PR TITLE
Fix AWS SSI Ruby multicontainer build after Debian 11 apt 404s

### DIFF
--- a/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-multicontainer/Dockerfile.ruby_2_6
+++ b/utils/build/virtual_machine/weblogs/ruby/test-app-ruby-multicontainer/Dockerfile.ruby_2_6
@@ -3,7 +3,12 @@ FROM public.ecr.aws/docker/library/ruby:2.6
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
+# Debian 11 LTS ended 2026-08-31; live security repos 404 — use archive only
+# ruby:2.6 pulls Bullseye and hits debian-security 404s during apt-get
 RUN set -ex && \
+  sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+  sed -i -E '/security\.debian\.org|debian-security|bullseye-security/d' /etc/apt/sources.list && \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
   echo "===> Installing dependencies" && \
   apt-get -y update && \
   apt-get install -y --force-yes --no-install-recommends \


### PR DESCRIPTION
## Motivation

<!-- What inspired you to submit this pull request? -->
test-app-ruby-multicontainer builds ruby:2.6 on the VM. That image is Bullseye and still runs apt-get against live debian-security. After Debian 11 LTS ended (2026-08-31) the pool 404s, so create_and_run_app_multicontainer.sh fails (seen on Ubuntu 24 — the host is fine; the container build is not).

Same archive-only workaround as the other Bullseye Ruby images: point apt at archive.debian.org, drop security repos, disable Check-Valid-Until.

Dockerfile.ruby_3_4 is Trixie and does not need this. The alpine 2.6 variant does not use apt.
## Changes

<!-- A brief description of the change being made with this pull request. -->

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
