### PR TITLE
chore(dotnet): temporarily skip capability completeness during FFE rollout

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -889,6 +889,7 @@ manifest:
     - declaration: bug (APMRP-360)
       component_version: <=2.53.2
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled: v2.49.0
+  tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_default_capability_completeness: missing_feature (FFL-2703 declares FFE_FLAG_CONFIGURATION_RULES for dotnet from 3.54.0)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigTracingEnabled::test_tracing_client_tracing_disable_one_way: irrelevant (dotnet tracer supports re-enabling over RC)
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1: v2.33.0
   tests/parametric/test_dynamic_configuration.py::TestDynamicConfigV1::test_trace_sampling_rate_override_default:


### PR DESCRIPTION
## Motivation

`dd-trace-dotnet` starts advertising `FFE_FLAG_CONFIGURATION_RULES` (capability 46) in 3.54.0, from [DataDog/dd-trace-dotnet#9044](https://github.com/DataDog/dd-trace-dotnet/pull/9044).

`test_default_capability_completeness` enforces strict equality for non-prerelease versions, and dotnet snapshot builds report a clean version, so:

- the tracer PR fails with `seen_but_not_expected_capabilities={<Capabilities.FFE_FLAG_CONFIGURATION_RULES: 46>}`;
- adding the registry entry first is not an option either, because it then fails with `expected_but_not_seen_capabilities` until the tracer ships.

## Changes

Declares `test_default_capability_completeness` as `missing_feature` for dotnet, so the tracer PR can merge with a green `system_tests` check. [#7612](https://github.com/DataDog/system-tests/pull/7612) removes this declaration in the same PR that declares the capability at `>=3.54.0`, restoring strict checking.

Merge order:

1. this PR;
2. [DataDog/dd-trace-dotnet#9044](https://github.com/DataDog/dd-trace-dotnet/pull/9044);
3. [#7612](https://github.com/DataDog/system-tests/pull/7612) — declares `>=3.54.0` and removes the declaration added here.

## Decisions

Skipping one test for one language is preferred to merging the tracer PR with a red `system_tests` check.

The pair is already verified: with `[dotnet@pavlo.khrebto/EX-2703/ffe-module-wiring]` in the title, `System Tests (dotnet, dev) / parametric` passed on run [34122374529](https://github.com/DataDog/system-tests/actions/runs/34122374529), which ran the suite against a branch image of the tracer PR.

## Verification

- `./format.sh` — no changes
- `./run.sh TEST_THE_TEST tests/test_the_test/test_capabilities.py` — passed

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
