### PR TITLE
test(nodejs): enable agentless EVP exposure egress

### DIFF
--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -1836,9 +1836,18 @@ manifest:
     - weblog_declaration:
         "*": incomplete_test_app
         express4: *ref_5_77_0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (dd-trace-js#9527)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: missing_feature (dd-trace-js#9527)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (dd-trace-js#9527)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        express4: v7.0.0-pre
   tests/ffe/test_exposures_datadog_agent.py:
     - weblog_declaration:
         "*": incomplete_test_app

--- a/tests/test_the_test/test_nodejs_direct_evp_shutdown.py
+++ b/tests/test_the_test/test_nodejs_direct_evp_shutdown.py
@@ -1,0 +1,20 @@
+"""Guard the Node weblog lifecycle required by direct-EVP shutdown validation."""
+
+from pathlib import Path
+
+from utils import features, scenarios
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_node_direct_shutdown_fixture_execs_runtime_and_scopes_sigterm_handler() -> None:
+    dockerfile = Path("utils/build/docker/nodejs/express4.Dockerfile").read_text(encoding="utf-8")
+    app = Path("utils/build/docker/nodejs/express/app.js").read_text(encoding="utf-8")
+
+    assert "RUN printf 'exec node app.js\\n' >> app.sh" in dockerfile
+    assert 'CMD ["./app.sh"]' in dockerfile
+    assert "SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED === 'true'" in app
+    assert "process.once('SIGTERM'" in app
+    assert "server.close(" in app
+    assert "event: 'system_tests.ffe.shutdown.server_closed'" in app
+    assert "timestamp: new Date().toISOString()" in app

--- a/utils/build/docker/nodejs/express/app.js
+++ b/utils/build/docker/nodejs/express/app.js
@@ -972,6 +972,25 @@ const startServer = () => {
       }
     })
 
+    // Direct-EVP shutdown coverage needs Docker's SIGTERM to reach the ordinary Node
+    // process and let dd-trace's beforeExit hooks flush. Keep this opt-in so other
+    // scenarios retain the weblog's historical signal behavior.
+    if (process.env.SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED === 'true') {
+      process.once('SIGTERM', () => {
+        server.close(error => {
+          if (error) {
+            console.error('Failed to close server during SIGTERM:', error)
+            process.exitCode = 1
+            return
+          }
+          console.log(JSON.stringify({
+            event: 'system_tests.ffe.shutdown.server_closed',
+            timestamp: new Date().toISOString()
+          }))
+        })
+      })
+    }
+
     server.listen(7777, '0.0.0.0', () => {
       tracer.trace('init.service', () => {})
       console.log('listening')

--- a/utils/build/docker/nodejs/express4.Dockerfile
+++ b/utils/build/docker/nodejs/express4.Dockerfile
@@ -20,11 +20,14 @@ ENV PGPORT=5433
 
 ENV DD_DATA_STREAMS_ENABLED=true
 
+# Allow Node.js to trust the CA bundle mounted by direct-intake test scenarios.
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
 # docker startup
 COPY utils/build/docker/nodejs/app.sh app.sh
 RUN chmod +x app.sh
-RUN printf 'node app.js' >> app.sh
-CMD ./app.sh
+RUN printf 'exec node app.js\n' >> app.sh
+CMD ["./app.sh"]
 
 COPY utils/build/docker/nodejs/install_ddtrace.sh binaries* /binaries/
 RUN /binaries/install_ddtrace.sh && rm -rf /root/.bun


### PR DESCRIPTION
## Motivation

We are shipping agentless CDN-delivered configuration to make customer deployments simpler. The SDK's core Feature Flags telemetry still needs a network path out of the process: automatically use a compatible running Agent or `serverless-init` relay when available, and fall back to direct EVP intake when no relay exists.

[FFLSDK-191](https://linear.app/datadoghq/issue/FFLSDK-191/system-testsnodejs-enable-agentless-evp-fallback-coverage) activates Node.js against the shared cross-language contract in #7299 and makes the remaining signal gap explicit before rollout.

## Changes

| Capability | Direct intake | `serverless-init` | Agent |
|---|---:|---:|---:|
| Exposures | Enabled and locally passing | Enabled and locally passing | Existing coverage |
| Flag evaluations | Not emitted yet | Not emitted yet | Not emitted yet |
| Shutdown exposure flush | Enabled and locally passing | — | — |

- Activate the Express 4 weblog at Node.js 7.0.
- Add the test observer CA to the ordinary Node.js runtime trust configuration.
- Make Node the container PID 1 and add an opt-in SIGTERM path that closes the server before the shared shutdown marker.

## Decisions

- Target #7299 directly; do not depend on another language activation.
- Keep this PR exposure-only. Node.js flag-evaluation emission and privacy remain tracked by [FFLSDK-19](https://linear.app/datadoghq/issue/FFLSDK-19/nodejs-sdk-emits-flagevaluations-to-evp), [dd-trace-js#8902](https://github.com/DataDog/dd-trace-js/pull/8902), and its privacy work.
- Do not claim the language rollout complete until both signals, EVP identity, and the safe fallback transition are merged and activated.
- Keep the shutdown hook test-only and opt-in.
- Keep OTLP out of scope: these contracts validate EVP egress.

## Validation

System-tests base: `9c753fbcbdcc6122eed15fd5af827671fbc0771c`

System-tests candidate: `a548cfc82bfcad980a4bedf98eb2ce3931117582`

Node.js SDK candidate: [`95ae311455bc8f2c7ca65d8524e996c844546e30`](https://github.com/DataDog/dd-trace-js/commit/95ae311455bc8f2c7ca65d8524e996c844546e30) from [dd-trace-js#10309](https://github.com/DataDog/dd-trace-js/pull/10309)

```text
./run.sh TEST_THE_TEST \
  tests/test_the_test/test_nodejs_direct_evp_shutdown.py \
  tests/test_the_test/test_manifest.py
33 passed in 11.30s
```

The Express 4 weblog was rebuilt from the exact SDK candidate:

```text
DataDog/dd-trace-js#95ae311455bc8f2c7ca65d8524e996c844546e30
Library: nodejs@7.0.0-pre
Weblog variant: express4
```

```text
./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_DIRECT \
  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct \
  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown
2 passed in 16.17s

./run.sh FEATURE_FLAGGING_AND_EXPERIMENTATION_AGENTLESS_SERVERLESS \
  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar
1 passed in 22.22s
```

This is local mock-intake proof of routing, credentials, identity, payload uniqueness, and shutdown behavior; it is not staging or production-intake proof.
