### PR TITLE
test(java): enable agentless EVP egress

### DIFF
--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3351,9 +3351,15 @@ manifest:
     - weblog_declaration:
         "*": irrelevant
         spring-boot: v1.56.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - component_version: <1.67.0-SNAPSHOT
+      declaration: missing_feature (Agentless direct exposure egress requires Java tracer 1.67.0)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown:
+    - component_version: <1.67.0-SNAPSHOT
+      declaration: missing_feature (Agentless direct shutdown egress requires Java tracer 1.67.0)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar:
+    - component_version: <1.67.0-SNAPSHOT
+      declaration: missing_feature (Agentless sidecar egress requires Java tracer 1.67.0)
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": irrelevant
@@ -3363,7 +3369,29 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3415)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3415)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3415)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Basic: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Context_Bounds: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Count: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.67.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.67.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent:
+    - weblog_declaration:
+        "*": irrelevant
+        spring-boot: v1.67.0-SNAPSHOT
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_High_Cardinality_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Load_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Runtime_Default: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py:
     - weblog_declaration:
         "*": irrelevant

--- a/tests/test_the_test/test_java_direct_evp_activation.py
+++ b/tests/test_the_test/test_java_direct_evp_activation.py
@@ -1,0 +1,89 @@
+"""Guard the Java-only trust and shutdown pieces for direct-EVP validation."""
+
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from utils import features, scenarios
+from utils._context._scenarios.agentless_endtoend import FeatureFlaggingAgentlessEndToEndScenario
+from utils.proxy.ports import ProxyPorts
+
+
+@pytest.mark.parametrize(
+    ("route", "library", "weblog_variant", "expected"),
+    [
+        ("direct", "java", "spring-boot", "configured"),
+        ("sidecar", "java", "spring-boot", "unchanged"),
+        ("direct", "java", "spring-boot-3-native", "unchanged"),
+        ("direct", "nodejs", "express4", "unchanged"),
+    ],
+)
+@scenarios.test_the_test
+@features.not_reported
+def test_java_direct_evp_uses_canonical_startup_and_preserves_java_opts(
+    route: Literal["direct", "sidecar"],
+    library: str,
+    weblog_variant: str,
+    expected: Literal["configured", "unchanged"],
+) -> None:
+    scenario = FeatureFlaggingAgentlessEndToEndScenario(
+        "MOCK_FFE_JAVA_DIRECT_EVP",
+        doc="test",
+        exposure_egress=route,
+    )
+    library_container = scenario.weblog_infra.http_container
+    library_container.image.labels["system-tests-library"] = library
+    library_container.weblog_variant = weblog_variant
+    library_container.environment["JAVA_OPTS"] = "-Dexisting.option=true"
+
+    scenario._configure_java_direct_evp()  # noqa: SLF001 - focused activation test
+
+    assert library_container.environment["JAVA_OPTS"] == "-Dexisting.option=true"
+    if expected == "unchanged":
+        assert "SYSTEM_TESTS_JAVA_PROXY_OPTS" not in library_container.environment
+        assert "./utils/build/docker/java/app-with-proxy-ca.sh" not in library_container.volumes
+        assert "./utils/build/docker/java/app.sh" not in library_container.volumes
+        assert "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer" not in library_container.volumes
+        return
+
+    assert library_container.environment["SYSTEM_TESTS_JAVA_PROXY_OPTS"] == (
+        f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
+    )
+    assert library_container.volumes["./utils/build/docker/java/app-with-proxy-ca.sh"] == {
+        "bind": "/app/app.sh",
+        "mode": "ro",
+    }
+    assert library_container.volumes["./utils/build/docker/java/app.sh"] == {
+        "bind": "/app/system-tests-java-app.sh",
+        "mode": "ro",
+    }
+    assert library_container.volumes["./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer"] == {
+        "bind": "/app/system-tests-proxy-ca.cer",
+        "mode": "ro",
+    }
+
+    wrapper = Path("utils/build/docker/java/app-with-proxy-ca.sh").read_text(encoding="utf-8")
+    assert 'JAVA_OPTS="${JAVA_OPTS:-} ${SYSTEM_TESTS_JAVA_PROXY_OPTS:-}' in wrapper
+    assert "export JAVA_OPTS" in wrapper
+    assert "exec /app/system-tests-java-app.sh" in wrapper
+    assert "java -Xmx" not in wrapper
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_java_direct_evp_shutdown_is_opt_in_and_closes_server_before_exit() -> None:
+    entrypoint = Path(
+        "utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/"
+        "SpringbootwildflyApplication.java"
+    ).read_text(encoding="utf-8")
+    shutdown = Path(
+        "utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/DirectEvpShutdown.java"
+    ).read_text(encoding="utf-8")
+
+    assert "ConfigurableApplicationContext context = SpringApplication.run(applicationClass, args);" in entrypoint
+    assert "DirectEvpShutdown.install(context);" in entrypoint
+    assert "SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED" in shutdown
+    assert 'Signal.handle(new Signal("TERM")' in shutdown
+    assert shutdown.index("context.close();") < shutdown.index("system_tests.ffe.shutdown.server_closed")
+    assert shutdown.index("system_tests.ffe.shutdown.server_closed") < shutdown.index("System.exit(exitCode);")

--- a/utils/_context/_scenarios/agentless_endtoend.py
+++ b/utils/_context/_scenarios/agentless_endtoend.py
@@ -235,11 +235,40 @@ class FeatureFlaggingAgentlessEndToEndScenario(AgentlessEndToEndScenario):
         try:
             super().configure(config)
             if self.exposure_egress is not None:
+                self._configure_java_direct_evp()
                 interfaces.datadog_sidecar.configure(self.host_log_folder, replay=self.replay)
                 interfaces.datadog_direct.configure(self.host_log_folder, replay=self.replay)
         except BaseException:
             self._stop_mock_backend(persist_status=False)
             raise
+
+    def _configure_java_direct_evp(self) -> None:
+        """Install the capture CA without replacing Java's canonical startup behavior."""
+        if (
+            self.exposure_egress != "direct"
+            or self.weblog_infra.library_name != "java"
+            or self.weblog_variant != "spring-boot"
+        ):
+            return
+
+        library_container = self.weblog_infra.library_container
+        library_container.environment["SYSTEM_TESTS_JAVA_PROXY_OPTS"] = (
+            f"-Dhttps.proxyHost=proxy -Dhttps.proxyPort={ProxyPorts.datadog_direct}"
+        )
+        library_container.volumes |= {
+            "./utils/build/docker/java/app-with-proxy-ca.sh": {
+                "bind": "/app/app.sh",
+                "mode": "ro",
+            },
+            "./utils/build/docker/java/app.sh": {
+                "bind": "/app/system-tests-java-app.sh",
+                "mode": "ro",
+            },
+            "./utils/proxy/.mitmproxy/mitmproxy-ca-cert.cer": {
+                "bind": "/app/system-tests-proxy-ca.cer",
+                "mode": "ro",
+            },
+        }
 
     @property
     def serverless_init_container(self) -> ServerlessInitContainer:

--- a/utils/build/docker/java/app-with-proxy-ca.sh
+++ b/utils/build/docker/java/app-with-proxy-ca.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+trust_store=/tmp/system-tests-cacerts
+cp "${JAVA_HOME}/lib/security/cacerts" "${trust_store}"
+keytool -importcert -noprompt -trustcacerts \
+  -alias system-tests-proxy \
+  -file /app/system-tests-proxy-ca.cer \
+  -keystore "${trust_store}" \
+  -storepass changeit
+
+JAVA_OPTS="${JAVA_OPTS:-} ${SYSTEM_TESTS_JAVA_PROXY_OPTS:-} -Djavax.net.ssl.trustStore=${trust_store} -Djavax.net.ssl.trustStorePassword=changeit"
+export JAVA_OPTS
+
+exec /app/system-tests-java-app.sh

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/DirectEvpShutdown.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/DirectEvpShutdown.java
@@ -1,0 +1,40 @@
+package com.datadoghq.system_tests.springboot;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.context.ConfigurableApplicationContext;
+import sun.misc.Signal;
+
+/** Opt-in SIGTERM lifecycle used only by the direct-EVP shutdown system test. */
+final class DirectEvpShutdown {
+    private static final String ENABLE_ENV = "SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED";
+
+    private DirectEvpShutdown() {}
+
+    static void install(ConfigurableApplicationContext context) {
+        if (!"true".equals(System.getenv(ENABLE_ENV))) {
+            return;
+        }
+
+        AtomicBoolean stopping = new AtomicBoolean();
+        Signal.handle(new Signal("TERM"), signal -> {
+            if (!stopping.compareAndSet(false, true)) {
+                return;
+            }
+
+            int exitCode = 0;
+            try {
+                context.close();
+                System.out.println(
+                    "{\"event\":\"system_tests.ffe.shutdown.server_closed\",\"timestamp\":\""
+                        + Instant.now()
+                        + "\"}"
+                );
+            } catch (Throwable error) {
+                error.printStackTrace(System.err);
+                exitCode = 1;
+            }
+            System.exit(exitCode);
+        });
+    }
+}

--- a/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/SpringbootwildflyApplication.java
+++ b/utils/build/docker/java/spring-boot/src/main/java/com/datadoghq/system_tests/springboot/SpringbootwildflyApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
 
 // Spring Boot 1.x
 //import org.springframework.boot.web.support.SpringBootServletInitializer;
@@ -29,7 +30,8 @@ public class SpringbootwildflyApplication extends SpringBootServletInitializer {
             }
             return;
         }
-        SpringApplication.run(applicationClass, args);
+        ConfigurableApplicationContext context = SpringApplication.run(applicationClass, args);
+        DirectEvpShutdown.install(context);
     }
 
     @Override
@@ -40,5 +42,4 @@ public class SpringbootwildflyApplication extends SpringBootServletInitializer {
     //private static Class<SpringbootwildflyApplication> applicationClass = SpringbootwildflyApplication.class;
     private static Class<App> applicationClass = App.class;
 }
-
 


### PR DESCRIPTION
## Motivation

We are shipping agentless CDN-delivered configuration to make customer deployments simpler. The SDK's core Feature Flags telemetry still needs a network path out of the process: automatically use a compatible running Agent or `serverless-init` relay when available, and fall back to direct EVP intake when no compatible relay exists.

[FFLSDK-193](https://linear.app/datadoghq/issue/FFLSDK-193/system-testsjava-enable-agentless-evp-fallback-coverage) activates Java against the shared cross-language contract in #7299 so configuration success cannot mask missing exposure or flag-evaluation delivery.

## Changes

| Capability | Topology | Assertion |
|---|---|---|
| Exposure delivery | Direct intake | `/api/v2/exposures` reaches the direct EVP capture with the shared transport contract |
| Flag-evaluation delivery | Direct intake | `/api/v2/flagevaluation` reaches the direct EVP capture with the shared transport contract |
| Shutdown exposure flush | Direct intake | An exposure queued immediately before application shutdown reaches EVP exactly once |
| Exposure delivery | `serverless-init` | `/api/v2/exposures` reaches intake through the compatible relay |
| Flag-evaluation delivery | `serverless-init` | `/api/v2/flagevaluation` reaches intake through the compatible relay |
| Agent-backed delivery | Agent | Existing coverage remains enabled |

- Activate the supported `spring-boot` weblog at Java 1.67.
- Add the test observer CA without replacing the canonical application startup.
- Add an opt-in Spring shutdown lifecycle that closes the application before emitting the shared shutdown marker.

## Decisions

- Stack directly on #7299; do not depend on another language activation.
- Scope activation to the supported `spring-boot` weblog.
- Keep shutdown behavior test-only and opt-in through `SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED`.
- Preserve the existing `FFL-2446` exclusions for broader non-egress aggregation contracts.
- Validate the transport implementation from [dd-trace-java#12477](https://github.com/DataDog/dd-trace-java/pull/12477) at exact commit `e20a9d77c333ddb0c0444835f23fafba70952373`.
- Require the relay to advertise forwarding support for both `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION`; the shared base uses `serverless-init` 1.10.4 because 1.10.2 does not advertise or forward those headers.

## Validation

- System-tests base: `9c753fbcbdcc6122eed15fd5af827671fbc0771c`
- System-tests candidate: `364b7dcfd7294b0ede91222b688ca90d8e9d52dd`
- Java candidate: `e20a9d77c333ddb0c0444835f23fafba70952373` (`1.67.0-SNAPSHOT+e20a9d77c3`)
- `./run.sh TEST_THE_TEST tests/test_the_test/test_java_direct_evp_activation.py tests/test_the_test/test_manifest.py` — 37 passed
- `./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :products:feature-flagging:feature-flagging-api:jar --rerun-tasks` — passed, 1,036 tasks; produced the exact Java candidate above
- `./build.sh java -w spring-boot` — passed; image reported the exact Java candidate above
- Direct exposure, shutdown exposure, and flag evaluation at candidate parent `c8edddec6bb33d46f71b8be32e22c87bdb804887` — 3 passed in 26.27s. The only subsequent merge changes the shared `serverless-init` image pin and its mirror metadata.
- Forced-`serverless-init` exposure and flag evaluation at candidate `364b7dcfd7294b0ede91222b688ca90d8e9d52dd` with `serverless-init` 1.10.4 — 2 passed in 24.67s
- This is local mock-intake transport proof, not staging or production backend proof.
- Commits `c8edddec6bb33d46f71b8be32e22c87bdb804887` and `364b7dcfd7294b0ede91222b688ca90d8e9d52dd` — GitHub signatures verified
