### PR TITLE
feat(llmobs): test prompt config version bundles

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3970,6 +3970,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_updates_existing_prompt: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts::test_prompt_annotation_with_string_template: missing_feature (prompt annotation not supported in Java LLMObs SDK)
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: incomplete_test_app (Java parametric app does not implement /llm_observability/dataset endpoints)
+  tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Prompt_Config: incomplete_test_app (Java parametric app does not implement /llm_observability/prompt endpoints)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.35.2
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2396,6 +2396,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: *ref_5_66_0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: *ref_5_83_0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: missing_feature
+  tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Prompt_Config: missing_feature
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2058,6 +2058,7 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Enablement: v3.14.0
   tests/parametric/test_llm_observability/test_llm_observability.py::Test_Prompts: v3.15.0
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: v4.2.0
+  tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Prompt_Config: v4.15.0
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability: '>=4.3.1'  # Modified by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_in_order: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_concurrent_traces_nested_dd_root: missing_feature  # Created by easy win activation script

--- a/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_post_a390a006.json
+++ b/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_post_a390a006.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datad0g.com/api/unstable/llm-obs/v1/prompts",
+    "headers": {
+      "x-datadog-sdk-language": "python",
+      "Content-Type": "application/json",
+      "datadog-entity-id": "in-2516",
+      "Content-Length": "196"
+    },
+    "body": "{\"prompt_id\": \"system-tests-prompt-config-versioned-bundle\", \"template\": [{\"role\": \"user\", \"content\": \"Hello {name}\"}], \"config\": {\"model\": {\"temperature\": 0.2}, \"unknown\": {\"nested\": [1, true]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "dd-test-drive-name": "prompt-config-achoura-0909",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "411",
+      "date": "Wed, 09 Sep 2026 19:22:18 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"ID\":\"eec1ded6-ae45-5b04-bac7-ecdeaf04b84e\",\"prompt_id\":\"system-tests-prompt-config-versioned-bundle\",\"source\":\"registry\",\"created_at\":\"2026-09-09T19:22:18.347916956Z\",\"last_version_created_at\":\"2026-09-09T19:22:18.347916956Z\",\"num_versions\":1,\"in_registry\":true,\"created_from\":\"sdk-registry\",\"author\":\"c5e19e5a-ad6b-11ed-ab4f-927130d31ef9\",\"config\":{\"model\":{\"temperature\":0.2},\"unknown\":{\"nested\":[1,true]}}}"
+  }
+}

--- a/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_delete_695fa6d4.json
+++ b/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_delete_695fa6d4.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "DELETE",
+    "url": "https://api.datad0g.com/api/unstable/llm-obs/v1/prompts/system-tests-prompt-config-versioned-bundle",
+    "headers": {
+      "x-datadog-sdk-language": "python",
+      "Content-Type": "application/json",
+      "datadog-entity-id": "in-2516"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "dd-test-drive-name": "prompt-config-achoura-0909",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "146",
+      "date": "Wed, 09 Sep 2026 19:22:21 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"ID\":\"eec1ded6-ae45-5b04-bac7-ecdeaf04b84e\",\"prompt_id\":\"system-tests-prompt-config-versioned-bundle\",\"deleted_at\":\"2026-09-09T19:22:21.814637Z\"}"
+  }
+}

--- a/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_1_get_ba6b844e.json
+++ b/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_1_get_ba6b844e.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://api.datad0g.com/api/unstable/llm-obs/v1/prompts/system-tests-prompt-config-versioned-bundle/versions/1",
+    "headers": {
+      "x-datadog-sdk-language": "python",
+      "datadog-entity-id": "in-2516"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "dd-test-drive-name": "prompt-config-achoura-0909",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "433",
+      "date": "Wed, 09 Sep 2026 19:22:19 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"ID\":\"492cb5a5-cc6e-5907-b01f-bf70463c6024\",\"prompt_uuid\":\"eec1ded6-ae45-5b04-bac7-ecdeaf04b84e\",\"prompt_id\":\"system-tests-prompt-config-versioned-bundle\",\"template\":[{\"role\":\"user\",\"content\":\"Hello {name}\"}],\"config\":{\"model\":{\"temperature\":0.2},\"unknown\":{\"nested\":[1,true]}},\"version\":1,\"created_at\":\"2026-09-09T19:22:18.347916Z\",\"version_created_at\":\"2026-09-09T19:22:18.347916Z\",\"author\":\"c5e19e5a-ad6b-11ed-ab4f-927130d31ef9\"}"
+  }
+}

--- a/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_2_get_67e7040f.json
+++ b/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_2_get_67e7040f.json
@@ -1,0 +1,28 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "https://api.datad0g.com/api/unstable/llm-obs/v1/prompts/system-tests-prompt-config-versioned-bundle/versions/2",
+    "headers": {
+      "x-datadog-sdk-language": "python",
+      "datadog-entity-id": "in-2516"
+    },
+    "body": ""
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "dd-test-drive-name": "prompt-config-achoura-0909",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "434",
+      "date": "Wed, 09 Sep 2026 19:22:20 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"ID\":\"a05f9f7b-4338-59f5-8322-639176adc143\",\"prompt_uuid\":\"eec1ded6-ae45-5b04-bac7-ecdeaf04b84e\",\"prompt_id\":\"system-tests-prompt-config-versioned-bundle\",\"template\":[{\"role\":\"user\",\"content\":\"Hello {name}\"}],\"config\":{\"model\":{\"temperature\":0.8},\"unknown\":{\"nested\":[2,false]}},\"version\":2,\"created_at\":\"2026-09-09T19:22:19.733642Z\",\"version_created_at\":\"2026-09-09T19:22:19.733642Z\",\"author\":\"c5e19e5a-ad6b-11ed-ab4f-927130d31ef9\"}"
+  }
+}

--- a/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_post_c9849f95.json
+++ b/tests/integration_frameworks/utils/vcr-cassettes/datadog-staging/test_prompt_config_lifecycle_datadog-staging_api_unstable_llm-obs_v1_prompts_system-tests-prompt-config-versioned-bundle_versions_post_c9849f95.json
@@ -1,0 +1,30 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://api.datad0g.com/api/unstable/llm-obs/v1/prompts/system-tests-prompt-config-versioned-bundle/versions",
+    "headers": {
+      "x-datadog-sdk-language": "python",
+      "Content-Type": "application/json",
+      "datadog-entity-id": "in-2516",
+      "Content-Length": "137"
+    },
+    "body": "{\"template\": [{\"role\": \"user\", \"content\": \"Hello {name}\"}], \"config\": {\"model\": {\"temperature\": 0.8}, \"unknown\": {\"nested\": [2, false]}}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "content-type": "application/json",
+      "dd-test-drive-name": "prompt-config-achoura-0909",
+      "vary": "Accept-Encoding",
+      "x-frame-options": "SAMEORIGIN",
+      "content-length": "440",
+      "date": "Wed, 09 Sep 2026 19:22:19 GMT",
+      "x-content-type-options": "nosniff",
+      "strict-transport-security": "max-age=31536000; includeSubDomains; preload"
+    },
+    "body": "{\"ID\":\"a05f9f7b-4338-59f5-8322-639176adc143\",\"prompt_uuid\":\"eec1ded6-ae45-5b04-bac7-ecdeaf04b84e\",\"prompt_id\":\"system-tests-prompt-config-versioned-bundle\",\"template\":[{\"role\":\"user\",\"content\":\"Hello {name}\"}],\"config\":{\"model\":{\"temperature\":0.8},\"unknown\":{\"nested\":[2,false]}},\"version\":2,\"created_at\":\"2026-09-09T19:22:19.733642999Z\",\"version_created_at\":\"2026-09-09T19:22:19.733642999Z\",\"author\":\"c5e19e5a-ad6b-11ed-ab4f-927130d31ef9\"}"
+  }
+}

--- a/tests/parametric/test_llm_observability/conftest.py
+++ b/tests/parametric/test_llm_observability/conftest.py
@@ -88,6 +88,7 @@ def library_env(
 def agent_env(request: pytest.FixtureRequest) -> dict[str, object]:
     agent_env: dict[str, object] = {
         "VCR_IGNORE_HEADERS": "content-security-policy",
+        "VCR_PROVIDER_MAP": "datadog-staging=https://api.datad0g.com/",
     }
 
     if not request.config.option.generate_cassettes:

--- a/tests/parametric/test_llm_observability/test_llm_observability_dne.py
+++ b/tests/parametric/test_llm_observability/test_llm_observability_dne.py
@@ -8,6 +8,7 @@ from ..conftest import APMLibrary  # noqa: TID252
 
 if TYPE_CHECKING:
     from utils.docker_fixtures.spec.llm_observability import DatasetCreateRequest
+    from utils.docker_fixtures.spec.llm_observability import PromptConfigLifecycleRequest
 
 
 @pytest.fixture
@@ -49,3 +50,29 @@ class Test_Dataset:
 
             result = test_library.llmobs_dataset_delete(dataset_id=dataset["dataset_id"])
             assert result.get("success") is True
+
+
+@features.llm_observability_prompts
+@scenarios.parametric
+class Test_Prompt_Config:
+    @pytest.fixture
+    def llmobs_override_origin(self, test_agent: TestAgentAPI) -> str:
+        return f"http://{test_agent.container_name}:{test_agent.container_port}/vcr/datadog-staging"
+
+    def test_prompt_config_lifecycle(self, test_agent: TestAgentAPI, test_library: APMLibrary):
+        """Test that template and config stay paired across prompt versions."""
+        template = [{"role": "user", "content": "Hello {name}"}]
+        request: PromptConfigLifecycleRequest = {
+            "prompt_id": "system-tests-prompt-config-versioned-bundle",
+            "template": template,
+            "initial_config": {"model": {"temperature": 0.2}, "unknown": {"nested": [1, True]}},
+            "next_config": {"model": {"temperature": 0.8}, "unknown": {"nested": [2, False]}},
+        }
+
+        with test_agent.vcr_context():
+            result = test_library.llmobs_prompt_config_lifecycle(request)
+
+        assert result == {
+            "initial": {"version": "1", "template": template, "config": request["initial_config"]},
+            "next": {"version": "2", "template": template, "config": request["next_config"]},
+        }

--- a/utils/build/docker/python/parametric/apm_test_client/llmobs.py
+++ b/utils/build/docker/python/parametric/apm_test_client/llmobs.py
@@ -199,6 +199,13 @@ class DatasetDeleteRequestModel(BaseModel):
     dataset_id: str
 
 
+class PromptConfigLifecycleRequestModel(BaseModel):
+    prompt_id: str
+    template: list[dict[str, str]]
+    initial_config: dict[str, Any]
+    next_config: dict[str, Any]
+
+
 @router.post("/llm_observability/dataset/create")
 def llmobs_dataset_create(request: DatasetCreateRequestModel):
     records = None
@@ -235,3 +242,18 @@ def llmobs_dataset_create(request: DatasetCreateRequestModel):
 def llmobs_dataset_delete(request: DatasetDeleteRequestModel):
     LLMObs._delete_dataset(dataset_id=request.dataset_id)
     return {"success": True}
+
+
+@router.post("/llm_observability/prompt/config_lifecycle")
+def llmobs_prompt_config_lifecycle(request: PromptConfigLifecycleRequestModel):
+    LLMObs.create_prompt(request.prompt_id, request.template, config=request.initial_config)
+    try:
+        initial = LLMObs.get_prompt(request.prompt_id, version=1)
+        LLMObs.create_prompt_version(request.prompt_id, request.template, config=request.next_config)
+        next_version = LLMObs.get_prompt(request.prompt_id, version=2)
+        return {
+            "initial": {"version": initial.version, "template": initial.template, "config": initial.config},
+            "next": {"version": next_version.version, "template": next_version.template, "config": next_version.config},
+        }
+    finally:
+        LLMObs.delete_prompt(request.prompt_id)

--- a/utils/docker_fixtures/_test_clients/_test_client_parametric.py
+++ b/utils/docker_fixtures/_test_clients/_test_client_parametric.py
@@ -18,6 +18,8 @@ from utils.docker_fixtures.spec.llm_observability import (
     DatasetCreateRequest,
     DatasetResponse,
     LlmObsAnnotationContextRequest,
+    PromptConfigLifecycleRequest,
+    PromptConfigLifecycleResponse,
     SpanRequest,
 )
 from utils.docker_fixtures.spec.otel_trace import OtelSpanContext
@@ -1011,6 +1013,11 @@ class ParametricTestClientApi(TestClientApi):
 
         return resp.json()
 
+    def llmobs_prompt_config_lifecycle(self, request: PromptConfigLifecycleRequest) -> PromptConfigLifecycleResponse:
+        resp = self._session.post(self._url("/llm_observability/prompt/config_lifecycle"), json=request)
+        resp.raise_for_status()
+        return cast("PromptConfigLifecycleResponse", resp.json())
+
 
 class APMLibrary:
     def __init__(self, client: ParametricTestClientApi, lang: str):
@@ -1263,6 +1270,9 @@ class APMLibrary:
 
     def llmobs_dataset_delete(self, dataset_id: str) -> dict | str | None:
         return self._client.llmobs_dataset_delete(dataset_id=dataset_id)
+
+    def llmobs_prompt_config_lifecycle(self, request: PromptConfigLifecycleRequest) -> PromptConfigLifecycleResponse:
+        return self._client.llmobs_prompt_config_lifecycle(request)
 
     @property
     def container(self) -> Container:

--- a/utils/docker_fixtures/spec/llm_observability.py
+++ b/utils/docker_fixtures/spec/llm_observability.py
@@ -79,3 +79,21 @@ class DatasetResponse(TypedDict, total=False):
     version: int
     latest_version: int
     records: list[dict[str, Any]]
+
+
+class PromptConfigLifecycleRequest(TypedDict):
+    prompt_id: str
+    template: list[dict[str, str]]
+    initial_config: dict[str, Any]
+    next_config: dict[str, Any]
+
+
+class PromptBundle(TypedDict):
+    version: str
+    template: list[dict[str, str]]
+    config: dict[str, Any]
+
+
+class PromptConfigLifecycleResponse(TypedDict):
+    initial: PromptBundle
+    next: PromptBundle


### PR DESCRIPTION
> Closed by user direction: cassette replay duplicated backend/SDK coverage and did not exercise live FFE delivery.

## Motivation

This PR explored a parametric regression for versioned prompt configuration; the retained initiative uses the live Test Drive smoke and stress suite instead.

<!-- prompt-config-initiative-context:start -->
## API surface

**No product API endpoint or response shape changes.** The test harness adds one internal, parametric-test-only endpoint:

`POST /llm_observability/prompt/config_lifecycle`

Request:
```json
{"prompt_id":"example","template":[{"role":"user","content":"Hello"}],"initial_config":{"temperature":0.2},"next_config":{}}
```

Response:
```json
{"initial":{"version":"1","template":[{"role":"user","content":"Hello"}],"config":{"temperature":0.2}},"next":{"version":"2","template":[{"role":"user","content":"Hello"}],"config":{}}}
```

This route existed only in the Python parametric test application and replayed recorded backend interactions through the Python SDK.

## Initiative stack

| Stream | Pull request | Scope |
|---|---|---|
| KCFG-S | [pull#4085](https://github.com/ddoghq/k8s-resources/pull/4085) | Staging OrgStore column and object constraint — merged/deployed |
| BCFG | [pull#86374](https://github.com/ddoghq/dd-source/pull/86374) | Backend storage, management responses, SDK retrieval, and opaque FFE delivery |
| MP1-PY | [pull#20210](https://github.com/DataDog/dd-trace-py/pull/20210) | Python SDK retrieval, caches, fallback, and authoring |
| UICFG | [pull#11271](https://github.com/ddoghq/web-ui/pull/11271) | Prompt authoring, detail, and comparison UI |
| **STCFG (this PR)** | **[DataDog/system-tests#7684](https://github.com/DataDog/system-tests/pull/7684)** | Dropped — cassette replay duplicated SDK/backend coverage and did not exercise live FFE |
| KCFG-P | [pull#4124](https://github.com/ddoghq/k8s-resources/pull/4124) | Production OrgStore migration |
| MP1-GO | [pull#5333](https://github.com/DataDog/dd-trace-go/pull/5333) | Go SDK retrieval add-on; stacked on foundation [#5298](https://github.com/DataDog/dd-trace-go/pull/5298) |
| MP1-JS | [pull#10268](https://github.com/DataDog/dd-trace-js/pull/10268) | Node.js SDK retrieval/authoring add-on; stacked on foundation [#10015](https://github.com/DataDog/dd-trace-js/pull/10015) |
| APICFG | [pull#6669](https://github.com/DataDog/datadog-api-spec/pull/6669) | Public OpenAPI request/response contract |
| DOCSCFG | [pull#39823](https://github.com/DataDog/documentation/pull/39823) | Customer documentation |

Go and Node.js are non-blocking add-ons; their foundation merges and later retargeting do not block the core initiative.
<!-- prompt-config-initiative-context:end -->

## Historical changes

- added one Python parametric lifecycle that creates template + nested config, retrieves exact v1 through `LLMObs.get_prompt`, creates a same-template/config-only v2, and retrieves exact v2 without mixing bundle fields
- recorded five sanitized VCR cassettes from Rapid Test Drive `prompt-config-achoura-0909` at dd-source commit `0ac38419499b981d465564d554a6db265f17fcd4`
- activated the test for Python 4.15.0 and records the current Node.js/Java app gaps in their manifests

The harness does not mutate a shared prompt environment. Environment switch and rollback remain covered by the initiative Test Drive verifier, as allowed by the delivery contract.

## Validation

- `./format.sh`
- `TEST_LIBRARY=python ./run.sh PARAMETRIC -F tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Prompt_Config::test_prompt_config_lifecycle tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Prompt_Config::test_prompt_config_lifecycle`

## Reviewer checklist

- [ ] Anything but `tests/` or `manifests/` is modified? I have the approval from R&P team.
- [ ] A Docker base image is modified? If so, the relevant build label is present.
- [ ] A scenario is added, removed, or renamed? If so, get a review from R&P team.

