### PR TITLE
test(otel): better OTEL_SDK_DISABLED manifest entries

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -865,8 +865,8 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v3.37.0
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: missing_feature (false is ignored)
+  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: bug (APMAPI-2417)
+  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_false: bug (APMAPI-2417)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3813,8 +3813,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v1.54.0
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: 'missing_feature (Currently DD_TRACE_OTEL_ENABLED=true is required for OTEL_SDK_DISABLED to be parsed. Revisit when the OpenTelemetry integration is enabled by default.)'
+  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_true: bug (APMAPI-2419)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.12.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 1.24.0)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2253,7 +2253,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v5.83.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_datadog_configuration_takes_precedence: incomplete_test_app (config is not exposed)
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to true)
+  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: bug (APMAPI-2418)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1904,7 +1904,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v4.11.0
-  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
+  tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: bug (APMAPI-2416)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/tests/parametric/otel_env_vars/test_otel_sdk_disabled.py
+++ b/tests/parametric/otel_env_vars/test_otel_sdk_disabled.py
@@ -17,25 +17,6 @@ def _otel_sdk_disabled(test_agent: TestAgentAPI, library: APMLibrary) -> bool:
     return otel_enabled == "false"
 
 
-STABLE_VALUES = [
-    pytest.param(
-        {
-            "OTEL_SDK_DISABLED": "true",
-            "DD_TRACE_OTEL_ENABLED": None,
-        },
-        True,
-        id="true",
-    ),
-    pytest.param(
-        {
-            "OTEL_SDK_DISABLED": "false",
-            "DD_TRACE_OTEL_ENABLED": None,
-        },
-        False,
-        id="false",
-    ),
-]
-
 UNSET_AND_EMPTY_VALUES = [
     pytest.param(
         {
@@ -56,16 +37,39 @@ UNSET_AND_EMPTY_VALUES = [
 @scenarios.parametric
 @features.otel_sdk_disabled
 class Test_OTEL_SDK_DISABLED:
-    @pytest.mark.parametrize(("library_env", "expected"), STABLE_VALUES)
-    def test_stable_values(
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                "OTEL_SDK_DISABLED": "true",
+                "DD_TRACE_OTEL_ENABLED": None,
+            }
+        ],
+    )
+    def test_stable_true(
         self,
         test_agent: TestAgentAPI,
         test_library: APMLibrary,
-        *,
-        expected: bool,
     ):
         with test_library as library:
-            assert _otel_sdk_disabled(test_agent, library) is expected
+            assert _otel_sdk_disabled(test_agent, library) is True
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            {
+                "OTEL_SDK_DISABLED": "false",
+                "DD_TRACE_OTEL_ENABLED": None,
+            }
+        ],
+    )
+    def test_stable_false(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ):
+        with test_library as library:
+            assert _otel_sdk_disabled(test_agent, library) is False
 
     @pytest.mark.parametrize("library_env", UNSET_AND_EMPTY_VALUES)
     def test_default_matches_specification(self, test_agent: TestAgentAPI, test_library: APMLibrary):


### PR DESCRIPTION
## Summary

- split the stable true and false cases so manifests can classify them independently
- enable the four validated Feature Health easy wins for .NET and Java
- classify the remaining .NET, Java, Node.js, and Python compliance failures with APMAPI-2416 through APMAPI-2419

## Feature Health easy wins

- .NET: stable true
- Java: stable false, unset, and empty

## Jira

- https://datadoghq.atlassian.net/browse/APMAPI-2415
- https://datadoghq.atlassian.net/browse/APMAPI-2416
- https://datadoghq.atlassian.net/browse/APMAPI-2417
- https://datadoghq.atlassian.net/browse/APMAPI-2418
- https://datadoghq.atlassian.net/browse/APMAPI-2419

## Testing

- manifest parser validation
- TEST_LIBRARY=java ./run.sh PARAMETRIC --skip-parametric-build tests/parametric/otel_env_vars/test_otel_sdk_disabled.py
  - 4 passed, 1 xfailed
- git diff --check origin/main...HEAD