### PR TITLE
perf(debugger): skip unavailable test setup

### DIFF
--- a/tests/debugger/test_debugger_expression_language.py
+++ b/tests/debugger/test_debugger_expression_language.py
@@ -6,11 +6,12 @@ import re
 import json
 
 import tests.debugger.utils as debugger
-from utils import scenarios, features
+from utils import scenarios, features, slow
 
 
 @features.debugger_expression_language
 @scenarios.debugger_expression_language
+@slow
 class Test_Debugger_Expression_Language(debugger.BaseDebuggerTest):
     message_map: dict = {}
 

--- a/tests/debugger/test_debugger_inproduct_enablement.py
+++ b/tests/debugger/test_debugger_inproduct_enablement.py
@@ -119,6 +119,7 @@ class Test_Debugger_InProduct_Enablement_Exception_Replay(debugger.BaseDebuggerT
             "/exceptionreplay/multiframe", "multiple stack frames exception"
         )
 
+    @slow
     def test_inproduct_enablement_exception_replay(self):
         self.assert_rc_state_not_error()
         self.assert_all_weblog_responses_ok(expected_code=500)


### PR DESCRIPTION
## Motivation

Debugger scenarios execute expensive probe installation, request, diagnostic,
and snapshot setup even when the current library manifest declares the test
missing. The assertion then xfails, but only after the setup has consumed its
full waits.

This is especially costly for `DEBUGGER_EXPRESSION_LANGUAGE`: Go declares the
entire class missing while the repository timing data records roughly 1,035
seconds for the scenario.

## Changes

* Mark the expression-language class as slow, converting only tests with an
  active manifest declaration into early skips.
* Mark the missing exception-replay in-product enablement test as slow. Its
  existing multiconfig sibling already uses the same mechanism.
* Supported libraries and versions continue running the tests normally. Once a
  manifest declaration is removed, the marker becomes a no-op.

## Validation

Node.js Express 4 local comparisons:

* `DEBUGGER_EXPRESSION_LANGUAGE`: 143.66 seconds before; 78.31 seconds after.
  The optimized run had 10 passed and 2 skipped.
* `DEBUGGER_INPRODUCT_ENABLEMENT`: 129.39 seconds before; 80.54 seconds after.
  The optimized run had 1 passed and 4 skipped.
* Mypy: 556 source files passed.
* Ruff formatting and lint: passed.

The Go impact is inferred from its class-level `missing_feature` declaration
and checked-in timing data; a Go weblog was not built locally.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from
      [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified? I have the approval
  from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] The relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

*Generated by Codex.*
