### PR TITLE
test(otel): cover OTEL_SERVICE_NAME parametrically

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -58,6 +58,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: ">1.0.0"
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -867,6 +867,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v3.37.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: missing_feature (false is ignored)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v3.37.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -868,6 +868,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: missing_feature (false is ignored)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v3.37.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1562,6 +1562,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1563,6 +1563,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.6.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3816,6 +3816,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: 'missing_feature (Currently DD_TRACE_OTEL_ENABLED=true is required for OTEL_SDK_DISABLED to be parsed. Revisit when the OpenTelemetry integration is enabled by default.)'
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.54.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_matches_specification: v1.57.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2412)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: v1.57.0

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3815,6 +3815,10 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v1.54.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: 'missing_feature (Currently DD_TRACE_OTEL_ENABLED=true is required for OTEL_SDK_DISABLED to be parsed. Revisit when the OpenTelemetry integration is enabled by default.)'
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.54.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_matches_specification: v1.57.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2412)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: v1.57.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.12.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 1.24.0)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2254,6 +2254,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v5.83.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_datadog_configuration_takes_precedence: incomplete_test_app (config is not exposed)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to true)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v5.88.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2255,6 +2255,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_datadog_configuration_takes_precedence: incomplete_test_app (config is not exposed)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to true)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v5.88.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1380,6 +1380,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1381,6 +1381,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.17.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2437)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1381,6 +1381,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.17.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2437)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1908,6 +1908,8 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v4.11.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v4.11.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2414)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1909,6 +1909,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v4.11.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v4.11.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2414)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2274,6 +2274,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.22.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2413)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2273,6 +2273,8 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.22.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2413)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -70,6 +70,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v0.5.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -69,6 +69,10 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v0.5.0
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_matches_specification: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
+  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -70,9 +70,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v0.5.0
-  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_matches_specification: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
-  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
-  tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: incomplete_test_app (OTEL_RESOURCE_ATTRIBUTES does not surface in /trace/config)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/tests/parametric/otel_env_vars/test_otel_service_name.py
+++ b/tests/parametric/otel_env_vars/test_otel_service_name.py
@@ -1,0 +1,132 @@
+import pytest
+
+from tests.parametric.conftest import APMLibrary, nodejs_telemetry_value
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+
+
+def _service_name(test_agent: TestAgentAPI, library: APMLibrary) -> str:
+    if library.lang == "nodejs":
+        value = nodejs_telemetry_value(test_agent, "dd_service")
+    else:
+        value = library.config()["dd_service"]
+
+    assert isinstance(value, str)
+    return value
+
+
+SERVICE_NAMES = [
+    pytest.param(
+        {
+            "DD_SERVICE": None,
+            "OTEL_RESOURCE_ATTRIBUTES": None,
+            "OTEL_SERVICE_NAME": "checkout-service",
+        },
+        "checkout-service",
+        id="checkout-service",
+    ),
+    pytest.param(
+        {
+            "DD_SERVICE": None,
+            "OTEL_RESOURCE_ATTRIBUTES": None,
+            "OTEL_SERVICE_NAME": "checkout.worker/v2",
+        },
+        "checkout.worker/v2",
+        id="punctuation",
+    ),
+]
+
+UNSET_VALUE = [
+    pytest.param(
+        {
+            "DD_SERVICE": None,
+            "OTEL_RESOURCE_ATTRIBUTES": "service.name=resource-service",
+        },
+        id="unset",
+    )
+]
+
+EMPTY_VALUE = [
+    pytest.param(
+        {
+            "DD_SERVICE": None,
+            "OTEL_RESOURCE_ATTRIBUTES": "service.name=resource-service",
+            "OTEL_SERVICE_NAME": "",
+        },
+        id="empty",
+    ),
+]
+
+
+@scenarios.parametric
+@features.otel_service_name
+class Test_OTEL_SERVICE_NAME:
+    @pytest.mark.parametrize(("library_env", "expected"), SERVICE_NAMES)
+    def test_stable_values(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+        *,
+        expected: str,
+    ) -> None:
+        with test_library as library:
+            assert _service_name(test_agent, library) == expected
+
+    @pytest.mark.parametrize("library_env", UNSET_VALUE)
+    def test_default_matches_specification(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _service_name(test_agent, library) == "resource-service"
+
+    @pytest.mark.parametrize("library_env", EMPTY_VALUE)
+    def test_empty_is_treated_as_unset(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _service_name(test_agent, library) == "resource-service"
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    "DD_SERVICE": None,
+                    "OTEL_RESOURCE_ATTRIBUTES": "service.name=resource-service",
+                    "OTEL_SERVICE_NAME": "otel-service",
+                },
+                id="otel-over-resource",
+            )
+        ],
+    )
+    def test_otel_service_name_takes_precedence(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _service_name(test_agent, library) == "otel-service"
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    "DD_SERVICE": "datadog-service",
+                    "OTEL_SERVICE_NAME": "otel-service",
+                },
+                id="datadog-over-otel",
+            )
+        ],
+    )
+    def test_datadog_configuration_takes_precedence(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _service_name(test_agent, library) == "datadog-service"

--- a/tests/parametric/otel_env_vars/test_otel_service_name.py
+++ b/tests/parametric/otel_env_vars/test_otel_service_name.py
@@ -1,16 +1,18 @@
 import pytest
 
-from tests.parametric.conftest import APMLibrary, nodejs_telemetry_value
+from tests.parametric.conftest import APMLibrary
 from utils import features, scenarios
 from utils.docker_fixtures import TestAgentAPI
+from utils.docker_fixtures.spec.trace import find_span_in_traces
 
 
-def _service_name(test_agent: TestAgentAPI, library: APMLibrary) -> str:
-    if library.lang == "nodejs":
-        value = nodejs_telemetry_value(test_agent, "dd_service")
-    else:
-        value = library.config()["dd_service"]
+def _service_name(test_agent: TestAgentAPI, test_library: APMLibrary) -> str:
+    with test_library, test_library.dd_start_span("operation") as root:
+        pass
 
+    traces = test_agent.wait_for_num_traces(1, sort_by_start=False)
+    span = find_span_in_traces(traces, root.trace_id, root.span_id)
+    value = span["service"]
     assert isinstance(value, str)
     return value
 
@@ -69,8 +71,7 @@ class Test_OTEL_SERVICE_NAME:
         *,
         expected: str,
     ) -> None:
-        with test_library as library:
-            assert _service_name(test_agent, library) == expected
+        assert _service_name(test_agent, test_library) == expected
 
     @pytest.mark.parametrize("library_env", UNSET_VALUE)
     def test_default_matches_specification(
@@ -78,8 +79,7 @@ class Test_OTEL_SERVICE_NAME:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ) -> None:
-        with test_library as library:
-            assert _service_name(test_agent, library) == "resource-service"
+        assert _service_name(test_agent, test_library) == "resource-service"
 
     @pytest.mark.parametrize("library_env", EMPTY_VALUE)
     def test_empty_is_treated_as_unset(
@@ -87,8 +87,7 @@ class Test_OTEL_SERVICE_NAME:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ) -> None:
-        with test_library as library:
-            assert _service_name(test_agent, library) == "resource-service"
+        assert _service_name(test_agent, test_library) == "resource-service"
 
     @pytest.mark.parametrize(
         "library_env",
@@ -108,8 +107,7 @@ class Test_OTEL_SERVICE_NAME:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ) -> None:
-        with test_library as library:
-            assert _service_name(test_agent, library) == "otel-service"
+        assert _service_name(test_agent, test_library) == "otel-service"
 
     @pytest.mark.parametrize(
         "library_env",
@@ -128,5 +126,4 @@ class Test_OTEL_SERVICE_NAME:
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
     ) -> None:
-        with test_library as library:
-            assert _service_name(test_agent, library) == "datadog-service"
+        assert _service_name(test_agent, test_library) == "datadog-service"

--- a/tests/parametric/otel_env_vars/test_otel_service_name.py
+++ b/tests/parametric/otel_env_vars/test_otel_service_name.py
@@ -43,6 +43,7 @@ UNSET_VALUE = [
         {
             "DD_SERVICE": None,
             "OTEL_RESOURCE_ATTRIBUTES": "service.name=resource-service",
+            "OTEL_SERVICE_NAME": None,
         },
         id="unset",
     )
@@ -56,6 +57,17 @@ EMPTY_VALUE = [
             "OTEL_SERVICE_NAME": "",
         },
         id="empty",
+    ),
+]
+
+DEFAULT_VALUE = [
+    pytest.param(
+        {
+            "DD_SERVICE": None,
+            "OTEL_RESOURCE_ATTRIBUTES": None,
+            "OTEL_SERVICE_NAME": None,
+        },
+        id="default",
     ),
 ]
 
@@ -88,6 +100,14 @@ class Test_OTEL_SERVICE_NAME:
         test_library: APMLibrary,
     ) -> None:
         assert _service_name(test_agent, test_library) == "resource-service"
+
+    @pytest.mark.parametrize("library_env", DEFAULT_VALUE)
+    def test_default_follows_otel_spec(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        assert _service_name(test_agent, test_library).startswith("unknown_service")
 
     @pytest.mark.parametrize(
         "library_env",


### PR DESCRIPTION
## Motivation

Add specification-based parametric coverage for `OTEL_SERVICE_NAME`.

Tracks [APMAPI-2401].

## Changes

* Test representative service names, unset and empty values, and configuration
  precedence.
* Declare support in every tracer manifest from the configuration registry.
* Track Java, Python, and Ruby empty-value gaps in [APMAPI-2412],
  [APMAPI-2414], and [APMAPI-2413].
* Mark Rust resource-attribute checks as `incomplete_test_app` because
  `/trace/config` does not expose that configuration source.

## Validation

* Node.js 6.13.0 and Go 2.9.2: 6 passed.
* Java 1.66.0-SNAPSHOT and Ruby 2.36.0-dev: 5 passed and 1 expected failure.
* Rust 0.5.1-dev: 3 passed, 2 expected failures, and 1 expected-pass
  declaration.
* Python dev 4.15.0-rc2: 5 passed and the empty-value gap is tracked by
  [APMAPI-2414].
* Focused collection found the expected 6 cases; `git diff --check` passed.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from
      [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛏 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛏

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified? I have the approval
  from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] The relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from
      [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

[APMAPI-2401]: https://datadoghq.atlassian.net/browse/APMAPI-2401
[APMAPI-2412]: https://datadoghq.atlassian.net/browse/APMAPI-2412
[APMAPI-2413]: https://datadoghq.atlassian.net/browse/APMAPI-2413
[APMAPI-2414]: https://datadoghq.atlassian.net/browse/APMAPI-2414
