### PR TITLE
test(dotnet): enable agentless EVP exposure egress

### DIFF
--- a/manifests/dotnet.yml
+++ b/manifests/dotnet.yml
@@ -779,9 +779,18 @@ manifest:
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Flag_Parse_Error_Isolation: bug (FFL-2184)
   tests/ffe/test_dynamic_evaluation.py::Test_FFE_Unknown_Operator_Tolerance: bug (FFL-2184)
   tests/ffe/test_exposure_egress.py: v3.36.0
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown: missing_feature (Not yet implemented)
-  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar: missing_feature (Not yet implemented)
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct:
+    - weblog_declaration:
+        "*": irrelevant
+        poc: v3.54.0
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown:
+    - weblog_declaration:
+        "*": irrelevant
+        poc: v3.54.0
+  tests/ffe/test_exposure_egress.py::Test_FFE_Exposure_Egress_Agentless_Sidecar:
+    - weblog_declaration:
+        "*": irrelevant
+        poc: v3.54.0
   tests/ffe/test_exposures_datadog_agent.py: v3.36.0
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Appears: missing_feature (EX-3416)
   tests/ffe/test_exposures_datadog_agent.py::Test_FFE_Exposure_Caching_Serial_Id_Cycle: missing_feature (EX-3416)

--- a/tests/test_the_test/test_dotnet_direct_evp_activation.py
+++ b/tests/test_the_test/test_dotnet_direct_evp_activation.py
@@ -1,0 +1,44 @@
+"""Guard the .NET-only activation and lifecycle for direct-EVP validation."""
+
+from pathlib import Path
+
+from utils import features, scenarios
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_dotnet_direct_evp_activation_is_exposure_only_and_poc_scoped() -> None:
+    manifest = Path("manifests/dotnet.yml").read_text(encoding="utf-8")
+
+    for test_class in (
+        "Test_FFE_Exposure_Egress_Agentless_Direct",
+        "Test_FFE_Exposure_Egress_Agentless_Direct_Shutdown",
+        "Test_FFE_Exposure_Egress_Agentless_Sidecar",
+    ):
+        declaration = (
+            f"tests/ffe/test_exposure_egress.py::{test_class}:\n"
+            '    - weblog_declaration:\n        "*": irrelevant\n        poc: v3.54.0'
+        )
+        assert declaration in manifest
+
+    assert "tests/ffe/test_flag_eval_evp.py: missing_feature (FFL-2446)" in manifest
+
+
+@scenarios.test_the_test
+@features.not_reported
+def test_dotnet_direct_evp_shutdown_execs_runtime_and_marks_server_closed() -> None:
+    app_script = Path("utils/build/docker/dotnet/weblog/app.sh").read_text(encoding="utf-8")
+    program = Path("utils/build/docker/dotnet/weblog/Program.cs").read_text(encoding="utf-8")
+
+    shutdown_switch = 'SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED:-}" = "true"'
+    assert shutdown_switch in app_script
+    assert "exec dotnet app.dll" in app_script
+    assert app_script.index(shutdown_switch) < app_script.index("exec dotnet app.dll")
+    assert app_script.index("exec dotnet app.dll") < app_script.index("if ( ! dotnet app.dll)")
+
+    assert 'GetEnvironmentVariable("SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED") == "true"' in program
+    assert "GetRequiredService<IHostApplicationLifetime>().ApplicationStopped.Register" in program
+    assert 'event = "system_tests.ffe.shutdown.server_closed"' in program
+    assert 'timestamp = DateTimeOffset.UtcNow.ToString("O")' in program
+    assert "Console.Out.Flush();" in program
+    assert program.index("ApplicationStopped.Register") < program.index("host.Run();")

--- a/utils/build/docker/dotnet/weblog/Program.cs
+++ b/utils/build/docker/dotnet/weblog/Program.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Http;
 using Datadog.Trace;
@@ -37,7 +39,21 @@ namespace weblog
                 settings.LogsInjectionEnabled = true;
                 Tracer.Configure(settings);
             }
-            CreateHostBuilder(args).Build().Run();
+            var host = CreateHostBuilder(args).Build();
+            if (Environment.GetEnvironmentVariable("SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED") == "true")
+            {
+                host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopped.Register(() =>
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(new
+                    {
+                        @event = "system_tests.ffe.shutdown.server_closed",
+                        timestamp = DateTimeOffset.UtcNow.ToString("O")
+                    }));
+                    Console.Out.Flush();
+                });
+            }
+
+            host.Run();
         }
         public static IHostBuilder CreateHostBuilder(string[] args)
         {

--- a/utils/build/docker/dotnet/weblog/app.sh
+++ b/utils/build/docker/dotnet/weblog/app.sh
@@ -8,6 +8,10 @@ if [ "${UDS_WEBLOG:-0}" = "1" ]; then
     ./set-uds-transport.sh
 fi
 
+if [ "${SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED:-}" = "true" ]; then
+    exec dotnet app.dll
+fi
+
 if ( ! dotnet app.dll); then
     echo recovering dump to /var/log/system-tests/dumps
     mkdir -p /var/log/system-tests/dumps


### PR DESCRIPTION
## Motivation

We are shipping agentless CDN-delivered configuration to make customer deployments simpler. The SDK's core Feature Flags telemetry still needs a reliable network path out of the process: automatically use a compatible running Agent or `serverless-init` relay when available, and fall back to direct EVP intake when no relay exists.

[FFLSDK-195](https://linear.app/datadoghq/issue/FFLSDK-195) activates .NET against the shared cross-language contract in #7299 so successful construction cannot mask missing configuration polling or exposure delivery.

## Changes

| Capability | Direct intake | `serverless-init` | Agent |
|---|---:|---:|---:|
| Exposures | Enabled; exact candidate currently fails | Enabled; exact candidate currently fails | Existing coverage |
| Flag evaluations | Not emitted yet | Not emitted yet | Not emitted yet |
| Shutdown exposure flush | Enabled; blocked before flush | — | — |

- Activate the `poc` weblog for the .NET 3.54 development line.
- Make the .NET runtime PID 1 only for the direct shutdown contract so Docker's SIGTERM reaches the ordinary application lifecycle.
- Emit the shared structured server-close marker after ASP.NET Core reports `ApplicationStopped`.

## Decisions

- Target #7299 directly; do not depend on another language activation.
- Keep this draft as an executable product gate. Do not weaken or xfail the contracts: the exact SDK artifact exposes a real missing production dependency.
- Scope activation to `poc`. The `uds` weblog configures an Agent socket at runtime and therefore cannot prove a no-Agent direct topology.
- Keep this PR exposure-only. The separate flag-evaluation emitter remains owned by [FFLSDK-28](https://linear.app/datadoghq/issue/FFLSDK-28/dotnet-sdk-emits-flagevaluations-to-evp).
- Keep the PID 1 and shutdown-marker behavior test-only and opt-in through `SYSTEM_TESTS_FFE_SHUTDOWN_FLUSH_ENABLED`; all other .NET scenarios retain the existing crash-dump recovery wrapper.
- Require [dd-trace-dotnet#9044](https://github.com/DataDog/dd-trace-dotnet/pull/9044) to land or be combined with [#9235](https://github.com/DataDog/dd-trace-dotnet/pull/9235): #9235 constructs the fallback transport, but current `master` has no production caller that starts `AgentlessConfigurationSource`.
- Keep OTLP out of scope: these contracts validate EVP egress.

## Validation

System-tests base: `9c753fbcbdcc6122eed15fd5af827671fbc0771c`

System-tests candidate: `ccf370de4c3e4dc62aaf09977d2727d063449b05`

.NET SDK candidate: [`0ac1c3cca2c7423e41bd15b17ab2f543a9c261b3`](https://github.com/DataDog/dd-trace-dotnet/commit/0ac1c3cca2c7423e41bd15b17ab2f543a9c261b3) from [dd-trace-dotnet#9235](https://github.com/DataDog/dd-trace-dotnet/pull/9235)

Candidate artifact: `datadog-dotnet-apm-3.54.0.tar.gz`, SHA-256 `4ad48d2d6890682c4da6a86bd02555f22b93390b425a739177b26c88de3f9c3f`, from Azure build `208990`.

```text
./format.sh
passed

./run.sh TEST_THE_TEST \
  tests/test_the_test/test_dotnet_direct_evp_activation.py \
  tests/test_the_test/test_manifest.py
34 passed

./build.sh dotnet -w poc
passed
Library: dotnet@3.54.0
Weblog variant: poc
```

Exact-artifact E2E currently fails before event routing can be exercised:

```text
Direct exposure only:
Timed out waiting for Feature Flags EVP captures: /api/v2/exposures

serverless-init exposure only:
Timed out waiting for Feature Flags EVP captures: /api/v2/exposures
```

Diagnostic evidence:

- All five `/ffe` evaluations returned `{"reason":"DEFAULT","value":null,"count":1}`.
- The Agentless UFC mock recorded `requests_total: 0`; polling never started.
- Direct intake captured 19 APM telemetry requests and zero exposure requests.
- The runtime topology was correct: source `agentless`, API key present, no Agent variables, and `dotnet app.dll` was PID 1.
- `FeatureFlagsModule` constructs `FeatureFlagsEvpTransport` and `ExposureApi`, but subscribes only to RCM. `AgentlessConfigurationSource.Create(...).Start()` has no production caller on the exact candidate's base.

This is a product-stack dependency failure, not a system-test teardown failure. Rebuild the exact combined #9044 + #9235 candidate and rerun direct exposure/shutdown and serverless-init exposure before calling this activation green.

Both system-test commits are GitHub `verified=true`, `reason=valid`.

## Reviewer checklist

- [ ] Anything but `tests/` or `manifests/` is modified: request R&P review for the test-only .NET lifecycle hook.
- [x] No Docker base image is modified.
- [x] No scenario is added, removed, or renamed.
