### PR TITLE
test(ffe/ruby): enable agentless configuration-source coverage [ruby@pavlo.khrebto/FFLSDK-10/provider-initialization]

### DIFF
--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2026,7 +2026,7 @@ manifest:
     - declaration: missing_feature (Not implemented)
       component_version: <2.7.0
   tests/docker_ssi/test_docker_ssi_servicenaming.py::TestDockerServiceNaming::test_service_name: missing_feature (No implemented)
-  tests/ffe/test_agentless_configuration.py: missing_feature (FFL-2701 tracks Ruby agentless configuration-source implementation; FFL-2731 tracks the system-tests contract)
+  tests/ffe/test_agentless_configuration.py: v2.43.0-dev
   tests/ffe/test_dynamic_evaluation.py:
     - weblog_declaration:
         "*": irrelevant
@@ -2351,7 +2351,7 @@ manifest:
       component_version: <2.40.0
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart: incomplete_test_app (The parametric test app does not emit restart span links or preserve baggage)
   tests/parametric/test_extract_behavior.py::Test_ExtractBehavior_Restart_With_Extract_First: incomplete_test_app (The parametric test app does not emit restart span links or preserve baggage)
-  tests/parametric/test_ffe/test_configuration_sources.py: missing_feature (FFL-2701 tracks Ruby agentless configuration-source implementation; FFL-2731 tracks system-tests configuration-source contract)
+  tests/parametric/test_ffe/test_configuration_sources.py: v2.43.0-dev
   tests/parametric/test_ffe/test_dynamic_evaluation.py::Test_Feature_Flag_Dynamic_Evaluation: v2.23.0
   tests/parametric/test_ffe/test_span_enrichment.py: missing_feature
   tests/parametric/test_headers_b3.py::Test_Headers_B3::test_headers_b3_extract_invalid:  # Easy win for all weblogs and version 2.27.0

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -45,14 +45,8 @@ Datadog.configure do |c|
   c.logger.instance = Logger.new(STDOUT) # Make sure logs are available for inspection from outside the container.
 end
 
-if Datadog::Core::Remote.active_remote
-  # TODO: Remove this whole `if` condition if remote configuration is started by default.
-  if Datadog::Core::Remote.active_remote.started?
-    raise 'Remote Configuration worker already started! Remove this check and `Datadog::Core::Remote.active_remote.start` below.'
-  end
-
-  Datadog::Core::Remote.active_remote.start
-end
+remote = Datadog::Core::Remote.active_remote
+remote&.start unless remote&.started?
 
 def otel_tracer
   OpenTelemetry.tracer_provider.tracer('otel-tracer')
@@ -842,22 +836,12 @@ def extract_http_headers(headers)
   end
 end
 
-def handle_ffe_start(req, res)
-  OpenFeature::SDK.set_provider(Datadog::OpenFeature::Provider.new)
-
-  # NOTE: There is no set_provider_and_wait in Ruby OpenFeature::SDK, but this is
-  #       a subject to change.
-  #
-  #       Remote Configuration will be received at this point because of the short
-  #       polling delay.
-  10.times do
-    evaluator = Datadog::OpenFeature.engine.instance_variable_get(:@evaluator)
-    break unless evaluator.instance_variable_get(:@configuration).nil?
-
-    sleep 0.5
-  end
-
+def handle_ffe_start(_req, res)
+  OpenFeature::SDK.set_provider_and_wait(Datadog::OpenFeature::Provider.new)
   res.write({}.to_json)
+rescue => e
+  res.status = 500
+  res.write({error: e.message}.to_json)
 end
 
 def handle_ffe_evaluation(req, res)

--- a/utils/build/docker/ruby/parametric/server.rb
+++ b/utils/build/docker/ruby/parametric/server.rb
@@ -837,7 +837,22 @@ def extract_http_headers(headers)
 end
 
 def handle_ffe_start(_req, res)
-  OpenFeature::SDK.set_provider_and_wait(Datadog::OpenFeature::Provider.new)
+  provider = Datadog::OpenFeature::Provider.new
+  feature_flagging_configured = %w[
+    DD_FEATURE_FLAGS_ENABLED
+    DD_FEATURE_FLAGS_CONFIGURATION_SOURCE
+    DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_BASE_URL
+    DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_POLL_INTERVAL_SECONDS
+    DD_FEATURE_FLAGS_CONFIGURATION_SOURCE_AGENTLESS_REQUEST_TIMEOUT_SECONDS
+    DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED
+    DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS
+  ].any? { |name| ENV.key?(name) }
+
+  if feature_flagging_configured
+    OpenFeature::SDK.set_provider_and_wait(provider)
+  else
+    OpenFeature::SDK.set_provider(provider)
+  end
   res.write({}.to_json)
 rescue => e
   res.status = 500

--- a/utils/build/docker/ruby/rails72/app/controllers/open_feature_controller.rb
+++ b/utils/build/docker/ruby/rails72/app/controllers/open_feature_controller.rb
@@ -4,15 +4,10 @@ class OpenFeatureController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def start
-    OpenFeature::SDK.set_provider(Datadog::OpenFeature::Provider.new)
-
-    # NOTE: There is no set_provider_and_wait in OpenFeature::SDK
-    loop do
-      break unless Datadog::OpenFeature.evaluator.ufc_json.nil?
-      sleep 0.1
-    end
-
+    OpenFeature::SDK.set_provider_and_wait(Datadog::OpenFeature::Provider.new)
     render json: {}
+  rescue => e
+    render json: {error: e.message}, status: :internal_server_error
   end
 
   def evaluate


### PR DESCRIPTION
## Motivation

The Ruby tracer stack adds agentless Feature Flagging configuration delivery while preserving the existing Remote Configuration path. This PR aligns the Ruby test applications with the resulting provider initialization lifecycle and enables the shared configuration-source contracts for Ruby 2.43.0-dev.

> [!WARNING]
> This PR must not merge until the complete dd-trace-rb stack is merged: [#6295](https://github.com/DataDog/dd-trace-rb/pull/6295) into [#6294](https://github.com/DataDog/dd-trace-rb/pull/6294), #6294 into [#6292](https://github.com/DataDog/dd-trace-rb/pull/6292), #6292 into [#6291](https://github.com/DataDog/dd-trace-rb/pull/6291), and finally #6291 into master.

## Changes

* Replace Ruby test-app polling of private provider state with `OpenFeature::SDK.set_provider_and_wait`, returning HTTP 500 when initialization fails.
* Start the parametric app's generic Remote Configuration worker only when the tracer has not already started it for the selected FFE source.
* Enable the parametric configuration-source suite and Rails agentless end-to-end suite at `v2.43.0-dev`.

Validated locally with all 29 parametric configuration-source cases and the Rails agentless scenario passing.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
