### PR TITLE
Delete broken Test_Client_Stats_With_Client_Obfuscation_Disabled

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -378,7 +378,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_ExtractBehavior_Default::test_multiple_tracecontexts: missing_feature (baggage is not implemented, also remove DD_TRACE_PROPAGATION_STYLE_EXTRACT workaround in containers.py)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -130,7 +130,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -390,7 +390,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags: missing_feature  # Created by easy win activation script
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -1235,7 +1235,6 @@ manifest:
     - weblog_declaration:
         uds: '>=3.43.0'
         poc: '>=3.43.0'
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler:
     - weblog_declaration:
         uds: '>=3.43.0'

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1848,7 +1848,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: v2.9.1
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: v2.9.1
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: v2.9.1
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog: incomplete_test_app (/otel_drop_in_baggage_api_datadog endpoint is not implemented)
   tests/test_baggage.py::Test_Baggage_Headers_Api_OTel: incomplete_test_app (/otel_drop_in_baggage_api_otel endpoint is not implemented)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -4265,7 +4265,6 @@ manifest:
         vertx3: '>=1.64.2'
         spring-boot-payara: '>=1.64.2'
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler:
     - weblog_declaration:
         "*": v1.54.0

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -64,7 +64,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2719,14 +2719,6 @@ manifest:
         fastify: missing_feature
         express4-typescript: missing_feature
         nextjs: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled:
-    - weblog_declaration:
-        express4: missing_feature
-        express5: missing_feature
-        uds-express4: missing_feature
-        fastify: missing_feature
-        express4-typescript: missing_feature
-        nextjs: missing_feature
   tests/stats/test_stats.py::Test_Peer_Tags:
     - weblog_declaration:
         express4: missing_feature

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -81,7 +81,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1769,7 +1769,6 @@ manifest:
         '*': missing_feature
         symfony7x: '>=1.23.3'
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature (error traces dropped client-side under sampling; errors counted in stats but traces not sent)
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_baggage.py::Test_Baggage_Headers_Api_Datadog:

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -2314,7 +2314,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: '>=4.11.0'
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: '>=4.11.0'
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: '>=4.11.0'
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: '>=4.11.0'
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats_bucket_alignment:  # Modified by easy win activation script
     - weblog_declaration:

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -326,7 +326,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -73,7 +73,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/test_library_conf.py::Test_HeaderTags_DynamicConfig::test_tracing_client_http_header_tags_apm_multiconfig: missing_feature (APM_TRACING_MULTICONFIG is not supported in any language yet)
   tests/test_library_logs.py::Test_NoExceptions::test_dotnet: irrelevant (only for .NET)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2738,7 +2738,6 @@ manifest:
   tests/stats/test_stats.py::Test_Client_Stats_Missing_Obfuscation_Version: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_Obfuscation_Version_Zero: missing_feature
   tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation: missing_feature
-  tests/stats/test_stats.py::Test_Client_Stats_With_Client_Obfuscation_Disabled: missing_feature
   tests/stats/test_stats.py::Test_Error_Sampler: missing_feature (no client-side stats computed when sampling drops all traces)
   tests/stats/test_stats.py::Test_Stats_Service_Source: irrelevant (Only implemented for Java)
   tests/stats/test_stats.py::Test_Time_Bucketing::test_client_side_stats:  # Created by easy win activation script

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -173,50 +173,6 @@ class Test_Client_Stats_With_Client_Obfuscation:
 
 
 @features.client_side_stats_supported
-@scenarios.trace_stats_computation_obfuscation_disabled
-class Test_Client_Stats_With_Client_Obfuscation_Disabled:
-    """Test that libraries read the agent /info to respect the obfuscation config"""
-
-    TEST_USER_IDS = ["1", "2", "admin", "test"]
-
-    def setup_obfuscation(self):
-        """Setup for obfuscation test - generates SQL spans for obfuscation testing"""
-        for user_id in self.TEST_USER_IDS:
-            weblog.get(f"/rasp/sqli?user_id={user_id}")
-
-    def test_obfuscation(self):
-        """Test that SQL resources are obfuscated before stats aggregation.
-
-        Validates:
-        - Datadog-Obfuscation-Version header is present on stats payloads
-        - SQL resource names are not obfuscated, only normalized
-        """
-        sql_stats = []
-        obfuscation_header_found = False
-
-        for data in interfaces.library.get_data("/v0.6/stats"):
-            headers = {h[0].lower(): h[1] for h in data["request"]["headers"]}
-            if "datadog-obfuscation-version" in headers:
-                obfuscation_header_found = True
-                assert int(headers["datadog-obfuscation-version"]) >= 1, (
-                    f"Expected obfuscation version to be >= 1, got '{headers['datadog-obfuscation-version']}'"
-                )
-
-            payload = data["request"]["content"]
-            for bucket in payload.get("Stats", []):
-                for stat in bucket.get("Stats", []):
-                    if stat.get("Type") == "sql" and stat["Resource"].startswith("SELECT"):
-                        sql_stats.append(stat)
-
-        assert obfuscation_header_found, "Datadog-Obfuscation-Version header not found on any stats payload"
-
-        unique_resources = {stat["Resource"] for stat in sql_stats}
-        assert len(unique_resources) >= 4, (
-            "Expected at least 4 distinct SQL stats entries, because obfuscation was not applied client-side"
-        )
-
-
-@features.client_side_stats_supported
 @scenarios.trace_stats_computation_future_obfuscation_version
 class Test_Client_Stats_Future_Obfuscation_Version:
     """Test that the SDK skips client-side obfuscation when the agent advertises a future/unknown obfuscation version"""


### PR DESCRIPTION
## Motivation
This test was recently broken (by me) and is blocking some [unrelated pipelines in dd-trace-py](https://github.com/DataDog/system-tests/actions/runs/34476227111/job/102869451401?pr=7693).

The test will soon be replaced with some that verify obfuscation configuration is followed by tracers. 

Now, a custom config disables CSS obfuscation altogether since https://github.com/DataDog/datadog-agent/pull/54573


## Changes

Delete 1 test, it is no longer relevant.

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
