### PR TITLE
test(otel): cover OTEL_RESOURCE_ATTRIBUTES parametrically

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -57,6 +57,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: missing_feature
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: ">1.0.0"
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: missing_feature (propagation style not supported)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -864,6 +864,8 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v3.37.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2424)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v3.37.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: missing_feature (false is ignored)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1561,6 +1561,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v2.3.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2432)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2425)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3812,6 +3812,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v1.57.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2433)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2426)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v1.54.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_values: 'missing_feature (Currently DD_TRACE_OTEL_ENABLED=true is required for OTEL_SDK_DISABLED to be parsed. Revisit when the OpenTelemetry integration is enabled by default.)'

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2251,6 +2251,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v5.83.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2434)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2427)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v5.83.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_datadog_configuration_takes_precedence: incomplete_test_app (config is not exposed)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to true)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1375,6 +1375,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v1.17.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2423)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2428)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1903,6 +1903,8 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v4.11.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2429)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: v4.11.0
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: missing_feature (defaults to disabled)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2272,6 +2272,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v2.22.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2435)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2430)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -68,6 +68,9 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelLogE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES: v0.3.0
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_invalid_value_is_discarded: bug (APMAPI-2436)
+  tests/parametric/otel_env_vars/test_otel_resource_attributes.py::Test_OTEL_RESOURCE_ATTRIBUTES::test_percent_encoded_separators: bug (APMAPI-2431)
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
@@ -231,7 +234,6 @@ manifest:
     - declaration: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
     - declaration: incomplete_test_app
     - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_attribute_mapping: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_env_vars_set: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_off: incomplete_test_app (/trace/config endpoint is not implemented)

--- a/tests/parametric/otel_env_vars/test_otel_resource_attributes.py
+++ b/tests/parametric/otel_env_vars/test_otel_resource_attributes.py
@@ -1,0 +1,212 @@
+import pytest
+
+from ddapm_test_agent.trace import Span
+from tests.parametric.conftest import APMLibrary, assert_nodejs_telemetry_config
+from utils import features, scenario_crash, scenarios
+from utils.docker_fixtures import TestAgentAPI
+from utils.docker_fixtures.spec.trace import find_only_span
+
+
+type ResourceAttributes = str | list[str] | dict[str, str]
+
+
+def _finished_span(test_agent: TestAgentAPI, library: APMLibrary) -> Span:
+    with library.dd_start_span(name="otel_resource_attributes"):
+        pass
+    return find_only_span(test_agent.wait_for_num_traces(1))
+
+
+def _resource_attributes(test_agent: TestAgentAPI, library: APMLibrary) -> ResourceAttributes:
+    if library.lang in ("nodejs", "rust"):
+        span = _finished_span(test_agent, library)
+        attributes = span["meta"]
+        assert isinstance(attributes, dict)
+        return attributes
+
+    attributes = library.config()["dd_tags"]
+    assert isinstance(attributes, (str, list))
+    return attributes
+
+
+def _assert_resource_attributes(attributes: ResourceAttributes, expected: dict[str, str]) -> None:
+    for key, value in expected.items():
+        if isinstance(attributes, dict):
+            assert attributes.get(key) == value
+        else:
+            assert f"{key}:{value}" in attributes
+
+
+def _assert_resource_attribute_absent(attributes: ResourceAttributes, key: str) -> None:
+    if isinstance(attributes, dict):
+        assert key not in attributes
+    else:
+        assert f"{key}:" not in attributes
+
+
+STABLE_VALUES = [
+    pytest.param(
+        {
+            "DD_TAGS": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_RESOURCE_ATTRIBUTES": "resource.test=single",
+        },
+        {"resource.test": "single"},
+        id="single-pair",
+    ),
+    pytest.param(
+        {
+            "DD_TAGS": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_RESOURCE_ATTRIBUTES": "resource.test=first,resource.extra=second",
+        },
+        {"resource.test": "first", "resource.extra": "second"},
+        id="multiple-pairs",
+    ),
+]
+
+UNSET_AND_EMPTY_VALUES = [
+    pytest.param(
+        {
+            "DD_TAGS": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_RESOURCE_ATTRIBUTES": None,
+        },
+        id="unset",
+    ),
+    pytest.param(
+        {
+            "DD_TAGS": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_RESOURCE_ATTRIBUTES": "",
+        },
+        id="empty",
+    ),
+]
+
+
+@scenarios.parametric
+@features.otel_resource_attributes
+class Test_OTEL_RESOURCE_ATTRIBUTES:
+    @pytest.mark.parametrize(("library_env", "expected"), STABLE_VALUES)
+    def test_stable_values(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+        *,
+        expected: dict[str, str],
+    ) -> None:
+        with test_library as library:
+            attributes = _resource_attributes(test_agent, library)
+
+        _assert_resource_attributes(attributes, expected)
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    "DD_TAGS": None,
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                    "OTEL_RESOURCE_ATTRIBUTES": "resource.test=comma%2Cequals%3Dvalue",
+                },
+                id="percent-encoded-separators",
+            )
+        ],
+    )
+    def test_percent_encoded_separators(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            attributes = _resource_attributes(test_agent, library)
+
+        _assert_resource_attributes(
+            attributes,
+            {"resource.test": "comma,equals=value"},
+        )
+
+    @pytest.mark.parametrize("library_env", UNSET_AND_EMPTY_VALUES)
+    def test_default_matches_specification(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            attributes = _resource_attributes(test_agent, library)
+
+        _assert_resource_attribute_absent(attributes, "resource.test")
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    "DD_TAGS": None,
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                    "OTEL_RESOURCE_ATTRIBUTES": "resource.test=discarded,invalid",
+                },
+                id="malformed-pair",
+            )
+        ],
+    )
+    @scenario_crash
+    def test_invalid_value_is_discarded(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            attributes = _resource_attributes(test_agent, library)
+
+        _assert_resource_attribute_absent(attributes, "resource.test")
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    "DD_ENV": None,
+                    "DD_SERVICE": None,
+                    "DD_TAGS": None,
+                    "DD_TRACE_OTEL_ENABLED": "true",
+                    "DD_VERSION": None,
+                    "OTEL_RESOURCE_ATTRIBUTES": (
+                        "deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1"
+                    ),
+                    "OTEL_SERVICE_NAME": None,
+                },
+                id="reserved-attributes",
+            )
+        ],
+    )
+    def test_reserved_attributes_are_mapped(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            if library.lang in ("nodejs", "rust"):
+                if library.lang == "nodejs":
+                    assert_nodejs_telemetry_config(
+                        test_agent,
+                        {"dd_service": "test2", "dd_env": "test1", "dd_version": "5"},
+                    )
+                span = _finished_span(test_agent, library)
+                assert span["service"] == "test2"
+                assert span["meta"]["env"] == "test1"
+                assert span["meta"]["version"] == "5"
+                _assert_resource_attributes(
+                    span["meta"],
+                    {"foo": "bar1", "baz": "qux1"},
+                )
+                return
+
+            config = library.config()
+
+        assert config["dd_service"] == "test2"
+        assert config["dd_env"] == "test1"
+        assert config["dd_version"] == "5"
+        tags = config["dd_tags"]
+        assert isinstance(tags, (str, list))
+        _assert_resource_attributes(tags, {"foo": "bar1", "baz": "qux1"})

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -144,38 +144,6 @@ class Test_Otel_Env_Vars:
 
         assert resp["dd_log_level"] == "error"
 
-    @pytest.mark.parametrize(
-        "library_env",
-        [
-            {
-                "OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=test1,service.name=test2,service.version=5,foo=bar1,baz=qux1",
-                "DD_TRACE_OTEL_ENABLED": "true",
-            }
-        ],
-    )
-    def test_otel_attribute_mapping(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert_nodejs_telemetry_config(
-                    test_agent, {"dd_service": "test2", "dd_env": "test1", "dd_version": "5"}
-                )
-                # OTEL_RESOURCE_ATTRIBUTES tags surface on spans, not in the DD_TAGS telemetry value
-                with t.dd_start_span(name="otel_attrs"):
-                    pass
-                span = find_only_span(test_agent.wait_for_num_traces(1))
-                assert span["meta"]["foo"] == "bar1"
-                assert span["meta"]["baz"] == "qux1"
-                return
-            resp = t.config()
-
-        assert resp["dd_service"] == "test2"
-        assert resp["dd_env"] == "test1"
-        assert resp["dd_version"] == "5"
-        tags = resp["dd_tags"]
-        assert isinstance(tags, (str, list))
-        assert "foo:bar1" in tags
-        assert "baz:qux1" in tags
-
     @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on", "DD_TRACE_OTEL_ENABLED": "true"}])
     def test_otel_traces_always_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):
         with test_library as t:


### PR DESCRIPTION
## Summary

- add dedicated parametric coverage for `OTEL_RESOURCE_ATTRIBUTES`
- cover stable values, unset and empty values, malformed input, percent-encoded
  separators, and reserved attribute mappings
- activate supported tracers from registry version boundaries and track known
  parser gaps with language-specific Jira tickets

## Tracking

- implementation: APMAPI-2399
- percent-decoding gaps: APMAPI-2421
- malformed-list gaps: APMAPI-2422
- PHP malformed-input crash: APMAPI-2423

## Validation

- `./format.sh`
- focused parametric matrix on .NET, Go, Java, Node.js, PHP, Python, Ruby,
  and Rust
