### PR TITLE
test(otel): cover OTEL_TRACES variables parametrically

### DIFF
--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -60,6 +60,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: missing_feature
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: ">1.0.0"
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: missing_feature (propagation style not supported)
@@ -218,8 +219,6 @@ manifest:
   tests/parametric/test_llm_observability/: irrelevant (library does not implement LLM Observability)
   tests/parametric/test_otel_api_interoperability.py: irrelevant (library does not implement OpenTelemetry)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: missing_feature
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py: '>=2.0.0'  # Modified by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection::test_otlp_logs_enabled: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR03_Resource_Attributes: missing_feature  # Created by easy win activation script

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -61,6 +61,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: missing_feature
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: missing_feature
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: ">1.0.0"
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/manifests/cpp.yml
+++ b/manifests/cpp.yml
@@ -59,6 +59,7 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: missing_feature
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: ">1.0.0"
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/manifests/cpp_httpd.yml
+++ b/manifests/cpp_httpd.yml
@@ -96,8 +96,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/: irrelevant (Parametric scenario is not applied on C++ httpd)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)

--- a/manifests/cpp_nginx.yml
+++ b/manifests/cpp_nginx.yml
@@ -356,8 +356,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -869,6 +869,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_stable_false: bug (APMAPI-2417)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v3.37.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v3.41.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -871,6 +871,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v3.41.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v3.37.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v3.37.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:

--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -870,6 +870,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v3.37.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v3.41.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v3.37.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.42.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: missing_feature (does not support hostname)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default:
@@ -1026,8 +1027,6 @@ manifest:
   tests/parametric/test_llm_observability/: irrelevant (library does not implement LLM Observability)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.53.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in .NET)
   tests/parametric/test_otel_logs.py: '>=3.36.0'  # Modified by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection::test_otlp_logs_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1566,6 +1566,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.6.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v2.6.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v2.3.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1565,6 +1565,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.6.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.6.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
@@ -1697,8 +1698,6 @@ manifest:
   tests/parametric/test_llm_observability/: incomplete_test_app
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.66.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in go)
   tests/parametric/test_otel_logs.py: '>=2.5.0'  # Modified by easy win activation script
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection::test_otlp_logs_enabled: missing_feature  # Created by easy win activation script

--- a/manifests/golang.yml
+++ b/manifests/golang.yml
@@ -1564,6 +1564,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.6.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.50.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.72.0-dev
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3820,6 +3820,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: v1.57.0
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.57.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v1.57.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v1.57.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.12.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 1.24.0)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3818,6 +3818,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_matches_specification: v1.57.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2412)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: v1.57.0
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.57.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.12.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 1.24.0)

--- a/manifests/java.yml
+++ b/manifests/java.yml
@@ -3819,6 +3819,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2412)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_otel_service_name_takes_precedence: v1.57.0
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.57.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v1.57.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.12.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 1.24.0)
@@ -3977,8 +3978,6 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset::test_dataset_create_delete: incomplete_test_app (Java parametric app does not implement /llm_observability/dataset endpoints)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.35.2
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py: '>=1.62.0'
   tests/parametric/test_otel_logs.py::Test_FR06_OTLP_Protocols::test_otlp_protocols: incomplete_test_app (GPRC fails for system-test but works with real collector)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)

--- a/manifests/java_otel.yml
+++ b/manifests/java_otel.yml
@@ -48,8 +48,6 @@ manifest:
   tests/integrations/test_service_overrides.py::Test_SqlServiceNameSource: irrelevant (Only implemented for Java)
   tests/integrations/test_sql.py::Test_Sql: missing_feature (Endpoint is not implemented on weblog)
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2258,6 +2258,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v5.88.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v5.88.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v5.88.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2257,6 +2257,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v5.88.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v5.88.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v5.88.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)
@@ -2401,8 +2402,6 @@ manifest:
   tests/parametric/test_llm_observability/test_llm_observability_dne.py::Test_Dataset: missing_feature
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v5.11.0  #implemented in v5.11.0, v4.35.0, &v3.56.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR03_Resource_Attributes: *ref_5_72_0
   tests/parametric/test_otel_logs.py::Test_FR04_Trace_Span_IDs: *ref_5_72_0

--- a/manifests/nodejs.yml
+++ b/manifests/nodejs.yml
@@ -2256,6 +2256,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED::test_default_matches_specification: bug (APMAPI-2418)
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v5.88.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v5.88.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: *ref_3_0_0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_datadog_128_bit_generation_enabled_by_default:
     - declaration: missing_feature (Implemented in 4.19.0 & 3.40.0)

--- a/manifests/nodejs_otel.yml
+++ b/manifests/nodejs_otel.yml
@@ -65,8 +65,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::TestRemoteConfigApplyEndpoint: incomplete_test_app (POST /trace/remote-config/apply only implemented in the python parametric app)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1383,6 +1383,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v1.17.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2437)
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.23.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1385,6 +1385,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2437)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.23.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v1.23.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)

--- a/manifests/php.yml
+++ b/manifests/php.yml
@@ -1384,6 +1384,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2437)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v1.23.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v1.23.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.84.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd: v1.9.0
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
@@ -1564,15 +1565,7 @@ manifest:
   tests/parametric/test_llm_observability/: irrelevant (library does not implement LLM Observability)
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability: v0.94.0
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v1.1.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_to_debug_mapping: irrelevant (PHP uses DD_TRACE_DEBUG to set DD_TRACE_LOG_LEVEL=debug, so it does not do this mapping in the reverse direction)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_on:
-    - declaration: missing_feature (The always_on sampler mapping is properly implemented in v1.2.0)
-      component_version: <=1.1.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_on:
-    - declaration: missing_feature (The always_on sampler mapping is properly implemented in v1.2.0)
-      component_version: <=1.1.0
   tests/parametric/test_otel_logs.py: v1.20.0
   tests/parametric/test_otel_logs.py::Test_FR06_OTLP_Protocols: missing_feature (gRPC requires user-installed open-telemetry/transport-grpc + ext-grpc; http/protobuf is exercised via FR01/FR05/FR08)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1911,6 +1911,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v4.11.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2414)
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v4.11.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1913,6 +1913,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2414)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v4.11.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v4.11.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v4.11.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/python.yml
+++ b/manifests/python.yml
@@ -1912,6 +1912,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2414)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v4.11.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v4.11.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v2.6.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
@@ -2081,8 +2082,6 @@ manifest:
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_span_links_add: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_api_interoperability.py::Test_Otel_API_Interoperability::test_update_resource: missing_feature  # Created by easy win activation script
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.9.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in Python)
   tests/parametric/test_otel_logs.py::Test_FR01_Enable_OTLP_Log_Collection: v3.13.0.dev
   tests/parametric/test_otel_logs.py::Test_FR03_Resource_Attributes: v3.13.0.dev

--- a/manifests/python_lambda.yml
+++ b/manifests/python_lambda.yml
@@ -311,8 +311,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)

--- a/manifests/python_otel.yml
+++ b/manifests/python_otel.yml
@@ -58,8 +58,6 @@ manifest:
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelMetricE2E: irrelevant
   tests/otel_tracing_e2e/test_e2e.py::Test_OTelTracingE2E: irrelevant
   tests/parametric/test_config_consistency.py::Test_Config_Dogstatsd::test_dogstatsd_default: incomplete_test_app (PHP parameteric app can not access the dogstatsd default values, this logic is internal to the tracer)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_span_methods.py::Test_Otel_Span_Methods::test_otel_record_exception_sets_handling_stack_in_go: irrelevant
   tests/parametric/test_parametric_endpoints.py::Test_Parametric_Write_Log::test_create_logger: incomplete_test_app (Logs endpoint is only implemented in python and node.js app)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2276,6 +2276,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v2.22.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2413)
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.22.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2277,6 +2277,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2413)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.22.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v2.22.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
@@ -2473,8 +2474,6 @@ manifest:
   tests/parametric/test_llm_observability/: irrelevant (library does not implement LLM Observability)
   tests/parametric/test_otel_api_interoperability.py: missing_feature
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars: v2.1.0
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: missing_feature (DD_LOG_LEVEL is not supported in ruby)
   tests/parametric/test_otel_logs.py: '>=2.34.0-dev'
   tests/parametric/test_otel_logs.py::Test_FR08_Custom_Headers: missing_feature (Ruby net/http titlecases header names; test checks lowercase; fix requires overriding OTLP exporter HTTP headers)

--- a/manifests/ruby.yml
+++ b/manifests/ruby.yml
@@ -2278,6 +2278,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_empty_is_treated_as_unset: bug (APMAPI-2413)
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: v2.22.0
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: v2.22.0
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: v2.22.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v1.17.0
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_disabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3single_128_bit_generation_enabled: irrelevant (Supports the value `b3` instead of the deprecated `B3 single header`)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -71,6 +71,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_sdk_disabled.py::Test_OTEL_SDK_DISABLED: missing_feature
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v0.5.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
+  tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)
@@ -238,7 +239,6 @@ manifest:
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_off: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_on: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_exporter_none: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_off: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_on: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_ratio: incomplete_test_app (/trace/config endpoint is not implemented)

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -72,6 +72,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME: v0.5.0
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
+  tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)
@@ -226,23 +227,9 @@ manifest:
     - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
       component_version: <0.4.1-dev+926c77a
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_env_var_take_precedence: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_false:
-    - declaration: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-    - declaration: incomplete_test_app
-    - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_dd_trace_sample_ignore_parent_true:
-    - declaration: missing_feature (dd_trace_sample_ignore_parent requires an RFC, this feature is not implemented in any language)
-    - declaration: incomplete_test_app
-    - declaration: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_attribute_mapping: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_env_vars_set: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_log_level_env: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_off: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_always_on: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_off: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_on: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_parentbased_ratio: incomplete_test_app (/trace/config endpoint is not implemented)
-  tests/parametric/test_otel_env_vars.py::Test_Otel_Env_Vars::test_otel_traces_traceidratio: incomplete_test_app (/trace/config endpoint is not implemented)
   tests/parametric/test_otel_logs.py: v0.3.0
   tests/parametric/test_otel_logs.py::Test_FR07_Host_Name::test_hostname_from_dd_hostname: irrelevant (DD_HOSTNAME is only supported in Python)
   tests/parametric/test_otel_logs.py::Test_FR11_Telemetry::test_telemetry_metrics:  # TODO: a lower version might be supported

--- a/manifests/rust.yml
+++ b/manifests/rust.yml
@@ -73,6 +73,7 @@ manifest:
   tests/parametric/otel_env_vars/test_otel_service_name.py::Test_OTEL_SERVICE_NAME::test_default_follows_otel_spec: irrelevant
   tests/parametric/otel_env_vars/test_otel_traces_exporter.py::Test_OTEL_TRACES_EXPORTER: missing_feature
   tests/parametric/otel_env_vars/test_otel_traces_sampler.py::Test_OTEL_TRACES_SAMPLER: missing_feature
+  tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py::Test_OTEL_TRACES_SAMPLER_ARG: missing_feature
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids: v0.0.1
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_disabled: missing_feature (propagation style not supported)
   tests/parametric/test_128_bit_traceids.py::Test_128_Bit_Traceids::test_b3multi_128_bit_generation_enabled: missing_feature (propagation style not supported)

--- a/tests/parametric/otel_env_vars/test_otel_traces_exporter.py
+++ b/tests/parametric/otel_env_vars/test_otel_traces_exporter.py
@@ -1,0 +1,225 @@
+import pytest
+
+from tests.parametric.conftest import APMLibrary
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+
+
+SPAN_NAME = "otel-traces-exporter-span"
+OTLP_TRACE_PATH = "/v1/traces"
+ZIPKIN_TRACE_PATH = "/api/v2/spans"
+
+OTLP_EXPORTER = "otlp"
+ZIPKIN_EXPORTER = "zipkin"
+CONSOLE_EXPORTER = "console"
+NONE_EXPORTER = "none"
+LOGGING_EXPORTER = "logging"
+OTLP_STDOUT_EXPORTER = "otlp/stdout"
+
+BASE_ENV = {
+    "DD_TRACE_AGENT_PROTOCOL_VERSION": None,
+    "DD_TRACE_DEBUG": "false",
+    "DD_TRACE_ENABLED": None,
+    "DD_TRACE_OTEL_ENABLED": "true",
+    "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf",
+}
+
+STABLE_VALUES = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": OTLP_EXPORTER},
+        OTLP_EXPORTER,
+        id=OTLP_EXPORTER,
+    ),
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": ZIPKIN_EXPORTER},
+        ZIPKIN_EXPORTER,
+        id=ZIPKIN_EXPORTER,
+    ),
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": CONSOLE_EXPORTER},
+        CONSOLE_EXPORTER,
+        id=CONSOLE_EXPORTER,
+    ),
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": NONE_EXPORTER},
+        NONE_EXPORTER,
+        id=NONE_EXPORTER,
+    ),
+]
+
+DEPRECATED_VALUES = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": LOGGING_EXPORTER},
+        id=LOGGING_EXPORTER,
+    ),
+]
+
+DEVELOPMENT_VALUES = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": OTLP_STDOUT_EXPORTER},
+        id=OTLP_STDOUT_EXPORTER,
+    ),
+]
+
+UNSET_VALUE = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": None},
+        id="unset",
+    ),
+]
+
+EMPTY_VALUE = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": ""},
+        id="empty",
+    ),
+]
+
+INVALID_VALUE = [
+    pytest.param(
+        {**BASE_ENV, "OTEL_TRACES_EXPORTER": "invalid"},
+        id="invalid",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _exporter_endpoints(
+    library_env: dict[str, str],
+    test_agent: TestAgentAPI,
+    test_agent_otlp_http_port: int,
+) -> None:
+    library_env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = (
+        f"http://{test_agent.container_name}:{test_agent_otlp_http_port}{OTLP_TRACE_PATH}"
+    )
+    library_env["OTEL_EXPORTER_ZIPKIN_ENDPOINT"] = (
+        f"http://{test_agent.container_name}:{test_agent.container_port}{ZIPKIN_TRACE_PATH}"
+    )
+
+
+def _emit_span(library: APMLibrary) -> str:
+    with library.dd_start_span(name=SPAN_NAME):
+        pass
+    library.dd_flush()
+    return library.get_logs()
+
+
+def _assert_no_native_trace(test_agent: TestAgentAPI) -> None:
+    with pytest.raises(ValueError):
+        test_agent.wait_for_num_traces(num=1)
+
+
+def _assert_otlp_export(test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    with test_library as library:
+        _emit_span(library)
+
+    requests = test_agent.otlp_requests()
+    assert any(request["url"].endswith(OTLP_TRACE_PATH) for request in requests)
+    _assert_no_native_trace(test_agent)
+
+
+def _assert_zipkin_export(test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    with test_library as library:
+        _emit_span(library)
+
+    requests = test_agent.requests()
+    assert any(request["url"].endswith(ZIPKIN_TRACE_PATH) for request in requests)
+    _assert_no_native_trace(test_agent)
+
+
+def _assert_stdout_export(test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    with test_library as library:
+        logs = _emit_span(library)
+
+    assert SPAN_NAME in logs
+    assert not any(request["url"].endswith(OTLP_TRACE_PATH) for request in test_agent.otlp_requests())
+    _assert_no_native_trace(test_agent)
+
+
+def _assert_no_export(test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    with test_library as library:
+        if library.lang == "nodejs":
+            _emit_span(library)
+            _assert_no_native_trace(test_agent)
+            return
+
+        config = library.config()
+
+    assert config["dd_trace_enabled"] == "false"
+
+
+def _assert_exporter(exporter: str, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+    if exporter == OTLP_EXPORTER:
+        _assert_otlp_export(test_agent, test_library)
+        return
+
+    if exporter == ZIPKIN_EXPORTER:
+        _assert_zipkin_export(test_agent, test_library)
+        return
+
+    if exporter == CONSOLE_EXPORTER:
+        _assert_stdout_export(test_agent, test_library)
+        return
+
+    if exporter == NONE_EXPORTER:
+        _assert_no_export(test_agent, test_library)
+        return
+
+    raise AssertionError(f"Unknown exporter: {exporter}")
+
+
+@scenarios.parametric
+@features.otel_traces_exporter
+class Test_OTEL_TRACES_EXPORTER:
+    @pytest.mark.parametrize(("library_env", "exporter"), STABLE_VALUES)
+    def test_stable_values(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+        *,
+        exporter: str,
+    ) -> None:
+        _assert_exporter(exporter, test_agent, test_library)
+
+    @pytest.mark.parametrize("library_env", DEPRECATED_VALUES)
+    def test_deprecated_values(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        _assert_stdout_export(test_agent, test_library)
+
+    @pytest.mark.parametrize("library_env", DEVELOPMENT_VALUES)
+    def test_development_values(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        _assert_stdout_export(test_agent, test_library)
+
+    @pytest.mark.parametrize("library_env", UNSET_VALUE)
+    def test_default_matches_specification(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        _assert_otlp_export(test_agent, test_library)
+
+    @pytest.mark.parametrize("library_env", EMPTY_VALUE)
+    def test_empty_is_treated_as_unset(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        _assert_otlp_export(test_agent, test_library)
+
+    @pytest.mark.parametrize("library_env", INVALID_VALUE)
+    def test_invalid_is_ignored(self, test_agent: TestAgentAPI, test_library: APMLibrary) -> None:
+        _assert_otlp_export(test_agent, test_library)
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {
+                    **BASE_ENV,
+                    "DD_TRACE_ENABLED": "true",
+                    "OTEL_TRACES_EXPORTER": NONE_EXPORTER,
+                },
+                id="datadog-over-otel",
+            )
+        ],
+    )
+    def test_datadog_configuration_takes_precedence(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            _emit_span(library)
+
+        assert test_agent.wait_for_num_traces(num=1)

--- a/tests/parametric/otel_env_vars/test_otel_traces_sampler.py
+++ b/tests/parametric/otel_env_vars/test_otel_traces_sampler.py
@@ -1,0 +1,201 @@
+import pytest
+
+from tests.parametric.conftest import APMLibrary, nodejs_telemetry_value
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+
+
+SAMPLER_ENV = {
+    "DD_TRACE_OTEL_ENABLED": "true",
+    "DD_TRACE_SAMPLE_RATE": None,
+    "DD_TRACE_SAMPLING_RULES": None,
+}
+
+JAEGER_REMOTE_ARGUMENT = "endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25"
+
+STABLE_VALUES = [
+    pytest.param(
+        {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "always_on"},
+        1.0,
+        id="always_on",
+    ),
+    pytest.param(
+        {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "always_off"},
+        0.0,
+        id="always_off",
+    ),
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0.25",
+        },
+        0.25,
+        id="traceidratio",
+    ),
+    pytest.param(
+        {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "parentbased_always_on"},
+        1.0,
+        id="parentbased_always_on",
+    ),
+    pytest.param(
+        {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "parentbased_always_off"},
+        0.0,
+        id="parentbased_always_off",
+    ),
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0.25",
+        },
+        0.25,
+        id="parentbased_traceidratio",
+    ),
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "jaeger_remote",
+            "OTEL_TRACES_SAMPLER_ARG": JAEGER_REMOTE_ARGUMENT,
+        },
+        0.25,
+        id="jaeger_remote",
+    ),
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "parentbased_jaeger_remote",
+            "OTEL_TRACES_SAMPLER_ARG": JAEGER_REMOTE_ARGUMENT,
+        },
+        0.25,
+        id="parentbased_jaeger_remote",
+    ),
+]
+
+UNSET_VALUE = [
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": None,
+            "OTEL_TRACES_SAMPLER_ARG": None,
+        },
+        id="unset",
+    )
+]
+
+EMPTY_VALUE = [
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "",
+            "OTEL_TRACES_SAMPLER_ARG": None,
+        },
+        id="empty",
+    )
+]
+
+INVALID_VALUE = [
+    pytest.param(
+        {
+            **SAMPLER_ENV,
+            "OTEL_TRACES_SAMPLER": "invalid",
+            "OTEL_TRACES_SAMPLER_ARG": None,
+        },
+        id="invalid",
+    )
+]
+
+THIRD_PARTY_VALUES = [
+    pytest.param(
+        {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "xray"},
+        id="xray",
+    )
+]
+
+XRAY_DECISION_COUNT = 32
+
+
+def _sample_rate(test_agent: TestAgentAPI, library: APMLibrary) -> float:
+    if library.lang == "nodejs":
+        value = nodejs_telemetry_value(test_agent, "dd_trace_sample_rate")
+    else:
+        value = library.config()["dd_trace_sample_rate"]
+
+    assert isinstance(value, (float, str, bool, int))
+    return float(value)
+
+
+@scenarios.parametric
+@features.otel_traces_sampler
+class Test_OTEL_TRACES_SAMPLER:
+    @pytest.mark.parametrize(("library_env", "expected"), STABLE_VALUES)
+    def test_stable_values(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+        *,
+        expected: float,
+    ) -> None:
+        with test_library as library:
+            assert _sample_rate(test_agent, library) == expected
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [pytest.param({**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "always_on"}, id="always_on")],
+    )
+    def test_dd_trace_sample_ignore_parent_true(self, test_library: APMLibrary) -> None:
+        with test_library as library:
+            config = library.config()
+        assert config["dd_trace_sample_ignore_parent"] == "true"
+
+    @pytest.mark.parametrize(
+        "library_env",
+        [
+            pytest.param(
+                {**SAMPLER_ENV, "OTEL_TRACES_SAMPLER": "parentbased_always_off"},
+                id="parentbased_always_off",
+            )
+        ],
+    )
+    def test_dd_trace_sample_ignore_parent_false(self, test_library: APMLibrary) -> None:
+        with test_library as library:
+            config = library.config()
+        assert config["dd_trace_sample_ignore_parent"] == "false"
+
+    @pytest.mark.parametrize("library_env", UNSET_VALUE)
+    def test_default_matches_specification(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _sample_rate(test_agent, library) == 1.0
+
+    @pytest.mark.parametrize("library_env", EMPTY_VALUE)
+    def test_empty_is_treated_as_unset(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _sample_rate(test_agent, library) == 1.0
+
+    @pytest.mark.parametrize("library_env", INVALID_VALUE)
+    def test_invalid_value_is_ignored(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        with test_library as library:
+            assert _sample_rate(test_agent, library) == 1.0
+
+    @pytest.mark.parametrize("library_env", THIRD_PARTY_VALUES)
+    def test_third_party_values(self, test_library: APMLibrary) -> None:
+        decisions = []
+        with test_library as library:
+            for index in range(XRAY_DECISION_COUNT):
+                with library.otel_start_span(f"xray-{index}") as span:
+                    decisions.append(span.is_recording())
+
+        assert any(decisions)
+        assert not all(decisions)

--- a/tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py
+++ b/tests/parametric/otel_env_vars/test_otel_traces_sampler_arg.py
@@ -1,0 +1,161 @@
+import pytest
+
+from tests.parametric.conftest import APMLibrary, nodejs_telemetry_value
+from utils import features, scenarios
+from utils.docker_fixtures import TestAgentAPI
+
+
+def _trace_sample_rate(test_agent: TestAgentAPI, test_library: APMLibrary) -> float:
+    with test_library as library:
+        if library.lang == "nodejs":
+            value = nodejs_telemetry_value(test_agent, "dd_trace_sample_rate")
+        else:
+            value = library.config()["dd_trace_sample_rate"]
+
+    assert isinstance(value, (float, int, str))
+    return float(value)
+
+
+VALID_RATIO_ARGUMENTS = [
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0",
+        },
+        0.0,
+        id="lower-boundary",
+    ),
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0.1",
+        },
+        0.1,
+        id="0.1",
+    ),
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "0.25",
+        },
+        0.25,
+        id="representative",
+    ),
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "1",
+        },
+        1.0,
+        id="upper-boundary",
+    ),
+]
+
+INVALID_RATIO_ARGUMENTS = [
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "-0.1",
+        },
+        id="below-range",
+    ),
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "1.1",
+        },
+        id="above-range",
+    ),
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "not-a-number",
+        },
+        id="not-a-number",
+    ),
+]
+
+UNSET_VALUE = [
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": None,
+        },
+        id="unset",
+    )
+]
+
+EMPTY_VALUE = [
+    pytest.param(
+        {
+            "DD_TRACE_SAMPLE_RATE": None,
+            "DD_TRACE_SAMPLING_RULES": None,
+            "DD_TRACE_OTEL_ENABLED": "true",
+            "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "",
+        },
+        id="empty",
+    )
+]
+
+
+@scenarios.parametric
+@features.otel_traces_sampler_arg
+class Test_OTEL_TRACES_SAMPLER_ARG:
+    @pytest.mark.parametrize(("library_env", "expected"), VALID_RATIO_ARGUMENTS)
+    def test_stable_values(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+        *,
+        expected: float,
+    ) -> None:
+        assert _trace_sample_rate(test_agent, test_library) == expected
+
+    @pytest.mark.parametrize("library_env", INVALID_RATIO_ARGUMENTS)
+    def test_invalid_values_are_ignored(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        assert _trace_sample_rate(test_agent, test_library) == 1.0
+
+    @pytest.mark.parametrize("library_env", UNSET_VALUE)
+    def test_default_matches_specification(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        assert _trace_sample_rate(test_agent, test_library) == 1.0
+
+    @pytest.mark.parametrize("library_env", EMPTY_VALUE)
+    def test_empty_is_treated_as_unset(
+        self,
+        test_agent: TestAgentAPI,
+        test_library: APMLibrary,
+    ) -> None:
+        assert _trace_sample_rate(test_agent, test_library) == 1.0

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -252,19 +252,6 @@ class Test_Otel_Env_Vars:
         assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
         assert float(resp["dd_trace_sample_rate"]) == 0.1
 
-    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_EXPORTER": "none", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_exporter_none(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                # OTEL_TRACES_EXPORTER=none disables tracing; assert no trace is produced
-                with t.dd_start_span(name="disabled"):
-                    pass
-                with pytest.raises(ValueError):
-                    test_agent.wait_for_num_traces(num=1)
-                return
-            resp = t.config()
-        assert resp["dd_trace_enabled"] == "false"
-
     @pytest.mark.parametrize(
         "library_env",
         [{"OTEL_LOG_LEVEL": "debug", "DD_TRACE_OTEL_ENABLED": "true", "DD_TRACE_STARTUP_LOGS": "true"}],

--- a/tests/parametric/test_otel_env_vars.py
+++ b/tests/parametric/test_otel_env_vars.py
@@ -176,82 +176,6 @@ class Test_Otel_Env_Vars:
         assert "foo:bar1" in tags
         assert "baz:qux1" in tags
 
-    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_always_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 1.0
-                return
-            resp = t.config()
-            assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-            assert float(resp["dd_trace_sample_rate"]) == 1.0
-
-    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_off", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_otel_traces_always_off(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.0
-                return
-            resp = t.config()
-        assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-        assert float(resp["dd_trace_sample_rate"]) == 0.0
-
-    @pytest.mark.parametrize(
-        "library_env",
-        [{"OTEL_TRACES_SAMPLER": "traceidratio", "OTEL_TRACES_SAMPLER_ARG": "0.1", "DD_TRACE_OTEL_ENABLED": "true"}],
-    )
-    def test_otel_traces_traceidratio(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.1
-                return
-            resp = t.config()
-        assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-        assert float(resp["dd_trace_sample_rate"]) == 0.1
-
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_on", "DD_TRACE_OTEL_ENABLED": "true"}]
-    )
-    def test_otel_traces_parentbased_on(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 1.0
-                return
-            resp = t.config()
-        assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-        assert float(resp["dd_trace_sample_rate"]) == 1.0
-
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off", "DD_TRACE_OTEL_ENABLED": "true"}]
-    )
-    def test_otel_traces_parentbased_off(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.0
-                return
-            resp = t.config()
-        assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-        assert float(resp["dd_trace_sample_rate"]) == 0.0
-
-    @pytest.mark.parametrize(
-        "library_env",
-        [
-            {
-                "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
-                "OTEL_TRACES_SAMPLER_ARG": "0.1",
-                "DD_TRACE_OTEL_ENABLED": "true",
-            }
-        ],
-    )
-    def test_otel_traces_parentbased_ratio(self, test_agent: TestAgentAPI, test_library: APMLibrary):
-        with test_library as t:
-            if t.lang == "nodejs":
-                assert float(str(nodejs_telemetry_value(test_agent, "dd_trace_sample_rate"))) == 0.1
-                return
-            resp = t.config()
-        assert isinstance(resp["dd_trace_sample_rate"], (float, str, bool, int))
-        assert float(resp["dd_trace_sample_rate"]) == 0.1
-
     @pytest.mark.parametrize(
         "library_env",
         [{"OTEL_LOG_LEVEL": "debug", "DD_TRACE_OTEL_ENABLED": "true", "DD_TRACE_STARTUP_LOGS": "true"}],
@@ -267,17 +191,3 @@ class Test_Otel_Env_Vars:
         assert resp["dd_trace_debug"] == "true"
         # If dd_log_level is set it must be consistent with dd_trace_debug
         assert (resp["dd_log_level"] == "debug") or (resp["dd_log_level"] is None)
-
-    @pytest.mark.parametrize("library_env", [{"OTEL_TRACES_SAMPLER": "always_on", "DD_TRACE_OTEL_ENABLED": "true"}])
-    def test_dd_trace_sample_ignore_parent_true(self, test_library: APMLibrary):
-        with test_library as t:
-            resp = t.config()
-        assert resp["dd_trace_sample_ignore_parent"] == "true"
-
-    @pytest.mark.parametrize(
-        "library_env", [{"OTEL_TRACES_SAMPLER": "parentbased_always_off", "DD_TRACE_OTEL_ENABLED": "true"}]
-    )
-    def test_dd_trace_sample_ignore_parent_false(self, test_library: APMLibrary):
-        with test_library as t:
-            resp = t.config()
-        assert resp["dd_trace_sample_ignore_parent"] == "false"


### PR DESCRIPTION
## Motivation

Add dedicated parametric system-test coverage for the `OTEL_TRACES_*` variables.

## Changes

- add registry-based coverage for `OTEL_TRACES_EXPORTER`
- add registry-based coverage for `OTEL_TRACES_SAMPLER`
- add registry-based coverage for `OTEL_TRACES_SAMPLER_ARG`
- migrate the corresponding legacy cases into focused test modules
- declare broad manifest assumptions sourced from the audit data

Tests were intentionally not run during this first phase.