### PR TITLE
Prevent PHP weblog APT source build failures

### DIFF
--- a/utils/build/docker/php/laravel11x.Dockerfile
+++ b/utils/build/docker/php/laravel11x.Dockerfile
@@ -8,11 +8,13 @@ FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 # timestamp instead (deb11u2 was only published there on 2026-08-16, so pick a date after that).
 # Check-Valid-Until is disabled because snapshot Release files carry an already-past Valid-Until.
 RUN set -ex && \
-  sed -i \
-    -e 's|http://deb.debian.org/debian |http://snapshot.debian.org/archive/debian/20260901T000000Z |g' \
-    -e 's|http://security.debian.org/debian-security |http://snapshot.debian.org/archive/debian-security/20260901T000000Z |g' \
-    /etc/apt/sources.list && \
-  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+  if [ -f /etc/apt/sources.list ]; then \
+    sed -i \
+      -e 's|http://deb.debian.org/debian |http://snapshot.debian.org/archive/debian/20260901T000000Z |g' \
+      -e 's|http://security.debian.org/debian-security |http://snapshot.debian.org/archive/debian-security/20260901T000000Z |g' \
+      /etc/apt/sources.list; \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until; \
+  fi
 
 ENV PHP_VERSION=8.2
 ENV DD_TRACE_ENABLED=1

--- a/utils/build/docker/php/symfony7x.Dockerfile
+++ b/utils/build/docker/php/symfony7x.Dockerfile
@@ -8,11 +8,13 @@ FROM datadog/dd-appsec-php-ci:php-$PHP_VERSION-$VARIANT
 # timestamp instead (deb11u2 was only published there on 2026-08-16, so pick a date after that).
 # Check-Valid-Until is disabled because snapshot Release files carry an already-past Valid-Until.
 RUN set -ex && \
-  sed -i \
-    -e 's|http://deb.debian.org/debian |http://snapshot.debian.org/archive/debian/20260901T000000Z |g' \
-    -e 's|http://security.debian.org/debian-security |http://snapshot.debian.org/archive/debian-security/20260901T000000Z |g' \
-    /etc/apt/sources.list && \
-  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+  if [ -f /etc/apt/sources.list ]; then \
+    sed -i \
+      -e 's|http://deb.debian.org/debian |http://snapshot.debian.org/archive/debian/20260901T000000Z |g' \
+      -e 's|http://security.debian.org/debian-security |http://snapshot.debian.org/archive/debian-security/20260901T000000Z |g' \
+      /etc/apt/sources.list; \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until; \
+  fi
 
 ENV PHP_VERSION=8.2
 ENV DD_TRACE_ENABLED=1


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fc817458-a498-42ea-8055-e571851ce70a","source":"chat","resourceId":"584e8daf-b420-404a-95fe-f0e632231ebd","workflowId":"1ce1e45d-af69-483e-abcc-5c6c62e3cfd8","codeChangeId":"1ce1e45d-af69-483e-abcc-5c6c62e3cfd8","sourceType":"assistant"} -->
## Motivation

Nightly and pull request PHP system tests fail while building the Laravel 11 and Symfony 7 weblogs because their base image uses DEB822 APT sources and does not provide `/etc/apt/sources.list`. The Debian 11 EOL workaround currently invokes `sed` on that missing file, stopping both builds before dependencies can be installed.

## Changes

Guard the Debian 11 snapshot rewrite behind an existence check for the legacy APT sources file. Images with DEB822 sources keep their native repository configuration, while legacy Debian 11 images still receive both the snapshot rewrite and the matching `Acquire::Check-Valid-Until` override.

## Testing

- Exercised the Dockerfile shell block in isolated mount namespaces for both layouts: the missing-file path exits successfully without creating the validity override, and the legacy-file path runs `sed` and creates the override.
- Confirmed both Dockerfiles use the same guarded block and `git diff --check` passes.
- `./format.sh` passed mypy, Ruff, and whitespace checks; its unrelated `yamlfmt` bootstrap was blocked by a sandbox proxy HTTP 502. No YAML files changed.
- `./build.sh php -w laravel11x` reached the base-image pull, which the sandbox blocked with an HTTP 502 from Docker Hub; CI will provide the full image build.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/584e8daf-b420-404a-95fe-f0e632231ebd)

Comment @datadog to request changes