### PR TITLE
[nodejs] Add live debugger guardrail fixtures

### DIFF
--- a/docs/understand/weblogs/end-to-end_weblog.md
+++ b/docs/understand/weblogs/end-to-end_weblog.md
@@ -967,6 +967,11 @@ Additionally, the method supports the following query parameters to use the sdk 
 
 These endpoints are used for the `Dynamic Instrumentation` tests.
 
+#### GET /debugger/budgets/<loops>
+
+Executes the same probe line `loops` times during one request. It is used to verify per-probe and global
+Dynamic Instrumentation rate limits.
+
 #### GET /debugger/snapshot/capture-timeout
 
 Creates a collection containing `collectionSize` object chains. Each chain has a leaf wrapped by

--- a/tests/debugger/test_debugger_guardrails.py
+++ b/tests/debugger/test_debugger_guardrails.py
@@ -13,6 +13,8 @@ MAX_SNAPSHOT_BYTES = 1024 * 1024
 # characters already blow past any evaluation-time budget. Keep it small so the value fits
 # comfortably in the request URL.
 REDOS_INPUT_LENGTH = 25
+# Keep this large enough that optimized runtimes cannot finish the full filter inside the smallest supported budget.
+EVALUATION_TIMEOUT_COLLECTION_SIZE = 1_000_000
 GUARDRAILS_RFC = "https://docs.google.com/document/d/1OhCH3SMuS_B4Ickays94GpqDlqKcc9b9gLos1T85F-Q/edit?usp=sharing"
 
 
@@ -63,7 +65,7 @@ class _DebuggerEvaluationTimeoutTest(debugger.BaseDebuggerTest):
         self._setup_evaluation_timeout(
             "probe_evaluation_timeout_collection_filter",
             "SnapshotLimits",
-            "/debugger/snapshot/limits?collectionSize=100000",
+            f"/debugger/snapshot/limits?collectionSize={EVALUATION_TIMEOUT_COLLECTION_SIZE}",
         )
 
     def test_evaluation_timeout_collection_filter(self) -> None:

--- a/tests/debugger/utils.py
+++ b/tests/debugger/utils.py
@@ -189,7 +189,7 @@ class BaseDebuggerTest:
     def method_and_language_to_line_number(self, method: str, language: str) -> list:
         """method_and_language_to_line_number returns the respective line number given the method and language"""
         definitions: dict[str, dict[str, list[int]]] = {
-            "Budgets": {"java": [140], "dotnet": [138], "python": [144], "golang": [117]},
+            "Budgets": {"java": [140], "dotnet": [138], "python": [144], "golang": [117], "nodejs": [163]},
             "LogProbe": {"nodejs": [20]},
             "Pii": {"java": [66], "dotnet": [66], "python": [66], "ruby": [66], "nodejs": [64]},
             "Expression": {"java": [73], "dotnet": [76], "python": [74], "ruby": [82], "nodejs": [82], "golang": [71]},
@@ -204,7 +204,7 @@ class BaseDebuggerTest:
             "CollectionOperations": {"java": [116], "dotnet": [116], "python": [125], "ruby": [162], "nodejs": [120]},
             "Nulls": {"java": [132], "dotnet": [129], "python": [138], "ruby": [192], "nodejs": [126]},
             "SnapshotLimits": {"java": [155], "python": [174], "nodejs": [136], "ruby": [233], "dotnet": [152]},
-            "CaptureTimeout": {"java": [174], "nodejs": [155], "dotnet": [173]},
+            "CaptureTimeout": {"java": [174], "nodejs": [157], "dotnet": [173]},
         }
 
         return definitions.get(method, {}).get(language, [])

--- a/utils/build/docker/nodejs/express/debugger/index.js
+++ b/utils/build/docker/nodejs/express/debugger/index.js
@@ -141,6 +141,8 @@ module.exports = {
       const nestingDepth = parseInt(req.query.nestingDepth, 10) || 0
       res.send(captureTimeoutFixture(collectionSize, nestingDepth))
     })
+
+    app.get('/debugger/budgets/:loops', budgets)
   }
 }
 
@@ -152,5 +154,13 @@ function captureTimeoutFixture (collectionSize, nestingDepth) {
     }
     return nested
   })
-  return 'Capture timeout probe' // This needs to be line 155
+  return 'Capture timeout probe' // This needs to be line 157
+}
+
+function budgets (request, reply) {
+  const loops = Number(request.params.loops)
+  for (let iteration = 0; iteration < loops; iteration++) {
+    const currentIteration = iteration // This needs to be line 163
+  }
+  return reply.send('Budgets')
 }

--- a/utils/build/docker/nodejs/express4-typescript/debugger/index.ts
+++ b/utils/build/docker/nodejs/express4-typescript/debugger/index.ts
@@ -141,6 +141,8 @@ export function initRoutes (app: Express) {
     const nestingDepth = parseInt(req.query.nestingDepth as string, 10) || 0
     res.send(captureTimeoutFixture(collectionSize, nestingDepth))
   })
+
+  app.get('/debugger/budgets/:loops', budgets)
 }
 
 function captureTimeoutFixture (collectionSize: number, nestingDepth: number): string {
@@ -152,5 +154,13 @@ function captureTimeoutFixture (collectionSize: number, nestingDepth: number): s
     return nested
   })
 
-  return 'Capture timeout probe' // This needs to be line 155
+  return 'Capture timeout probe' // This needs to be line 157
+}
+
+function budgets (request: Request, reply: Response): Response {
+  const loops = Number(request.params.loops)
+  for (let iteration = 0; iteration < loops; iteration++) {
+    const currentIteration = iteration // This needs to be line 163
+  }
+  return reply.send('Budgets')
 }

--- a/utils/build/docker/nodejs/fastify/debugger/index.js
+++ b/utils/build/docker/nodejs/fastify/debugger/index.js
@@ -141,6 +141,8 @@ module.exports = {
       const nestingDepth = parseInt(request.query.nestingDepth, 10) || 0
       return captureTimeoutFixture(collectionSize, nestingDepth)
     })
+
+    fastify.get('/debugger/budgets/:loops', budgets)
   }
 }
 
@@ -152,5 +154,13 @@ function captureTimeoutFixture (collectionSize, nestingDepth) {
     }
     return nested
   })
-  return 'Capture timeout probe' // This needs to be line 155
+  return 'Capture timeout probe' // This needs to be line 157
+}
+
+function budgets (request, reply) {
+  const loops = Number(request.params.loops)
+  for (let iteration = 0; iteration < loops; iteration++) {
+    const currentIteration = iteration // This needs to be line 163
+  }
+  return reply.send('Budgets')
 }


### PR DESCRIPTION
## Motivation

The Node.js tracer guardrail work for DEBUG-6081 needs matching system-test fixtures and stable inputs for its budget and timeout behavior.

## Changes

- add the `/debugger/budgets/:loops` fixture to the Node.js Express, TypeScript Express, and Fastify weblogs
- add the Node.js source-line mapping used by line-probe budget tests
- increase the collection-filter input so optimized runtimes reliably exceed the evaluation budget
- update the shifted capture-timeout line mapping and endpoint documentation

## Testing

Tested with the Node.js tracer stack tip `watson/DEBUG-6081/evaluation-timeout` pinned at `b1d7c6c5ef3393214c7095afe65885933d44e046`.

- `DEBUGGER_PROBES_SNAPSHOT`: 4 passed
  - line-probe budgets
  - line-probe capture-expression budgets
  - regex evaluation timeout
  - collection-filter evaluation timeout
- `DEBUGGER_CAPTURE_TIMEOUT`: 1 passed

Related tracer PR: https://github.com/DataDog/dd-trace-js/pull/10156

## Workflow

1. ⚠️ Create your PR as draft ⚠️
2. Work on you PR until the CI passes
3. Mark it as ready for review
    * Test logic is modified? -> Get a review from RFC owner.
    * Framework is modified, or non obvious usage of it -> get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)

:rocket: Once your PR is reviewed and the CI green, you can merge it!

🛟 [#apm-shared-testing](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X) 🛟

## Reviewer checklist

* [ ] Anything but `tests/` or `manifests/` is modified ? I have the approval from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
* [ ] A docker base image is modified?
    * [ ] the relevant `build-XXX-image` label is present
* [ ] A scenario is added, removed or renamed?
    * [ ] Get a review from [R&P team](https://dd.enterprise.slack.com/archives/C025TJ4RZ8X)
