### PR TITLE
test(python): enable agentless EVP egress

### DIFF
--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1462,15 +1462,15 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Down_From_Start: v4.0.0
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_RC_Unavailable: flaky (FFL-1622)
   tests/ffe/test_exposure_egress.py: v4.2.0-dev
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: v4.15.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: v4.15.0-dev
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: v4.15.0-dev
   tests/ffe/test_exposures_datadog_agent.py: v4.2.0-dev
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3413)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py: v4.15.0-dev
   tests/ffe/test_flag_eval_metrics.py: v4.7.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)
   tests/integration_frameworks/llm/anthropic/test_anthropic_ai_guard.py::TestAnthropicAiGuard: v4.11.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1470,7 +1470,9 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3413)
-  tests/ffe/test_flag_eval_evp.py: v4.15.0-dev
+  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v4.15.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: v4.15.0-dev
   tests/ffe/test_flag_eval_metrics.py: v4.7.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)
   tests/integration_frameworks/llm/anthropic/test_anthropic_ai_guard.py::TestAnthropicAiGuard: v4.11.0

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1470,9 +1470,21 @@ manifest:
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Disappears: missing_feature (EX-3413)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Serial_Id: missing_feature (EX-3413)
-  tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py: v4.15.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Basic: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Burst_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Context_Bounds: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Count: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Degradation: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct: v4.15.0-dev
   tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar: v4.15.0-dev
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_High_Cardinality_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Load_Aggregation: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed: missing_feature (FFL-2446)
+  tests/ffe/test_flag_eval_evp.py::Test_FFE_EVP_Flagevaluation_Runtime_Default: missing_feature (FFL-2446)
   tests/ffe/test_flag_eval_metrics.py: v4.7.0
   tests/ffe/test_flag_eval_metrics.py::Test_FFE_Eval_Nested_Attributes_Ignored: irrelevant (FFL-1980)
   tests/integration_frameworks/llm/anthropic/test_anthropic_ai_guard.py::TestAnthropicAiGuard: v4.11.0

--- a/tests/test_the_test/test_python_direct_evp_activation.py
+++ b/tests/test_the_test/test_python_direct_evp_activation.py
@@ -1,0 +1,46 @@
+"""Guard the Python-only lifecycle needed by direct-EVP validation."""
+
+from pathlib import Path
+
+from utils import features, scenarios
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_python_direct_evp_shutdown_uses_opt_in_gunicorn_worker_exit_hook() -> None:
+    app_script = Path("utils/build/docker/python/flask/app.sh").read_text(encoding="utf-8")
+    gunicorn_config = Path("utils/build/docker/python/flask/direct_evp_gunicorn.py").read_text(encoding="utf-8")
+
+    assert 'SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED:-} = "true"' in app_script
+    assert "export DD_FFE_INTAKE_HEARTBEAT_INTERVAL=5" in app_script
+    assert "gunicorn_args+=(--config python:direct_evp_gunicorn)" in app_script
+    assert 'exec ddtrace-run gunicorn "${gunicorn_args[@]}"' in app_script
+    assert app_script.index('SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED:-} = "true"') < app_script.index(
+        "export DD_FFE_INTAKE_HEARTBEAT_INTERVAL=5"
+    )
+    assert app_script.index("export DD_FFE_INTAKE_HEARTBEAT_INTERVAL=5") < app_script.index(
+        "gunicorn_args+=(--config python:direct_evp_gunicorn)"
+    )
+    assert "def worker_exit(" in gunicorn_config
+    assert "system_tests.ffe.shutdown.server_closed" in gunicorn_config
+    assert gunicorn_config.index("worker_exit") < gunicorn_config.index("sys.stdout.write")
+    assert gunicorn_config.index("sys.stdout.write") < gunicorn_config.index("sys.stdout.flush")
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_python_direct_evp_activation_preserves_full_data_privacy_contract() -> None:
+    manifest = Path("manifests/python.yml").read_text(encoding="utf-8")
+    contract = Path("tests/ffe/test_flag_eval_evp.py").read_text(encoding="utf-8")
+
+    assert "tests/ffe/test_flag_eval_evp.py: v4.15.0-dev" in manifest
+    for required_contract in (
+        "Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed",
+        "Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed",
+        "Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed",
+        'PII_TARGETING_KEY_HASHED = "sha256_',
+        'assert "evaluation" not in context',
+        "assert targeting_key == PII_TARGETING_KEY",
+        "for key, expected_value in PII_ATTRIBUTES.items()",
+    ):
+        assert required_contract in contract

--- a/tests/test_the_test/test_python_direct_evp_activation.py
+++ b/tests/test_the_test/test_python_direct_evp_activation.py
@@ -33,7 +33,7 @@ def test_python_direct_evp_activation_is_scoped_to_agentless_egress() -> None:
     manifest = Path("manifests/python.yml").read_text(encoding="utf-8")
     contract = Path("tests/ffe/test_flag_eval_evp.py").read_text(encoding="utf-8")
 
-    assert "tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)" in manifest
+    assert "tests/ffe/test_flag_eval_evp.py: v4.15.0-dev" in manifest
     for enabled_contract in (
         "Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct",
         "Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar",
@@ -41,5 +41,10 @@ def test_python_direct_evp_activation_is_scoped_to_agentless_egress() -> None:
         assert f"tests/ffe/test_flag_eval_evp.py::{enabled_contract}: v4.15.0-dev" in manifest
         assert enabled_contract in contract
 
-    assert "Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v4.15.0-dev" not in manifest
-    assert "Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v4.15.0-dev" not in manifest
+    for deferred_contract in (
+        "Test_FFE_EVP_Flagevaluation_Egress_Datadog_Agent",
+        "Test_FFE_EVP_Flagevaluation_Basic",
+        "Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed",
+        "Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed",
+    ):
+        assert f"tests/ffe/test_flag_eval_evp.py::{deferred_contract}: missing_feature (FFL-2446)" in manifest

--- a/tests/test_the_test/test_python_direct_evp_activation.py
+++ b/tests/test_the_test/test_python_direct_evp_activation.py
@@ -29,18 +29,17 @@ def test_python_direct_evp_shutdown_uses_opt_in_gunicorn_worker_exit_hook() -> N
 
 @scenarios.test_the_test
 @features.not_reported
-def test_python_direct_evp_activation_preserves_full_data_privacy_contract() -> None:
+def test_python_direct_evp_activation_is_scoped_to_agentless_egress() -> None:
     manifest = Path("manifests/python.yml").read_text(encoding="utf-8")
     contract = Path("tests/ffe/test_flag_eval_evp.py").read_text(encoding="utf-8")
 
-    assert "tests/ffe/test_flag_eval_evp.py: v4.15.0-dev" in manifest
-    for required_contract in (
-        "Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed",
-        "Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed",
-        "Test_FFE_EVP_Flagevaluation_ObserveFullData_True_Unhashed",
-        'PII_TARGETING_KEY_HASHED = "sha256_',
-        'assert "evaluation" not in context',
-        "assert targeting_key == PII_TARGETING_KEY",
-        "for key, expected_value in PII_ATTRIBUTES.items()",
+    assert "tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)" in manifest
+    for enabled_contract in (
+        "Test_FFE_EVP_Flagevaluation_Egress_Agentless_Direct",
+        "Test_FFE_EVP_Flagevaluation_Egress_Agentless_Sidecar",
     ):
-        assert required_contract in contract
+        assert f"tests/ffe/test_flag_eval_evp.py::{enabled_contract}: v4.15.0-dev" in manifest
+        assert enabled_contract in contract
+
+    assert "Test_FFE_EVP_Flagevaluation_ObserveFullData_Absent_Hashed: v4.15.0-dev" not in manifest
+    assert "Test_FFE_EVP_Flagevaluation_ObserveFullData_False_Hashed: v4.15.0-dev" not in manifest

--- a/utils/build/docker/python/flask/app.sh
+++ b/utils/build/docker/python/flask/app.sh
@@ -12,7 +12,14 @@ echo "------------------"
 if [[ ${UDS_WEBLOG:-} = "1" ]]; then
     ./set-uds-transport.sh
 fi
+
+gunicorn_args=()
+if [[ ${SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED:-} = "true" ]]; then
+    export DD_FFE_INTAKE_HEARTBEAT_INTERVAL=5
+    gunicorn_args+=(--config python:direct_evp_gunicorn)
+fi
+
 # CAVEAT: to debug the Python App, use these lines
 # export FLASK_APP=app
 # ddtrace-run flask run --no-reload --host=0.0.0.0 --port=7777
-exec ddtrace-run gunicorn -w 1 --threads 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent
+exec ddtrace-run gunicorn "${gunicorn_args[@]}" -w 1 --threads 1 -b 0.0.0.0:7777 --access-logfile - app:app -k gevent

--- a/utils/build/docker/python/flask/direct_evp_gunicorn.py
+++ b/utils/build/docker/python/flask/direct_evp_gunicorn.py
@@ -1,0 +1,23 @@
+"""Opt-in Gunicorn lifecycle evidence for direct Feature Flags EVP tests."""
+
+from datetime import UTC, datetime
+import json
+import os
+import sys
+from typing import Any
+
+
+DIRECT_EVP_SHUTDOWN_MARKER_EVENT = "system_tests.ffe.shutdown.server_closed"
+
+
+def worker_exit(_server: Any, _worker: Any) -> None:
+    """Mark the worker closed before interpreter shutdown flushes buffered events."""
+    if os.environ.get("SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED") != "true":
+        return
+
+    marker = {
+        "event": DIRECT_EVP_SHUTDOWN_MARKER_EVENT,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    sys.stdout.write(json.dumps(marker, separators=(",", ":")) + "\n")
+    sys.stdout.flush()


### PR DESCRIPTION
## Motivation

Agentless CDN-delivered configuration simplifies customer deployments only if Feature Flags telemetry also leaves the process reliably. This PR enables Python's shared direct-intake and serverless-init EVP contracts from #7299. Tracks [FFLSDK-192](https://linear.app/datadoghq/issue/FFLSDK-192/system-testspython-enable-agentless-evp-fallback-coverage).

## Changes

| Capability on `flask-poc` | Direct intake | Serverless-init |
|---|---|---|
| Exposure delivery and EVP identity | Enabled | Enabled |
| Flag-evaluation delivery and EVP identity | Enabled | Enabled |
| Exposure flush after HTTP shutdown | Enabled | — |

- Gate all five contracts on `v4.16.0-dev`; Python 4.15.1 predates the SDK implementation merge.
- Scope activation to `flask-poc`, matching the validated application and its opt-in Gunicorn shutdown hook.
- Add a manifest-resolution regression matrix for eight weblogs and three versions; preserve existing ordinary-Agent coverage and deferred flag-evaluation contracts.

## Decisions

- Remain a **sibling of Go #7604**, directly based on #7299; no language-to-language dependency.
- SDK prerequisite [dd-trace-py#19868](https://github.com/DataDog/dd-trace-py/pull/19868) merged September 18 at `58bd02adb17fd080bbe7f95c11fa4d1af831a7c7`. Default SDK artifacts can now exercise the implementation without a branch override.
- Keep broader aggregation/privacy coverage under FFL-2446 and other weblog enablement outside this narrow PR. Do not weaken the five enabled contracts.
- OTLP is out of scope. No skips count as evidence.

## Validation

Foundation: `793233f0f70bf49a37c0a3d2c8804fde1937a7df`.
Candidate: `4923ddc2320418ac71f6bd89c7fc8f90160ce02d`; signed merge, GitHub verified.

- `PYTHONPATH=$PWD IN_NIX_SHELL=1 PATH=$PWD/venv/bin:$PATH ./format.sh --check` — **passed**.
- `PYTHONPATH=$PWD venv/bin/python -m pytest -S TEST_THE_TEST tests/test_the_test/test_python_direct_evp_activation.py tests/test_the_test/test_mock_ffe_agentless_backend.py tests/test_the_test/test_ffe_evp_contract.py -q --disable-warnings` — **88 passed**, Python 3.12.10.
- [Fresh Flask dev image build](https://github.com/DataDog/system-tests/actions/runs/35445607574/job/105904331256) **passed**, installing SDK main `d6ab482ea3fb3c8666e75ac1905a3325b8f80098`, package `4.16.0rc1`; its build log records the exact commit and CPython 3.11 wheel installation. This SDK SHA contains the merged implementation (18 commits ahead, zero behind). The new CI self-tests also passed; E2E assertions are still pending, so this is not approval-ready E2E evidence.
- No fresh local E2E build: shared workspace has approximately 1.2 GB free after cleaning only this turn's disposable linter dependencies.

Historical local mock-intake evidence: system-tests `ff9ad48b16e76e475a2f6902fb29a3c9a2666516` with SDK `b04708e52fa58e0f2270dd8053a2c885a26dd5d0` passed direct **3/3** and serverless **2/2**. That predates the merge and is not current-head validation or production-intake proof.
